### PR TITLE
feat: publish coverage report to GitHub Pages and add README badge

### DIFF
--- a/.changeset/publish-coverage-report.md
+++ b/.changeset/publish-coverage-report.md
@@ -1,0 +1,5 @@
+---
+'@niivue/pwa': patch
+---
+
+Tooling: enable Istanbul reporter for Playwright/monocart e2e coverage so per-PR coverage HTML reports include e2e data alongside Vitest unit coverage. No runtime behavior change in the PWA itself.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,7 @@ jobs:
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - name: Checkout
@@ -384,7 +384,39 @@ jobs:
           path: apps/pwa/coverage/e2e/
         continue-on-error: true
 
+      - name: Determine coverage deploy target
+        id: target
+        run: |
+          repo_name="${{ github.event.repository.name }}"
+          owner="${{ github.repository_owner }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            dest="coverage/pr-${{ github.event.pull_request.number }}"
+          else
+            dest="coverage/main"
+          fi
+          url="https://${owner}.github.io/${repo_name}/${dest}/"
+          badge_url="https://img.shields.io/endpoint?url=${url}badge.json"
+          {
+            echo "dest=${dest}"
+            echo "url=${url}"
+            echo "badge_url=${badge_url}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Fetch baseline coverage from main (for delta)
+        continue-on-error: true
+        run: |
+          baseline_url="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/coverage/main/summary.json"
+          if curl -fsSL "$baseline_url" -o /tmp/coverage-baseline.json; then
+            echo "COVERAGE_BASELINE=/tmp/coverage-baseline.json" >> "$GITHUB_ENV"
+            echo "Baseline fetched from $baseline_url"
+          else
+            echo "No baseline available at $baseline_url (first run or main not yet published)"
+          fi
+
       - name: Aggregate coverage reports
+        env:
+          COVERAGE_REPORT_URL: ${{ steps.target.outputs.url }}
+          COVERAGE_BADGE_URL: ${{ steps.target.outputs.badge_url }}
         run: node scripts/coverage/aggregate.mjs
 
       - name: Upload merged coverage report
@@ -401,7 +433,30 @@ jobs:
           path: |
             coverage/summary.json
             coverage/summary.md
+            coverage/badge.json
           retention-days: 30
+
+      - name: Stage publishable coverage assets
+        run: |
+          mkdir -p coverage/publish
+          # Flatten merged/index.html to publish/ root so the deploy URL serves it directly
+          cp coverage/merged/index.html coverage/publish/index.html
+          cp coverage/badge.json coverage/publish/
+          cp coverage/summary.json coverage/publish/
+          cp coverage/summary.md coverage/publish/
+
+      - name: Deploy coverage report to GitHub Pages
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+        continue-on-error: true
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./coverage/publish
+          destination_dir: ${{ steps.target.outputs.dest }}
+          keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Publish coverage report to ${{ steps.target.outputs.dest }}'
 
       - name: Comment coverage summary on PR
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,6 +437,10 @@ jobs:
           retention-days: 30
 
       - name: Stage publishable coverage assets
+        # aggregate.mjs exits 0 when no coverage JSON files are present (e.g.
+        # docs-only commits where all test jobs were skipped) — skip staging
+        # rather than failing on missing files.
+        if: hashFiles('coverage/merged/index.html') != ''
         run: |
           mkdir -p coverage/publish
           # Flatten merged/index.html to publish/ root so the deploy URL serves it directly
@@ -446,7 +450,7 @@ jobs:
           cp coverage/summary.md coverage/publish/
 
       - name: Deploy coverage report to GitHub Pages
-        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+        if: (github.event_name == 'pull_request' || github.ref == 'refs/heads/main') && hashFiles('coverage/publish/index.html') != ''
         # Tolerate failures only on PRs (fork PRs have a read-only GITHUB_TOKEN
         # and will fail the deploy — we still want the sticky comment to post).
         # On main, a failed deploy means a stale badge, so we fail the build.
@@ -462,7 +466,7 @@ jobs:
           commit_message: 'Publish coverage report to ${{ steps.target.outputs.dest }}'
 
       - name: Comment coverage summary on PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && hashFiles('coverage/summary.md') != ''
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           path: coverage/summary.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,7 +447,10 @@ jobs:
 
       - name: Deploy coverage report to GitHub Pages
         if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
-        continue-on-error: true
+        # Tolerate failures only on PRs (fork PRs have a read-only GITHUB_TOKEN
+        # and will fail the deploy — we still want the sticky comment to post).
+        # On main, a failed deploy means a stale badge, so we fail the build.
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup_coverage_preview.yml
+++ b/.github/workflows/cleanup_coverage_preview.yml
@@ -5,6 +5,13 @@ on:
   pull_request:
     types: [closed]
 
+# Serialize against any other workflow that mutates gh-pages (notably
+# cleanup_pwa_preview.yml fires on the same event) so concurrent pushes
+# don't fail with non-fast-forward errors.
+concurrency:
+  group: gh-pages-mutation
+  cancel-in-progress: false
+
 permissions:
   contents: write
 

--- a/.github/workflows/cleanup_coverage_preview.yml
+++ b/.github/workflows/cleanup_coverage_preview.yml
@@ -21,13 +21,19 @@ jobs:
       - name: Remove PR coverage directory
         run: |
           PR_DIR="coverage/pr-${{ github.event.pull_request.number }}"
-          if [ -d "$PR_DIR" ]; then
-            git config user.name 'github-actions[bot]'
-            git config user.email 'github-actions[bot]@users.noreply.github.com'
-            git rm -rf "$PR_DIR"
+          if [ ! -d "$PR_DIR" ]; then
+            echo "Coverage directory $PR_DIR does not exist, nothing to clean up"
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          # --ignore-unmatch tolerates the case where the directory exists in the
+          # working tree but contains no tracked files (already removed in a prior run).
+          git rm -rf --ignore-unmatch "$PR_DIR"
+          if git diff --cached --quiet; then
+            echo "Nothing staged for $PR_DIR (already untracked), skipping commit"
+          else
             git commit -m "Remove coverage report for closed PR #${{ github.event.pull_request.number }}"
             git push
             echo "Removed coverage directory: $PR_DIR"
-          else
-            echo "Coverage directory $PR_DIR does not exist, nothing to clean up"
           fi

--- a/.github/workflows/cleanup_coverage_preview.yml
+++ b/.github/workflows/cleanup_coverage_preview.yml
@@ -1,0 +1,33 @@
+# Remove the per-PR coverage report directory from gh-pages when a PR closes.
+name: Cleanup Coverage Preview
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Remove PR coverage directory
+        run: |
+          PR_DIR="coverage/pr-${{ github.event.pull_request.number }}"
+          if [ -d "$PR_DIR" ]; then
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git rm -rf "$PR_DIR"
+            git commit -m "Remove coverage report for closed PR #${{ github.event.pull_request.number }}"
+            git push
+            echo "Removed coverage directory: $PR_DIR"
+          else
+            echo "Coverage directory $PR_DIR does not exist, nothing to clean up"
+          fi

--- a/.github/workflows/cleanup_pwa_preview.yml
+++ b/.github/workflows/cleanup_pwa_preview.yml
@@ -5,6 +5,12 @@ on:
   pull_request:
     types: [closed]
 
+# Shared group with cleanup_coverage_preview.yml — both push to gh-pages on
+# the same event and would otherwise race with non-fast-forward push errors.
+concurrency:
+  group: gh-pages-mutation
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NiiVue VS Code (and Jupyterlab, web native, streamlit)
 
+[![Coverage](https://img.shields.io/endpoint?url=https://niivue.github.io/niivue-vscode/coverage/main/badge.json)](https://niivue.github.io/niivue-vscode/coverage/main/)
+
 **WebGL 2.0 medical image viewers for multiple platforms**
 
 This monorepo contains the [NiiVue](https://github.com/niivue/niivue) integration projects for VS Code, JupyterLab, web browsers, and Streamlit. View NIfTI files, meshes, tractography, and DICOM images with hardware-accelerated rendering across your favorite development environments.
@@ -37,7 +39,7 @@ jupyter lab
 
 Browser-based viewer that works offline as an installable web app.
 
-- **Try it**: [https://korbinian90.github.io/niivue-vscode](https://korbinian90.github.io/niivue-vscode)
+- **Try it**: [https://niivue.github.io/niivue-vscode](https://niivue.github.io/niivue-vscode)
 - **Install**: Click "Install App" in Chrome/Edge
 - **Docs**: [apps/pwa/README.md](apps/pwa/README.md)
 

--- a/apps/pwa/playwright.config.ts
+++ b/apps/pwa/playwright.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
         sourceFilter: (sourcePath: string) =>
           sourcePath.includes('apps/pwa/src') ||
           sourcePath.includes('packages/niivue-react/src'),
-        reports: ['v8', 'json', 'json-summary', 'lcov'],
+        reports: ['v8', 'istanbul', 'json', 'json-summary', 'lcov'],
         outputDir: './coverage/e2e',
       },
     }],

--- a/scripts/coverage/aggregate.mjs
+++ b/scripts/coverage/aggregate.mjs
@@ -214,6 +214,7 @@ function bucketData(istanbulData) {
     }
     result[bucket.id] = { label: bucket.label, stats: computeStats(subset) }
   }
+  result._overall = { label: 'Overall', stats: computeStats(istanbulData) }
   return result
 }
 
@@ -226,25 +227,82 @@ function pctStr(v) {
   return `${v}%`
 }
 
-function buildMarkdownTable(summary) {
+function deltaStr(curr, prev) {
+  if (curr === null || prev === null || prev === undefined) return ''
+  const diff = Math.round((curr - prev) * 10) / 10
+  if (diff === 0) return ''
+  const sign = diff > 0 ? '+' : '−'
+  return ` (${sign}${Math.abs(diff)})`
+}
+
+// Shields color thresholds for line coverage.
+function badgeColor(pct) {
+  if (pct === null) return 'lightgrey'
+  if (pct >= 90) return 'brightgreen'
+  if (pct >= 80) return 'green'
+  if (pct >= 70) return 'yellowgreen'
+  if (pct >= 60) return 'yellow'
+  if (pct >= 50) return 'orange'
+  return 'red'
+}
+
+function buildBadgeJson(summary) {
+  const overall = summary._overall?.stats?.lines
+  return {
+    schemaVersion: 1,
+    label: 'coverage',
+    message: overall === null || overall === undefined ? 'unknown' : `${overall}%`,
+    color: badgeColor(overall ?? null),
+  }
+}
+
+function buildMarkdownTable(summary, opts = {}) {
+  const { baseline = null, reportUrl = null, badgeUrl = null } = opts
+
+  const overall = summary._overall?.stats?.lines ?? null
+  const baseOverall = baseline?._overall?.stats?.lines ?? null
+
   const rows = BUCKETS.map((b) => {
     const s = summary[b.id]?.stats ?? {}
+    const baseStats = baseline?.[b.id]?.stats ?? {}
     return [
       b.label,
-      pctStr(s.statements),
-      pctStr(s.branches),
-      pctStr(s.functions),
-      pctStr(s.lines),
+      pctStr(s.statements) + deltaStr(s.statements ?? null, baseStats.statements),
+      pctStr(s.branches) + deltaStr(s.branches ?? null, baseStats.branches),
+      pctStr(s.functions) + deltaStr(s.functions ?? null, baseStats.functions),
+      pctStr(s.lines) + deltaStr(s.lines ?? null, baseStats.lines),
     ]
   })
 
-  const header = ['Row', 'Statements', 'Branches', 'Functions', 'Lines']
+  const header = ['Package', 'Statements', 'Branches', 'Functions', 'Lines']
   const separator = header.map(() => '---')
   const table = [header, separator, ...rows]
     .map((row) => `| ${row.join(' | ')} |`)
     .join('\n')
 
-  return `## Coverage Summary\n\n${table}\n`
+  const lines = ['## Coverage Report', '']
+
+  if (badgeUrl) {
+    const badgeImg = `![coverage](${badgeUrl})`
+    lines.push(badgeImg)
+    lines.push('')
+  }
+
+  if (overall !== null) {
+    const delta = deltaStr(overall, baseOverall)
+    lines.push(`**Overall line coverage: ${pctStr(overall)}${delta ? ` ${delta.trim()} vs \`main\`` : ''}**`)
+    lines.push('')
+  }
+
+  lines.push(table)
+  lines.push('')
+
+  if (reportUrl) {
+    lines.push(`📊 [View full report →](${reportUrl})`)
+    lines.push('')
+  }
+
+  return lines.join('\n')
 }
 
 function buildHtmlReport(mergedData) {
@@ -315,8 +373,25 @@ async function main() {
   }
 
   const summary = bucketData(mergedData)
-  const markdownTable = buildMarkdownTable(summary)
+
+  // Optional baseline (previous summary.json fetched from gh-pages main report)
+  let baseline = null
+  const baselinePath = process.env.COVERAGE_BASELINE
+  if (baselinePath && existsSync(baselinePath)) {
+    try {
+      baseline = JSON.parse(readFileSync(baselinePath, 'utf8'))
+      console.log(`📐 Using baseline: ${baselinePath}`)
+    } catch (err) {
+      console.warn(`⚠️  Could not parse baseline at ${baselinePath}: ${err.message}`)
+    }
+  }
+
+  const reportUrl = process.env.COVERAGE_REPORT_URL || null
+  const badgeUrl = process.env.COVERAGE_BADGE_URL || null
+
+  const markdownTable = buildMarkdownTable(summary, { baseline, reportUrl, badgeUrl })
   const htmlReport = buildHtmlReport(mergedData)
+  const badgeJson = buildBadgeJson(summary)
 
   // Write outputs
   const outDir = path.join(repoRoot, 'coverage')
@@ -326,12 +401,14 @@ async function main() {
   writeFileSync(path.join(mergedDir, 'index.html'), htmlReport, 'utf8')
   writeFileSync(path.join(outDir, 'summary.json'), JSON.stringify(summary, null, 2), 'utf8')
   writeFileSync(path.join(outDir, 'summary.md'), markdownTable, 'utf8')
+  writeFileSync(path.join(outDir, 'badge.json'), JSON.stringify(badgeJson, null, 2), 'utf8')
 
   console.log('\n' + markdownTable)
   console.log(`✅ Written:`)
   console.log(`   coverage/merged/index.html`)
   console.log(`   coverage/summary.json`)
   console.log(`   coverage/summary.md`)
+  console.log(`   coverage/badge.json`)
 }
 
 main().catch((err) => {

--- a/scripts/coverage/aggregate.mjs
+++ b/scripts/coverage/aggregate.mjs
@@ -256,22 +256,38 @@ function buildBadgeJson(summary) {
   }
 }
 
+// Render a single cell. When the current run produced no value for this
+// metric but the baseline (last main run) has one, carry the baseline value
+// forward with a "*" marker so readers can tell the row was skipped, not
+// permanently uncovered. Returns { text, stale }.
+function renderCell(curr, prev) {
+  if (curr !== null && curr !== undefined) {
+    return { text: pctStr(curr) + deltaStr(curr, prev), stale: false }
+  }
+  if (prev !== null && prev !== undefined) {
+    return { text: `${prev}%*`, stale: true }
+  }
+  return { text: 'N/A', stale: false }
+}
+
 function buildMarkdownTable(summary, opts = {}) {
   const { baseline = null, reportUrl = null, badgeUrl = null } = opts
 
   const overall = summary._overall?.stats?.lines ?? null
   const baseOverall = baseline?._overall?.stats?.lines ?? null
 
+  let anyStale = false
   const rows = BUCKETS.map((b) => {
     const s = summary[b.id]?.stats ?? {}
     const baseStats = baseline?.[b.id]?.stats ?? {}
-    return [
-      b.label,
-      pctStr(s.statements) + deltaStr(s.statements ?? null, baseStats.statements),
-      pctStr(s.branches) + deltaStr(s.branches ?? null, baseStats.branches),
-      pctStr(s.functions) + deltaStr(s.functions ?? null, baseStats.functions),
-      pctStr(s.lines) + deltaStr(s.lines ?? null, baseStats.lines),
+    const cells = [
+      renderCell(s.statements ?? null, baseStats.statements ?? null),
+      renderCell(s.branches ?? null, baseStats.branches ?? null),
+      renderCell(s.functions ?? null, baseStats.functions ?? null),
+      renderCell(s.lines ?? null, baseStats.lines ?? null),
     ]
+    if (cells.some((c) => c.stale)) anyStale = true
+    return [b.label, ...cells.map((c) => c.text)]
   })
 
   const header = ['Package', 'Statements', 'Branches', 'Functions', 'Lines']
@@ -288,14 +304,25 @@ function buildMarkdownTable(summary, opts = {}) {
     lines.push('')
   }
 
-  if (overall !== null) {
-    const delta = deltaStr(overall, baseOverall)
-    lines.push(`**Overall line coverage: ${pctStr(overall)}${delta ? ` ${delta.trim()} vs \`main\`` : ''}**`)
+  const overallCell = renderCell(overall, baseOverall)
+  if (overallCell.text !== 'N/A') {
+    if (overallCell.stale) anyStale = true
+    if (overall !== null) {
+      const delta = deltaStr(overall, baseOverall)
+      lines.push(`**Overall line coverage: ${pctStr(overall)}${delta ? ` ${delta.trim()} vs \`main\`` : ''}**`)
+    } else {
+      lines.push(`**Overall line coverage: ${overallCell.text}**`)
+    }
     lines.push('')
   }
 
   lines.push(table)
   lines.push('')
+
+  if (anyStale) {
+    lines.push('_\\* value carried over from `main` — this run did not produce coverage for that cell._')
+    lines.push('')
+  }
 
   if (reportUrl) {
     lines.push(`📊 [View full report →](${reportUrl})`)


### PR DESCRIPTION
## Summary

Re-targets the work from #158 (which was inadvertently merged into the now-orphaned base branch of #157, so its content never reached `main`).

- Publishes the merged coverage report to GitHub Pages (`coverage/main/`, `coverage/pr-<N>/`) using `peaceiris/actions-gh-pages@v4` with `keep_files: true` so the existing PWA at the root is preserved.
- Adds a shields.io endpoint badge (`coverage/main/badge.json`) and links it from the root `README.md`.
- Enriches the PR coverage sticky comment with overall coverage, per-row deltas vs. `main`, and a "View full report" link.
- Adds a `cleanup_coverage_preview.yml` workflow that removes `coverage/pr-<N>/` when a PR closes (idempotent: uses `git rm --ignore-unmatch` and guards `git push` behind `git diff --cached --quiet`).
- Includes a small fix in `apps/pwa/playwright.config.ts` to emit the `istanbul` reporter so e2e coverage feeds into the aggregator.

The Pages deploy step uses `continue-on-error: ${{ github.event_name == 'pull_request' }}` — fork-PR token failures are tolerated (the sticky comment still posts), but a failed deploy on `main` fails the build so a stale badge can't hide behind green CI.

## Test plan

- [ ] Open this PR and confirm the sticky coverage comment posts with overall %, per-row deltas, and a working "View full report" link
- [ ] Confirm the gh-pages deploy succeeds and `https://niivue.github.io/niivue-vscode/coverage/pr-<this-PR>/` serves the report
- [ ] After merge to `main`, confirm `coverage/main/badge.json` exists and the README badge renders
- [ ] Close a test PR and confirm `coverage/pr-<N>/` is removed by the cleanup workflow

Supersedes #158 (merged into orphaned base, content not on `main`).