### PR TITLE
fix voxel size report and add shift+drop overlay

### DIFF
--- a/.changeset/clean-buttons-deny.md
+++ b/.changeset/clean-buttons-deny.md
@@ -1,0 +1,12 @@
+---
+'@niivue/react': patch
+'niivue': patch
+'@niivue/jupyter': patch
+'@niivue/pwa': patch
+'@niivue/streamlit': patch
+---
+
+shift+drop adds files as overlays to the last canvas instead of creating new ones
+overlay handler resolves index -1 to last canvas with bounds check
+HeaderBox now uses signal effect instead of stale useEffect dependency
+added onVolumeUpdated callback to ExtendedNiivue, called after load

--- a/apps/streamlit/niivue_component/frontend/src/hooks/useStreamlitNiivue.ts
+++ b/apps/streamlit/niivue_component/frontend/src/hooks/useStreamlitNiivue.ts
@@ -23,6 +23,7 @@ export const useStreamlitNiivue = (args: StreamlitArgs) => {
     defaultVolumeColormap: 'gray',
     zoomDragMode: false,
     defaultOverlayColormap: 'red',
+    defaultOverlayOpacity: 0.5,
     defaultMeshOverlayColormap: 'redyell',
     menuItems: {
       home: false,

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -407,6 +407,13 @@
           "default": "redyell",
           "description": "Default colormap to use for overlay images."
         },
+        "niivue.defaultOverlayOpacity": {
+          "type": "number",
+          "default": 0.5,
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Default opacity for overlay images (0 = transparent, 1 = opaque)."
+        },
         "niivue.defaultMeshOverlayColormap": {
           "type": "string",
           "default": "hsv",

--- a/apps/vscode/src/editorProvider.ts
+++ b/apps/vscode/src/editorProvider.ts
@@ -59,6 +59,7 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
     const zoomDragMode = config.get<boolean>('zoomDragMode', false)
     const defaultVolumeColormap = config.get<string>('defaultVolumeColormap', 'gray')
     const defaultOverlayColormap = config.get<string>('defaultOverlayColormap', 'redyell')
+    const defaultOverlayOpacity = config.get<number>('defaultOverlayOpacity', 0.5)
     const defaultMeshOverlayColormap = config.get<string>('defaultMeshOverlayColormap', 'hsv')
 
     panel.webview.postMessage({
@@ -71,6 +72,7 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
         zoomDragMode,
         defaultVolumeColormap,
         defaultOverlayColormap,
+        defaultOverlayOpacity,
         defaultMeshOverlayColormap,
       },
     })

--- a/packages/niivue-react/src/components/HeaderBox.tsx
+++ b/packages/niivue-react/src/components/HeaderBox.tsx
@@ -1,5 +1,4 @@
-import { useSignal } from '@preact/signals'
-import { useEffect } from 'preact/hooks'
+import { effect, useSignal } from '@preact/signals'
 import { ExtendedNiivue } from '../events'
 
 type HeaderInfo = {
@@ -13,15 +12,15 @@ export const HeaderBox = (props: any) => {
 
   const headerInfo = useSignal({ pixDims: [3, 1, 1, 1], qoffset: [0, 0, 0] } as HeaderInfo)
 
-  useEffect(() => {
-    if (nvArraySelected.value.length > 0) {
+  effect(() => {
+    if (nvArraySelected.value.length > 0 && nvArraySelected.value[0]?.volumes?.[0]) {
       const hdr = nvArraySelected.value[0].volumes[0].hdr
       headerInfo.value = {
         pixDims: [hdr.pixDims[0], hdr.pixDims[1], hdr.pixDims[2], hdr.pixDims[3]],
         qoffset: [hdr.qoffset_x, hdr.qoffset_y, hdr.qoffset_z],
       }
     }
-  }, [nvArraySelected])
+  })
 
   const setVoxelSizeAndOrigin = () => {
     nvArraySelected.value.forEach((nv: ExtendedNiivue) => {

--- a/packages/niivue-react/src/components/ImageDrop.tsx
+++ b/packages/niivue-react/src/components/ImageDrop.tsx
@@ -21,25 +21,43 @@ export const ImageDrop = ({ children }: { children: ComponentChildren }) => {
     e.preventDefault()
     const files = e.dataTransfer!.files
     const fileArray = Array.from(files)
-    window.postMessage({
-      type: 'initCanvas',
-      body: {
-        n: fileArray.length,
-      },
-    })
-    const readimages = async () => {
-      for (const file of fileArray) {
-        const buffer = await file.arrayBuffer()
-        window.postMessage({
-          type: 'addImage',
-          body: {
-            data: buffer,
-            uri: file.name,
-          },
-        })
+    if (e.shiftKey) {
+      // shift+drop adds files as overlays to the last loaded canvas
+      const readOverlays = async () => {
+        for (const file of fileArray) {
+          const buffer = await file.arrayBuffer()
+          window.postMessage({
+            type: 'overlay',
+            body: {
+              data: buffer,
+              uri: file.name,
+              index: -1,
+            },
+          })
+        }
       }
+      readOverlays()
+    } else {
+      window.postMessage({
+        type: 'initCanvas',
+        body: {
+          n: fileArray.length,
+        },
+      })
+      const readimages = async () => {
+        for (const file of fileArray) {
+          const buffer = await file.arrayBuffer()
+          window.postMessage({
+            type: 'addImage',
+            body: {
+              data: buffer,
+              uri: file.name,
+            },
+          })
+        }
+      }
+      readimages()
     }
-    readimages()
   }
 
   return (

--- a/packages/niivue-react/src/components/NiiVueCanvas.tsx
+++ b/packages/niivue-react/src/components/NiiVueCanvas.tsx
@@ -68,6 +68,7 @@ export const NiiVueCanvas = ({
         render.value++ // required to update the names
         nvArray.value = [...nvArray.value] // trigger react signal for changes
         nv.createOnLocationChange() // TODO fix, still required?
+        nv.onVolumeUpdated()
         notifyImageLoaded()
       })
       .catch((error) => {

--- a/packages/niivue-react/src/components/Volume.tsx
+++ b/packages/niivue-react/src/components/Volume.tsx
@@ -93,6 +93,71 @@ export const Volume = (props: AppProps & VolumeProps) => {
 
   const is4D = computed(() => nv.volumes[0]?.nFrame4D && nv.volumes[0]?.nFrame4D > 1)
 
+  // Use capture-phase listeners to intercept drag/drop before niivue's canvas handlers
+  // (niivue registers bubble-phase listeners that call stopPropagation, preventing our handlers)
+  useEffect(() => {
+    const el = canvasRef.current
+    if (!el) return
+
+    const handleCanvasDragOver = (e: DragEvent) => {
+      e.stopPropagation()
+      e.preventDefault()
+      if (e.dataTransfer) e.dataTransfer.dropEffect = 'link'
+    }
+
+    const handleCanvasDrop = (e: DragEvent) => {
+      e.stopPropagation()
+      e.preventDefault()
+      const files = Array.from(e.dataTransfer?.files ?? [])
+      if (files.length === 0) return
+
+      if (e.shiftKey) {
+        // shift+drop adds files as overlays to this canvas
+        const readOverlays = async () => {
+          for (const file of files) {
+            const buffer = await file.arrayBuffer()
+            window.postMessage({
+              type: 'overlay',
+              body: {
+                data: buffer,
+                uri: file.name,
+                index: volumeIndex,
+              },
+            })
+          }
+        }
+        readOverlays()
+      } else {
+        // normal drop creates new canvases
+        window.postMessage({
+          type: 'initCanvas',
+          body: { n: files.length },
+        })
+        const readImages = async () => {
+          for (const file of files) {
+            const buffer = await file.arrayBuffer()
+            window.postMessage({
+              type: 'addImage',
+              body: {
+                data: buffer,
+                uri: file.name,
+              },
+            })
+          }
+        }
+        readImages()
+      }
+    }
+
+    el.addEventListener('dragover', handleCanvasDragOver, { capture: true })
+    el.addEventListener('drop', handleCanvasDrop, { capture: true })
+
+    return () => {
+      el.removeEventListener('dragover', handleCanvasDragOver, { capture: true })
+      el.removeEventListener('drop', handleCanvasDrop, { capture: true })
+    }
+  }, [canvasRef.current, volumeIndex])
+
   return (
     <div
       className={`relative ${

--- a/packages/niivue-react/src/events.ts
+++ b/packages/niivue-react/src/events.ts
@@ -32,8 +32,11 @@ export async function handleMessage(message: any, appProps: AppProps) {
       break
     case 'overlay':
       {
-        await addOverlay(nvArray.value[body.index], body, settings.value)
-        notifyImageLoaded()
+        const index = body.index >= 0 ? body.index : nvArray.value.length - 1
+        if (index >= 0 && index < nvArray.value.length) {
+          await addOverlay(nvArray.value[index], body, settings.value)
+          notifyImageLoaded()
+        }
       }
       break
     case 'addImage':
@@ -367,6 +370,7 @@ export class ExtendedNiivue extends Niivue {
   uri = ''
   key = NaN
   body = null
+  onVolumeUpdated = () => { }
   onFrameUpdate = (frame: number) => { }
   setFrame4D(volumeOrId: any, frame: number) {
     super.setFrame4D(volumeOrId, frame)

--- a/packages/niivue-react/src/events.ts
+++ b/packages/niivue-react/src/events.ts
@@ -241,13 +241,20 @@ function getLayerDefaults(type: string, settings: NiiVueSettings) {
 async function addOverlay(nv: Niivue, item: any, settings: NiiVueSettings) {
   if (isImageType(item.uri)) {
     const overlayColormap = item.colormap || settings?.defaultOverlayColormap || 'redyell'
+    const overlayOpacity = item.opacity ?? settings?.defaultOverlayOpacity ?? 0.5
     const image = await NVImage.loadFromUrl({
       url: item.data || item.uri,
       name: item.uri,
       colormap: overlayColormap,
-      opacity: item.opacity ?? 0.5
+      opacity: overlayOpacity,
     })
     nv.addVolume(image)
+    const idx = nv.volumes.length - 1
+    if (idx >= 0) {
+      nv.volumes[idx].colormap = overlayColormap
+      nv.setOpacity(idx, overlayOpacity)
+      nv.updateGLVolume()
+    }
   } else {
     const mesh = await NVMesh.readMesh(item.data, item.uri, nv.gl, 0.5)
     nv.addMesh(mesh)
@@ -403,6 +410,7 @@ function growNvArrayBy(nvArray: Signal<Niivue[]>, n: number) {
     const nv = new ExtendedNiivue({
       isResizeCanvas: true,
       dragMode: 1, // contrast
+      dragAndDropEnabled: false, // handled by app (Volume component)
     })
     nv.key = Math.random()
     nvArray.value = [...nvArray.value, nv]

--- a/packages/niivue-react/src/settings.ts
+++ b/packages/niivue-react/src/settings.ts
@@ -17,6 +17,7 @@ export interface NiiVueSettings {
   zoomDragMode: boolean
   defaultVolumeColormap: string
   defaultOverlayColormap: string
+  defaultOverlayOpacity: number
   defaultMeshOverlayColormap: string
   menuItems?: MenuItems
 }
@@ -29,6 +30,7 @@ export const defaultSettings: NiiVueSettings = {
   zoomDragMode: false,
   defaultVolumeColormap: 'gray',
   defaultOverlayColormap: 'redyell',
+  defaultOverlayOpacity: 0.5,
   defaultMeshOverlayColormap: 'hsv',
   menuItems: {
     home: true,


### PR DESCRIPTION
- [x] Fix voxel size report reactivity in HeaderBox
- [x] Add shift+drop overlay support (surrounding area)
- [x] Add overlay opacity default setting
- [x] Fix streamlit type-check error (add missing `defaultOverlayOpacity`)
- [x] Add `niivue` (VS Code) to changeset
- [x] Disable niivue's built-in canvas drag/drop (`dragAndDropEnabled: false`)
- [x] Add capture-phase drag/drop listeners on Volume component to intercept before niivue's handlers
- [x] Shift+drop on canvas → overlay on that canvas; normal drop → new canvas
- [x] Verify type-check passes

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Send tasks to Copilot coding agent from [Slack](https://gh.io/cca-slack-docs) and [Teams](https://gh.io/cca-teams-docs) to turn conversations into code. Copilot posts an update in your thread when it's finished.