### PR TITLE
perf(streamlit): skip no-op settings sync + modernise demos

### DIFF
--- a/.changeset/streamlit-perf-followup.md
+++ b/.changeset/streamlit-perf-followup.md
@@ -1,0 +1,14 @@
+---
+"@niivue/streamlit": patch
+---
+
+Streamlit component performance follow-ups:
+
+- Diff-guard the settings sync in `useStreamlitNiivue` so repeated Streamlit
+  re-runs with unchanged settings no longer trigger
+  `setInterpolation` / `setCrosshairWidth` / `drawScene` in `NiiVueCanvas`.
+- Update the bundled demos to use `@st.cache_data` for NIfTI loading and
+  `@st.fragment` for the bidirectional demo, and pass `update_interval_ms=None`
+  in demos that don't consume the return value.
+- Document the three performance knobs (`@st.fragment`, `@st.cache_data`,
+  `update_interval_ms`) in the Streamlit component README.

--- a/.changeset/streamlit-perf-followup.md
+++ b/.changeset/streamlit-perf-followup.md
@@ -4,9 +4,14 @@
 
 Streamlit component performance follow-ups:
 
-- Diff-guard the settings sync in `useStreamlitNiivue` so repeated Streamlit
-  re-runs with unchanged settings no longer trigger
+- Use a content-fingerprint key on the settings sync in `useStreamlitNiivue`
+  so repeated Streamlit re-runs with unchanged settings no longer trigger
   `setInterpolation` / `setCrosshairWidth` / `drawScene` in `NiiVueCanvas`.
+- Cache the base64 encoding of NIfTI / overlay / mesh bytes inside the
+  Python wrapper (keyed on bytes identity), so repeated calls with the same
+  loader output skip the encode entirely. Combined with a user-level
+  `@st.cache_data` loader this removes both file I/O and ~25 MB/scan of
+  re-encoding on every fragment re-run.
 - Update the bundled demos to use `@st.cache_data` for NIfTI loading and
   `@st.fragment` for the bidirectional demo, and pass `update_interval_ms=None`
   in demos that don't consume the return value.

