### PR TITLE
feat: publish coverage to GitHub Pages + README badge + PR comment deltas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,7 @@ jobs:
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - name: Checkout
@@ -384,7 +384,39 @@ jobs:
           path: apps/pwa/coverage/e2e/
         continue-on-error: true
 
+      - name: Determine coverage deploy target
+        id: target
+        run: |
+          repo_name="${{ github.event.repository.name }}"
+          owner="${{ github.repository_owner }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            dest="coverage/pr-${{ github.event.pull_request.number }}"
+          else
+            dest="coverage/main"
+          fi
+          url="https://${owner}.github.io/${repo_name}/${dest}/"
+          badge_url="https://img.shields.io/endpoint?url=${url}badge.json"
+          {
+            echo "dest=${dest}"
+            echo "url=${url}"
+            echo "badge_url=${badge_url}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Fetch baseline coverage from main (for delta)
+        continue-on-error: true
+        run: |
+          baseline_url="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/coverage/main/summary.json"
+          if curl -fsSL "$baseline_url" -o /tmp/coverage-baseline.json; then
+            echo "COVERAGE_BASELINE=/tmp/coverage-baseline.json" >> "$GITHUB_ENV"
+            echo "Baseline fetched from $baseline_url"
+          else
+            echo "No baseline available at $baseline_url (first run or main not yet published)"
+          fi
+
       - name: Aggregate coverage reports
+        env:
+          COVERAGE_REPORT_URL: ${{ steps.target.outputs.url }}
+          COVERAGE_BADGE_URL: ${{ steps.target.outputs.badge_url }}
         run: node scripts/coverage/aggregate.mjs
 
       - name: Upload merged coverage report
@@ -401,7 +433,30 @@ jobs:
           path: |
             coverage/summary.json
             coverage/summary.md
+            coverage/badge.json
           retention-days: 30
+
+      - name: Stage publishable coverage assets
+        run: |
+          mkdir -p coverage/publish
+          # Flatten merged/index.html to publish/ root so the deploy URL serves it directly
+          cp coverage/merged/index.html coverage/publish/index.html
+          cp coverage/badge.json coverage/publish/
+          cp coverage/summary.json coverage/publish/
+          cp coverage/summary.md coverage/publish/
+
+      - name: Deploy coverage report to GitHub Pages
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+        continue-on-error: true
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./coverage/publish
+          destination_dir: ${{ steps.target.outputs.dest }}
+          keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Publish coverage report to ${{ steps.target.outputs.dest }}'
 
       - name: Comment coverage summary on PR
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,7 +447,10 @@ jobs:
 
       - name: Deploy coverage report to GitHub Pages
         if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
-        continue-on-error: true
+        # Tolerate failures only on PRs (fork PRs have a read-only GITHUB_TOKEN
+        # and will fail the deploy — we still want the sticky comment to post).
+        # On main, a failed deploy means a stale badge, so we fail the build.
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup_coverage_preview.yml
+++ b/.github/workflows/cleanup_coverage_preview.yml
@@ -21,13 +21,19 @@ jobs:
       - name: Remove PR coverage directory
         run: |
           PR_DIR="coverage/pr-${{ github.event.pull_request.number }}"
-          if [ -d "$PR_DIR" ]; then
-            git config user.name 'github-actions[bot]'
-            git config user.email 'github-actions[bot]@users.noreply.github.com'
-            git rm -rf "$PR_DIR"
+          if [ ! -d "$PR_DIR" ]; then
+            echo "Coverage directory $PR_DIR does not exist, nothing to clean up"
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          # --ignore-unmatch tolerates the case where the directory exists in the
+          # working tree but contains no tracked files (already removed in a prior run).
+          git rm -rf --ignore-unmatch "$PR_DIR"
+          if git diff --cached --quiet; then
+            echo "Nothing staged for $PR_DIR (already untracked), skipping commit"
+          else
             git commit -m "Remove coverage report for closed PR #${{ github.event.pull_request.number }}"
             git push
             echo "Removed coverage directory: $PR_DIR"
-          else
-            echo "Coverage directory $PR_DIR does not exist, nothing to clean up"
           fi

--- a/.github/workflows/cleanup_coverage_preview.yml
+++ b/.github/workflows/cleanup_coverage_preview.yml
@@ -1,0 +1,33 @@
+# Remove the per-PR coverage report directory from gh-pages when a PR closes.
+name: Cleanup Coverage Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Remove PR coverage directory
+        run: |
+          PR_DIR="coverage/pr-${{ github.event.pull_request.number }}"
+          if [ -d "$PR_DIR" ]; then
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git rm -rf "$PR_DIR"
+            git commit -m "Remove coverage report for closed PR #${{ github.event.pull_request.number }}"
+            git push
+            echo "Removed coverage directory: $PR_DIR"
+          else
+            echo "Coverage directory $PR_DIR does not exist, nothing to clean up"
+          fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NiiVue VS Code (and Jupyterlab, web native, streamlit)
 
+[![Coverage](https://img.shields.io/endpoint?url=https://niivue.github.io/niivue-vscode/coverage/main/badge.json)](https://niivue.github.io/niivue-vscode/coverage/main/)
+
 **WebGL 2.0 medical image viewers for multiple platforms**
 
 This monorepo contains the [NiiVue](https://github.com/niivue/niivue) integration projects for VS Code, JupyterLab, web browsers, and Streamlit. View NIfTI files, meshes, tractography, and DICOM images with hardware-accelerated rendering across your favorite development environments.
@@ -37,7 +39,7 @@ jupyter lab
 
 Browser-based viewer that works offline as an installable web app.
 
-- **Try it**: [https://korbinian90.github.io/niivue-vscode](https://korbinian90.github.io/niivue-vscode)
+- **Try it**: [https://niivue.github.io/niivue-vscode](https://niivue.github.io/niivue-vscode)
 - **Install**: Click "Install App" in Chrome/Edge
 - **Docs**: [apps/pwa/README.md](apps/pwa/README.md)
 

--- a/scripts/coverage/aggregate.mjs
+++ b/scripts/coverage/aggregate.mjs
@@ -214,6 +214,7 @@ function bucketData(istanbulData) {
     }
     result[bucket.id] = { label: bucket.label, stats: computeStats(subset) }
   }
+  result._overall = { label: 'Overall', stats: computeStats(istanbulData) }
   return result
 }
 
@@ -226,25 +227,82 @@ function pctStr(v) {
   return `${v}%`
 }
 
-function buildMarkdownTable(summary) {
+function deltaStr(curr, prev) {
+  if (curr === null || prev === null || prev === undefined) return ''
+  const diff = Math.round((curr - prev) * 10) / 10
+  if (diff === 0) return ''
+  const sign = diff > 0 ? '+' : '−'
+  return ` (${sign}${Math.abs(diff)})`
+}
+
+// Shields color thresholds for line coverage.
+function badgeColor(pct) {
+  if (pct === null) return 'lightgrey'
+  if (pct >= 90) return 'brightgreen'
+  if (pct >= 80) return 'green'
+  if (pct >= 70) return 'yellowgreen'
+  if (pct >= 60) return 'yellow'
+  if (pct >= 50) return 'orange'
+  return 'red'
+}
+
+function buildBadgeJson(summary) {
+  const overall = summary._overall?.stats?.lines
+  return {
+    schemaVersion: 1,
+    label: 'coverage',
+    message: overall === null || overall === undefined ? 'unknown' : `${overall}%`,
+    color: badgeColor(overall ?? null),
+  }
+}
+
+function buildMarkdownTable(summary, opts = {}) {
+  const { baseline = null, reportUrl = null, badgeUrl = null } = opts
+
+  const overall = summary._overall?.stats?.lines ?? null
+  const baseOverall = baseline?._overall?.stats?.lines ?? null
+
   const rows = BUCKETS.map((b) => {
     const s = summary[b.id]?.stats ?? {}
+    const baseStats = baseline?.[b.id]?.stats ?? {}
     return [
       b.label,
-      pctStr(s.statements),
-      pctStr(s.branches),
-      pctStr(s.functions),
-      pctStr(s.lines),
+      pctStr(s.statements) + deltaStr(s.statements ?? null, baseStats.statements),
+      pctStr(s.branches) + deltaStr(s.branches ?? null, baseStats.branches),
+      pctStr(s.functions) + deltaStr(s.functions ?? null, baseStats.functions),
+      pctStr(s.lines) + deltaStr(s.lines ?? null, baseStats.lines),
     ]
   })
 
-  const header = ['Row', 'Statements', 'Branches', 'Functions', 'Lines']
+  const header = ['Package', 'Statements', 'Branches', 'Functions', 'Lines']
   const separator = header.map(() => '---')
   const table = [header, separator, ...rows]
     .map((row) => `| ${row.join(' | ')} |`)
     .join('\n')
 
-  return `## Coverage Summary\n\n${table}\n`
+  const lines = ['## Coverage Report', '']
+
+  if (badgeUrl) {
+    const badgeImg = `![coverage](${badgeUrl})`
+    lines.push(badgeImg)
+    lines.push('')
+  }
+
+  if (overall !== null) {
+    const delta = deltaStr(overall, baseOverall)
+    lines.push(`**Overall line coverage: ${pctStr(overall)}${delta ? ` ${delta.trim()} vs \`main\`` : ''}**`)
+    lines.push('')
+  }
+
+  lines.push(table)
+  lines.push('')
+
+  if (reportUrl) {
+    lines.push(`📊 [View full report →](${reportUrl})`)
+    lines.push('')
+  }
+
+  return lines.join('\n')
 }
 
 function buildHtmlReport(mergedData) {
@@ -315,8 +373,25 @@ async function main() {
   }
 
   const summary = bucketData(mergedData)
-  const markdownTable = buildMarkdownTable(summary)
+
+  // Optional baseline (previous summary.json fetched from gh-pages main report)
+  let baseline = null
+  const baselinePath = process.env.COVERAGE_BASELINE
+  if (baselinePath && existsSync(baselinePath)) {
+    try {
+      baseline = JSON.parse(readFileSync(baselinePath, 'utf8'))
+      console.log(`📐 Using baseline: ${baselinePath}`)
+    } catch (err) {
+      console.warn(`⚠️  Could not parse baseline at ${baselinePath}: ${err.message}`)
+    }
+  }
+
+  const reportUrl = process.env.COVERAGE_REPORT_URL || null
+  const badgeUrl = process.env.COVERAGE_BADGE_URL || null
+
+  const markdownTable = buildMarkdownTable(summary, { baseline, reportUrl, badgeUrl })
   const htmlReport = buildHtmlReport(mergedData)
+  const badgeJson = buildBadgeJson(summary)
 
   // Write outputs
   const outDir = path.join(repoRoot, 'coverage')
@@ -326,12 +401,14 @@ async function main() {
   writeFileSync(path.join(mergedDir, 'index.html'), htmlReport, 'utf8')
   writeFileSync(path.join(outDir, 'summary.json'), JSON.stringify(summary, null, 2), 'utf8')
   writeFileSync(path.join(outDir, 'summary.md'), markdownTable, 'utf8')
+  writeFileSync(path.join(outDir, 'badge.json'), JSON.stringify(badgeJson, null, 2), 'utf8')
 
   console.log('\n' + markdownTable)
   console.log(`✅ Written:`)
   console.log(`   coverage/merged/index.html`)
   console.log(`   coverage/summary.json`)
   console.log(`   coverage/summary.md`)
+  console.log(`   coverage/badge.json`)
 }
 
 main().catch((err) => {


### PR DESCRIPTION
Stacked on top of #_ (the `copilot/add-monorepo-awareness-coverage-reporting` PR) — merge that one first.

## Summary

Adds the visibility layer on top of the existing coverage aggregation:

- **README badge** (one number, click → full hosted report)
- **PR sticky comment** now shows overall line coverage, per-bucket deltas vs `main`, and a deep-link to the full per-file HTML report scoped to the PR
- **gh-pages publishing** of the merged report under `coverage/main/` (main push) and `coverage/pr-<N>/` (PRs); auto-cleaned on PR close, mirroring the existing PWA preview workflow

### Sample PR comment

```
## Coverage Report

![coverage](shields…/coverage/pr-42/badge.json)

**Overall line coverage: 57.1% (+2.1) vs `main`**

| Package | Statements | Branches | Functions | Lines |
| --- | --- | --- | --- | --- |
| Shared core (`packages/niivue-react`) | 75% | 50% | 50% | 75% (+5) |
| `apps/pwa` | 33.3% | N/A | 50% | 33.3% (−6.7) |
| ...

📊 [View full report →](…/coverage/pr-42/)
```

Unchanged deltas are suppressed so reader eyes go to movers.

## Files

- `scripts/coverage/aggregate.mjs` — emits `coverage/badge.json` (shields endpoint), adds `_overall` row, supports `COVERAGE_BASELINE` env var for deltas, embeds report URL + badge image into `summary.md`
- `.github/workflows/ci.yml` coverage job — upgrades to `contents: write`, computes target dir/URL from `${{ github.repository_owner }}`, curls baseline from main, stages publishable assets (flattens `merged/index.html` to publish root), deploys via `peaceiris/actions-gh-pages@v4` with `keep_files: true`
- `.github/workflows/cleanup_coverage_preview.yml` — new, removes `coverage/pr-<N>/` on PR close
- `README.md` — coverage badge under the title; aligned the PWA "Try it" link to `niivue.github.io` (was inconsistent with `deploy_pwa_preview.yml` which hardcodes the niivue org host)

## Known behavior

- **First main push after merge:** no baseline yet → no deltas in PR comments until the second main publish writes `coverage/main/summary.json`. Graceful — script skips baseline silently.
- **Fork PRs:** `GITHUB_TOKEN` is read-only, so the deploy step will fail. `continue-on-error: true` keeps the sticky comment posting; the "View full report" link in that comment will 404. Same limitation the existing PWA preview workflow lives with.
- **Coexistence with PWA on gh-pages:** `keep_files: true` + scoped `destination_dir` mean the PWA at gh-pages root and other PR previews are preserved.

## Test plan

- [ ] Merge the base PR first; observe the next main CI run publishes to `https://niivue.github.io/niivue-vscode/coverage/main/` and the badge resolves
- [ ] Open a follow-up PR; observe sticky comment with table + report link, and a `coverage/pr-<N>/` directory created on `gh-pages`
- [ ] After two main publishes, deltas appear in the next PR comment
- [ ] Close a PR; observe `coverage/pr-<N>/` removed by `cleanup_coverage_preview.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)