### PR TITLE
feat(streamlit): add update_interval_ms to disable click feedback

### DIFF
--- a/.changeset/streamlit-disable-feedback.md
+++ b/.changeset/streamlit-disable-feedback.md
@@ -1,0 +1,7 @@
+---
+"@niivue/streamlit": patch
+---
+
+Add `update_interval_ms` parameter to `niivue_viewer()`. Passing `None`
+disables click/drag feedback to Python entirely, restoring the low-latency
+behaviour of the pre-overlay viewer. Defaults to `100` (current throttle).

--- a/apps/streamlit/niivue_component/__init__.py
+++ b/apps/streamlit/niivue_component/__init__.py
@@ -29,6 +29,7 @@ def niivue_viewer(
     view_mode="multiplanar",
     styled=True,
     settings=None,
+    update_interval_ms=100,
     key=None
 ):
     """Create a NiiVue viewer component.
@@ -67,6 +68,11 @@ def niivue_viewer(
         - radiological: bool - radiological convention (default: False)
         - colorbar: bool - show colorbar (default: False)
         - interpolation: bool - interpolate voxels (default: True)
+    update_interval_ms : int or None
+        Throttle interval in ms for click/drag events sent back to Python
+        (default: 100). Set to None to disable click feedback entirely —
+        this restores the low-latency behaviour of the pre-overlay viewer
+        and is recommended whenever the return value is not consumed.
     key : str or None
         Unique key for the component
         
@@ -156,6 +162,7 @@ def niivue_viewer(
         view_mode=view_mode,
         styled=styled,
         settings=settings or {},
+        update_interval_ms=update_interval_ms,
         default=None,
         key=key
     )

--- a/apps/streamlit/niivue_component/frontend/src/hooks/useStreamlitNiivue.ts
+++ b/apps/streamlit/niivue_component/frontend/src/hooks/useStreamlitNiivue.ts
@@ -234,10 +234,21 @@ export const useStreamlitNiivue = (args: StreamlitArgs) => {
   const feedbackDisabled = args.update_interval_ms === null
   const intervalMs = typeof args.update_interval_ms === 'number' ? args.update_interval_ms : 100
   const throttledSetValue = useRef<ReturnType<typeof throttle<(data: { type: string; voxel: number[]; mm: number[]; value: number; filename: string }) => void>> | null>(null)
-  if (!feedbackDisabled && !throttledSetValue.current) {
+  const throttleIntervalRef = useRef<number | null>(null)
+  // (Re)build the throttle on mount, on interval change, and after a toggle
+  // from disabled → enabled. The previous instance is cancelled first to
+  // avoid a stale trailing call firing with the old interval.
+  if (!feedbackDisabled && throttleIntervalRef.current !== intervalMs) {
+    throttledSetValue.current?.cancel()
     throttledSetValue.current = throttle((data: { type: string; voxel: number[]; mm: number[]; value: number; filename: string }) => {
       Streamlit.setComponentValue(data)
     }, intervalMs)
+    throttleIntervalRef.current = intervalMs
+  }
+  if (feedbackDisabled && throttledSetValue.current) {
+    throttledSetValue.current.cancel()
+    throttledSetValue.current = null
+    throttleIntervalRef.current = null
   }
 
   // Sync click events back to Streamlit
@@ -277,7 +288,7 @@ export const useStreamlitNiivue = (args: StreamlitArgs) => {
         }
       })
     }
-  }, [appProps.nvArray.value, args.filename, feedbackDisabled])
+  }, [appProps.nvArray.value, args.filename, feedbackDisabled, intervalMs])
 
   // Set frame height
   useEffect(() => {

--- a/apps/streamlit/niivue_component/frontend/src/hooks/useStreamlitNiivue.ts
+++ b/apps/streamlit/niivue_component/frontend/src/hooks/useStreamlitNiivue.ts
@@ -229,16 +229,23 @@ export const useStreamlitNiivue = (args: StreamlitArgs) => {
   }, [appProps.nvArray.value, appProps.nvArray.value[0]?.isLoaded, args.meshes])
 
   // Throttled wrapper for Streamlit.setComponentValue to avoid overwhelming
-  // Python with updates during mouse drag (fires at most once per 100ms)
+  // Python with updates during mouse drag. update_interval_ms === null
+  // disables feedback entirely: no handler attached, no Streamlit round-trips.
+  const feedbackDisabled = args.update_interval_ms === null
+  const intervalMs = typeof args.update_interval_ms === 'number' ? args.update_interval_ms : 100
   const throttledSetValue = useRef<ReturnType<typeof throttle<(data: { type: string; voxel: number[]; mm: number[]; value: number; filename: string }) => void>> | null>(null)
-  if (!throttledSetValue.current) {
+  if (!feedbackDisabled && !throttledSetValue.current) {
     throttledSetValue.current = throttle((data: { type: string; voxel: number[]; mm: number[]; value: number; filename: string }) => {
       Streamlit.setComponentValue(data)
-    }, 100)
+    }, intervalMs)
   }
 
   // Sync click events back to Streamlit
   useEffect(() => {
+    if (feedbackDisabled) {
+      return
+    }
+
     const handleLocationChange = (data: any) => {
       if (appProps.nvArray.value.length > 0 && appProps.nvArray.value[0]?.isLoaded) {
         const voxel = data.vox
@@ -270,7 +277,7 @@ export const useStreamlitNiivue = (args: StreamlitArgs) => {
         }
       })
     }
-  }, [appProps.nvArray.value, args.filename])
+  }, [appProps.nvArray.value, args.filename, feedbackDisabled])
 
   // Set frame height
   useEffect(() => {

--- a/apps/streamlit/niivue_component/frontend/src/types.ts
+++ b/apps/streamlit/niivue_component/frontend/src/types.ts
@@ -32,6 +32,10 @@ export interface StreamlitArgs {
     colorbar?: boolean
     interpolation?: boolean
   }
+  // Throttle interval (ms) for click/drag events sent back to Python.
+  // null disables feedback entirely — no setComponentValue calls, no Python
+  // round-trips on mouse interaction.
+  update_interval_ms?: number | null
 }
 
 export interface ClickEventData {

--- a/apps/streamlit/tests/test_niivue_component.py
+++ b/apps/streamlit/tests/test_niivue_component.py
@@ -274,6 +274,28 @@ def test_niivue_viewer_mesh_overlay_validation():
         niivue_viewer(meshes=meshes, key="test_mesh_overlay_no_data")
 
 
+def test_niivue_viewer_disable_feedback():
+    """update_interval_ms=None should be accepted (disables click feedback)."""
+    result = niivue_viewer(
+        nifti_data=b'\x00' * 100,
+        filename="test.nii",
+        update_interval_ms=None,
+        key="test_disable_feedback",
+    )
+    assert result is None
+
+
+def test_niivue_viewer_custom_update_interval():
+    """update_interval_ms as int should be accepted."""
+    result = niivue_viewer(
+        nifti_data=b'\x00' * 100,
+        filename="test.nii",
+        update_interval_ms=500,
+        key="test_custom_interval",
+    )
+    assert result is None
+
+
 def test_niivue_viewer_mesh_overlay_on_second_mesh_warns():
     """Test that overlays on non-first meshes emit a warning."""
     meshes = [


### PR DESCRIPTION
onLocationChange was always wired to Streamlit.setComponentValue after the overlay rewrite (#111), forcing a full Python re-run per drag event and making the viewer slower than the pre-overlay iframe implementation. #138's throttle caps the rate at 10 Hz but each round trip still re-base64s the NIfTI and re-flows settings signals.

Expose update_interval_ms on niivue_viewer(). None skips the listener entirely so there are no Streamlit round-trips during mouse interaction — matching the pre-overlay latency. Defaults to 100 (current behaviour).