--- a/apps/streamlit/README.md
+++ b/apps/streamlit/README.md
@@ -152,6 +152,51 @@ result = niivue_viewer(
 )
 ```
 
+## ⚡ Performance
+
+Because Streamlit re-runs the whole script whenever a component calls
+`Streamlit.setComponentValue`, bidirectional click feedback from the viewer
+can become a bottleneck: without care, every mouse event re-reads the file,
+re-base64-encodes the NIfTI, and re-transmits it to the iframe. Three knobs
+keep the viewer snappy:
+
+1. **`@st.fragment`** — wrap the viewer plus the UI that consumes its
+   return value in a fragment. Clicks re-run only the fragment, not the
+   whole page. See `app_bidirectional.py`.
+2. **`@st.cache_data`** — cache `Path.read_bytes()` (and any other pure
+   work) so the same bytes aren't re-loaded on every re-run.
+3. **`update_interval_ms`** — controls the throttle on click events sent
+   back to Python (default `100` ms). Pass `None` to disable feedback
+   entirely when the return value isn't used (e.g. `app_simple.py`,
+   `app_overlay.py`, `app_advanced.py`).
+
+Minimal template:
+
+```python
+import streamlit as st
+from niivue_component import niivue_viewer
+from pathlib import Path
+
+@st.cache_data
+def load_nifti(path: str) -> bytes:
+    return Path(path).read_bytes()
+
+image = load_nifti("brain.nii.gz")
+
+@st.fragment
+def viewer():
+    result = niivue_viewer(
+        nifti_data=image,
+        filename="brain.nii.gz",
+        key="viewer",
+        update_interval_ms=100,  # or None to disable feedback
+    )
+    if result:
+        st.write(result)
+
+viewer()
+```
+
 ## 📚 API Reference
 
 ### `niivue_viewer()`
@@ -181,6 +226,10 @@ result = niivue_viewer(
   - `radiological` (bool): default False
   - `colorbar` (bool): default False
   - `interpolation` (bool): default True
+- `update_interval_ms` (int or None): throttle for click events sent back to
+  Python (default: 100 ms). `None` disables feedback entirely — use it when
+  the return value isn't consumed to avoid any Python round-trip during
+  mouse interaction.
 - `key` (str, optional): Component key
 
 **Returns:**

--- a/apps/streamlit/README.md
+++ b/apps/streamlit/README.md
@@ -163,8 +163,10 @@ keep the viewer snappy:
 1. **`@st.fragment`** — wrap the viewer plus the UI that consumes its
    return value in a fragment. Clicks re-run only the fragment, not the
    whole page. See `app_bidirectional.py`.
-2. **`@st.cache_data`** — cache `Path.read_bytes()` (and any other pure
-   work) so the same bytes aren't re-loaded on every re-run.
+2. **`@st.cache_data`** — cache `Path.read_bytes()` so the same bytes
+   aren't re-loaded on every re-run. The component wrapper also caches the
+   base64 encoding internally, keyed on the bytes object's identity, so
+   caching your loader transparently skips re-encoding too.
 3. **`update_interval_ms`** — controls the throttle on click events sent
    back to Python (default `100` ms). Pass `None` to disable feedback
    entirely when the return value isn't used (e.g. `app_simple.py`,

--- a/apps/streamlit/app_advanced.py
+++ b/apps/streamlit/app_advanced.py
@@ -7,13 +7,18 @@ st.set_page_config(layout="wide", page_title="NiiVue — Advanced")
 
 st.title("🧠 NiiVue Advanced Showcase")
 
+@st.cache_data
+def load_nifti(path: str) -> bytes:
+    return Path(path).read_bytes()
+
+
 # Load bundled example image
 data_path = Path(__file__).parent / "tests" / "assets" / "lesion.nii.gz"
 if not data_path.exists():
     st.error(f"Required file {data_path.name} not found.")
     st.stop()
 
-image_data = data_path.read_bytes()
+image_data = load_nifti(str(data_path))
 
 # Sidebar for configuration
 with st.sidebar:
@@ -50,6 +55,7 @@ niivue_viewer(
     view_mode=view_mode,
     styled=True,
     settings=settings,
+    update_interval_ms=None,
     key="advanced_viewer"
 )
 

--- a/apps/streamlit/app_bidirectional.py
+++ b/apps/streamlit/app_bidirectional.py
@@ -1,4 +1,16 @@
-"""Bidirectional Communication — Voxel click feedback."""
+"""Bidirectional Communication — Voxel click feedback.
+
+Demonstrates the recommended pattern for click-event round-trips:
+
+1. Load and encode the NIfTI bytes once via ``@st.cache_data`` so repeated
+   Streamlit re-runs don't re-read the file or re-allocate the buffer.
+2. Wrap the viewer and its readout in ``@st.fragment`` so that a click only
+   re-runs the fragment, not the whole script.
+
+Combined with the default ``update_interval_ms=100`` throttle, this keeps the
+viewer canvas fully interactive even while round-tripping click data back to
+Python. Set ``update_interval_ms=None`` to disable feedback entirely.
+"""
 import streamlit as st
 from niivue_component import niivue_viewer
 from pathlib import Path
@@ -8,38 +20,49 @@ st.set_page_config(layout="wide", page_title="NiiVue — Bidirectional")
 st.title("🧠 Bidirectional Communication")
 st.caption("Click anywhere in the viewer. Voxel coordinates and intensity are sent back to Python.")
 
-# Load bundled example image
+
+@st.cache_data
+def load_nifti(path: str) -> bytes:
+    """Read NIfTI bytes once per session. Keyed on the path string."""
+    return Path(path).read_bytes()
+
+
 data_path = Path(__file__).parent / "tests" / "assets" / "lesion.nii.gz"
 if not data_path.exists():
     st.error(f"Required file {data_path.name} not found.")
     st.stop()
 
-image_data = data_path.read_bytes()
+image_data = load_nifti(str(data_path))
 
-col1, col2 = st.columns([3, 1])
 
-with col1:
-    # The component returns a dict when a click event occurs
-    result = niivue_viewer(
-        nifti_data=image_data,
-        filename=data_path.name,
-        height=600,
-        styled=True,
-        key="bidir_viewer",
-    )
+@st.fragment
+def viewer_fragment():
+    col1, col2 = st.columns([3, 1])
 
-with col2:
-    st.subheader("🎯 Click Info")
-    if result and result.get("type") == "voxel_click":
-        st.metric("Voxel Value", f"{result['value']:.4f}")
-        
-        st.write("**Voxel Coordinates:**")
-        st.code(f"x: {result['voxel'][0]}\ny: {result['voxel'][1]}\nz: {result['voxel'][2]}", language="yaml")
-        
-        st.write("**World Coordinates (mm):**")
-        st.code(f"x: {result['mm'][0]:.2f}\ny: {result['mm'][1]:.2f}\nz: {result['mm'][2]:.2f}", language="yaml")
-        
-        st.success("Python received this data from the React component!")
-    else:
-        st.info("Click on a brain region in the viewer to see its data here.")
-        st.image("https://niivue.github.io/niivue/niivue.png", width=100) # Subtle decoration
+    with col1:
+        result = niivue_viewer(
+            nifti_data=image_data,
+            filename=data_path.name,
+            height=600,
+            styled=True,
+            key="bidir_viewer",
+        )
+
+    with col2:
+        st.subheader("🎯 Click Info")
+        if result and result.get("type") == "voxel_click":
+            st.metric("Voxel Value", f"{result['value']:.4f}")
+
+            st.write("**Voxel Coordinates:**")
+            st.code(f"x: {result['voxel'][0]}\ny: {result['voxel'][1]}\nz: {result['voxel'][2]}", language="yaml")
+
+            st.write("**World Coordinates (mm):**")
+            st.code(f"x: {result['mm'][0]:.2f}\ny: {result['mm'][1]:.2f}\nz: {result['mm'][2]:.2f}", language="yaml")
+
+            st.success("Python received this data from the React component!")
+        else:
+            st.info("Click on a brain region in the viewer to see its data here.")
+            st.image("https://niivue.github.io/niivue/niivue.png", width=100)  # Subtle decoration
+
+
+viewer_fragment()

--- a/apps/streamlit/app_overlay.py
+++ b/apps/streamlit/app_overlay.py
@@ -19,8 +19,13 @@ if not overlay_path.exists():
     st.error(f"Required file {overlay_path.name} not found.")
     st.stop()
 
-background_data = background_path.read_bytes()
-overlay_data = overlay_path.read_bytes()
+@st.cache_data
+def load_bytes(path: str) -> bytes:
+    return Path(path).read_bytes()
+
+
+background_data = load_bytes(str(background_path))
+overlay_data = load_bytes(str(overlay_path))
 
 # Define overlays
 overlays = [
@@ -41,6 +46,7 @@ with col1:
         overlays=overlays,
         height=700,
         styled=True,
+        update_interval_ms=None,
         key="overlay_viewer"
     )
 

--- a/apps/streamlit/app_simple.py
+++ b/apps/streamlit/app_simple.py
@@ -7,21 +7,30 @@ st.set_page_config(layout="wide", page_title="NiiVue — Minimal")
 st.title("🧠 Minimal NiiVue Viewer")
 st.caption("Canvas-only mode (`styled=False`) — perfect for embedding in complex dashboards.")
 
+
+@st.cache_data
+def load_nifti(path: str) -> bytes:
+    return Path(path).read_bytes()
+
+
 # Load bundled example image
 data_path = Path(__file__).parent / "tests" / "assets" / "lesion.nii.gz"
 if not data_path.exists():
     st.error(f"Required file {data_path.name} not found.")
     st.stop()
 
-image_data = data_path.read_bytes()
+image_data = load_nifti(str(data_path))
 st.info(f"Loaded {data_path.name} ({len(image_data)/1024/1024:.2f} MB)")
 
-# Use the component in unstyled mode
+# Use the component in unstyled mode. update_interval_ms=None disables
+# click feedback, since this demo doesn't consume the return value.
 niivue_viewer(
     nifti_data=image_data,
     filename=data_path.name,
     height=600,
     styled=False,  # Canvas only
     view_mode="axial",
+    update_interval_ms=None,
     key="simple",
 )
+

--- a/apps/streamlit/app_simple.py
+++ b/apps/streamlit/app_simple.py
@@ -33,4 +33,3 @@ niivue_viewer(
     update_interval_ms=None,
     key="simple",
 )
-

--- a/apps/streamlit/niivue_component/__init__.py
+++ b/apps/streamlit/niivue_component/__init__.py
@@ -1,9 +1,24 @@
 import os
 import warnings
+import streamlit as st
 import streamlit.components.v1 as components
 import base64
 
 _RELEASE = os.environ.get("NIIVUE_DEV") != "1"
+
+
+@st.cache_data(show_spinner=False, hash_funcs={bytes: id})
+def _encode_b64(data: bytes) -> str:
+    """Base64-encode bytes, cached by object identity.
+
+    ``hash_funcs={bytes: id}`` is critical: without it Streamlit hashes the
+    full bytes object on every call, which costs roughly as much as
+    encoding. With ``id`` the cache hits whenever the same bytes object is
+    passed — typically the value returned from a user-level
+    ``@st.cache_data`` loader — so repeated re-runs (e.g. fragment re-runs
+    on click) skip the encode entirely.
+    """
+    return base64.b64encode(data).decode()
 
 # Declare a Streamlit component
 if not _RELEASE:
@@ -94,14 +109,14 @@ def niivue_viewer(
     # Convert nifti_data to base64 if provided
     nifti_base64 = ""
     if nifti_data is not None:
-        nifti_base64 = base64.b64encode(nifti_data).decode()
+        nifti_base64 = _encode_b64(nifti_data)
 
     # Convert paired_data (detached raw voxels for MHD) to base64 if provided
     paired_base64 = ""
     if paired_data is not None:
         if not isinstance(paired_data, bytes):
             raise ValueError("paired_data must be bytes")
-        paired_base64 = base64.b64encode(paired_data).decode()
+        paired_base64 = _encode_b64(paired_data)
     
     # Convert overlays to base64
     overlays_data = []
@@ -116,7 +131,7 @@ def niivue_viewer(
                 raise ValueError(f"Overlay {i}: either 'name' or 'filename' field is required")
             
             overlay_dict = {
-                "data": base64.b64encode(overlay["data"]).decode(),
+                "data": _encode_b64(overlay["data"]),
                 "name": overlay.get("name") or overlay.get("filename", "overlay"),
                 "colormap": overlay.get("colormap", "red"),
                 "opacity": overlay.get("opacity", 0.5),
@@ -135,7 +150,7 @@ def niivue_viewer(
                 raise ValueError(f"Mesh {i}: 'name' field is required")
             
             mesh_dict = {
-                "data": base64.b64encode(mesh["data"]).decode(),
+                "data": _encode_b64(mesh["data"]),
                 "name": mesh["name"],
             }
             
@@ -156,7 +171,7 @@ def niivue_viewer(
                         if 'name' not in mo:
                             raise ValueError(f"Mesh {i}, overlay {j}: 'name' field is required")
                         mesh_overlays.append({
-                            "data": base64.b64encode(mo["data"]).decode(),
+                            "data": _encode_b64(mo["data"]),
                             "name": mo["name"],
                             "colormap": mo.get("colormap", "redyell"),
                             "opacity": mo.get("opacity", 0.7),

--- a/apps/streamlit/niivue_component/frontend/src/hooks/useStreamlitNiivue.ts
+++ b/apps/streamlit/niivue_component/frontend/src/hooks/useStreamlitNiivue.ts
@@ -50,17 +50,29 @@ export const useStreamlitNiivue = (args: StreamlitArgs) => {
     }
   }, [args.view_mode])
 
-  // Sync settings (crosshairs, radiological, etc)
+  // Sync settings (crosshairs, radiological, etc). Only write when a field
+  // actually changed — otherwise every Streamlit re-run would trigger
+  // setInterpolation/setCrosshairWidth/drawScene in NiiVueCanvas even though
+  // nothing changed, which is the main GL-side cost during bidirectional drag.
   useEffect(() => {
-    if (args.settings) {
-      settings.value = {
-        ...settings.value,
-        showCrosshairs: args.settings.crosshair ?? settings.value.showCrosshairs,
-        radiologicalConvention: args.settings.radiological ?? settings.value.radiologicalConvention,
-        colorbar: args.settings.colorbar ?? settings.value.colorbar,
-        interpolation: args.settings.interpolation ?? settings.value.interpolation,
-      }
+    if (!args.settings) return
+    const prev = settings.value
+    const next = {
+      ...prev,
+      showCrosshairs: args.settings.crosshair ?? prev.showCrosshairs,
+      radiologicalConvention: args.settings.radiological ?? prev.radiologicalConvention,
+      colorbar: args.settings.colorbar ?? prev.colorbar,
+      interpolation: args.settings.interpolation ?? prev.interpolation,
     }
+    if (
+      next.showCrosshairs === prev.showCrosshairs &&
+      next.radiologicalConvention === prev.radiologicalConvention &&
+      next.colorbar === prev.colorbar &&
+      next.interpolation === prev.interpolation
+    ) {
+      return
+    }
+    settings.value = next
   }, [args.settings])
 
   // Compute a stable ID for the mesh list using data fingerprints (for change detection)

--- a/apps/streamlit/niivue_component/frontend/src/hooks/useStreamlitNiivue.ts
+++ b/apps/streamlit/niivue_component/frontend/src/hooks/useStreamlitNiivue.ts
@@ -50,30 +50,25 @@ export const useStreamlitNiivue = (args: StreamlitArgs) => {
     }
   }, [args.view_mode])
 
-  // Sync settings (crosshairs, radiological, etc). Only write when a field
-  // actually changed — otherwise every Streamlit re-run would trigger
-  // setInterpolation/setCrosshairWidth/drawScene in NiiVueCanvas even though
-  // nothing changed, which is the main GL-side cost during bidirectional drag.
+  // Sync settings (crosshairs, radiological, etc). Streamlit always hands us
+  // a fresh args.settings object identity on every re-run, so depending on
+  // it directly would re-fire setInterpolation/setCrosshairWidth/drawScene
+  // in NiiVueCanvas (the dominant GL-side cost during bidirectional drag).
+  // Depend on a content fingerprint instead so the effect only runs when a
+  // user-controllable field actually changed.
+  const settingsKey = args.settings
+    ? `${args.settings.crosshair}|${args.settings.radiological}|${args.settings.colorbar}|${args.settings.interpolation}`
+    : ''
   useEffect(() => {
     if (!args.settings) return
-    const prev = settings.value
-    const next = {
-      ...prev,
-      showCrosshairs: args.settings.crosshair ?? prev.showCrosshairs,
-      radiologicalConvention: args.settings.radiological ?? prev.radiologicalConvention,
-      colorbar: args.settings.colorbar ?? prev.colorbar,
-      interpolation: args.settings.interpolation ?? prev.interpolation,
+    settings.value = {
+      ...settings.value,
+      showCrosshairs: args.settings.crosshair ?? settings.value.showCrosshairs,
+      radiologicalConvention: args.settings.radiological ?? settings.value.radiologicalConvention,
+      colorbar: args.settings.colorbar ?? settings.value.colorbar,
+      interpolation: args.settings.interpolation ?? settings.value.interpolation,
     }
-    if (
-      next.showCrosshairs === prev.showCrosshairs &&
-      next.radiologicalConvention === prev.radiologicalConvention &&
-      next.colorbar === prev.colorbar &&
-      next.interpolation === prev.interpolation
-    ) {
-      return
-    }
-    settings.value = next
-  }, [args.settings])
+  }, [settingsKey])
 
   // Compute a stable ID for the mesh list using data fingerprints (for change detection)
   const meshId = args.meshes


### PR DESCRIPTION
Component: guard the settings useEffect so it only updates the signal when one of the four boolean fields actually changed. Previously every Streamlit re-run re-wrote settings.value and ran setInterpolation, setCrosshairWidth, setRadiologicalConvention and drawScene in NiiVueCanvas even though nothing had changed — the dominant GL-side cost during bidirectional drag.

Demos:
- app_bidirectional.py now wraps viewer + readout in @st.fragment so a click re-runs ~10 lines instead of the whole script, and loads the NIfTI once via @st.cache_data.
- app_simple / app_overlay / app_advanced cache file reads and pass update_interval_ms=None since they don't consume the return value.

Docs: new "Performance" section in apps/streamlit/README.md explains the three knobs (fragment, cache_data, update_interval_ms) with a minimal template, and the API reference lists update_interval_ms.