### PR TITLE
fix voxel size report on image drop

### DIFF
--- a/packages/niivue-react/src/components/HeaderBox.tsx
+++ b/packages/niivue-react/src/components/HeaderBox.tsx
@@ -1,5 +1,4 @@
-import { useSignal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { effect, useSignal } from '@preact/signals'
 import { ExtendedNiivue } from '../events'
 
 type HeaderInfo = {
@@ -13,15 +12,15 @@ export const HeaderBox = (props: any) => {
 
   const headerInfo = useSignal({ pixDims: [3, 1, 1, 1], qoffset: [0, 0, 0] } as HeaderInfo)
 
-  useEffect(() => {
-    if (nvArraySelected.value.length > 0) {
+  effect(() => {
+    if (nvArraySelected.value.length > 0 && nvArraySelected.value[0]?.volumes?.[0]) {
       const hdr = nvArraySelected.value[0].volumes[0].hdr
       headerInfo.value = {
         pixDims: [hdr.pixDims[0], hdr.pixDims[1], hdr.pixDims[2], hdr.pixDims[3]],
         qoffset: [hdr.qoffset_x, hdr.qoffset_y, hdr.qoffset_z],
       }
     }
-  }, [nvArraySelected])
+  })
 
   const setVoxelSizeAndOrigin = () => {
     nvArraySelected.value.forEach((nv: ExtendedNiivue) => {

--- a/packages/niivue-react/src/components/ImageDrop.tsx
+++ b/packages/niivue-react/src/components/ImageDrop.tsx
@@ -21,25 +21,43 @@ export const ImageDrop = ({ children }: { children: ComponentChildren }) => {
     e.preventDefault()
     const files = e.dataTransfer!.files
     const fileArray = Array.from(files)
-    window.postMessage({
-      type: 'initCanvas',
-      body: {
-        n: fileArray.length,
-      },
-    })
-    const readimages = async () => {
-      for (const file of fileArray) {
-        const buffer = await file.arrayBuffer()
-        window.postMessage({
-          type: 'addImage',
-          body: {
-            data: buffer,
-            uri: file.name,
-          },
-        })
+    if (e.shiftKey) {
+      // shift+drop adds files as overlays to the last loaded canvas
+      const readOverlays = async () => {
+        for (const file of fileArray) {
+          const buffer = await file.arrayBuffer()
+          window.postMessage({
+            type: 'overlay',
+            body: {
+              data: buffer,
+              uri: file.name,
+              index: -1,
+            },
+          })
+        }
       }
+      readOverlays()
+    } else {
+      window.postMessage({
+        type: 'initCanvas',
+        body: {
+          n: fileArray.length,
+        },
+      })
+      const readimages = async () => {
+        for (const file of fileArray) {
+          const buffer = await file.arrayBuffer()
+          window.postMessage({
+            type: 'addImage',
+            body: {
+              data: buffer,
+              uri: file.name,
+            },
+          })
+        }
+      }
+      readimages()
     }
-    readimages()
   }
 
   return (

--- a/packages/niivue-react/src/components/NiiVueCanvas.tsx
+++ b/packages/niivue-react/src/components/NiiVueCanvas.tsx
@@ -68,6 +68,7 @@ export const NiiVueCanvas = ({
         render.value++ // required to update the names
         nvArray.value = [...nvArray.value] // trigger react signal for changes
         nv.createOnLocationChange() // TODO fix, still required?
+        nv.onVolumeUpdated()
         notifyImageLoaded()
       })
       .catch((error) => {

--- a/packages/niivue-react/src/events.ts
+++ b/packages/niivue-react/src/events.ts
@@ -32,8 +32,11 @@ export async function handleMessage(message: any, appProps: AppProps) {
       break
     case 'overlay':
       {
-        await addOverlay(nvArray.value[body.index], body, settings.value)
-        notifyImageLoaded()
+        const index = body.index >= 0 ? body.index : nvArray.value.length - 1
+        if (index >= 0 && index < nvArray.value.length) {
+          await addOverlay(nvArray.value[index], body, settings.value)
+          notifyImageLoaded()
+        }
       }
       break
     case 'addImage':
@@ -367,6 +370,7 @@ export class ExtendedNiivue extends Niivue {
   uri = ''
   key = NaN
   body = null
+  onVolumeUpdated = () => { }
   onFrameUpdate = (frame: number) => { }
   setFrame4D(volumeOrId: any, frame: number) {
     super.setFrame4D(volumeOrId, frame)


### PR DESCRIPTION
Closes #77

- shift+drop adds files as overlays to the last canvas instead of creating new ones
- overlay handler resolves index -1 to last canvas with bounds check
- HeaderBox now uses signal effect instead of stale useEffect dependency
- added onVolumeUpdated callback to ExtendedNiivue, called after load