### PR TITLE
fix(vscode): binary fallback for files outside webview resource scope

### DIFF
--- a/.changeset/fix-vscode-remote-add-overlay.md
+++ b/.changeset/fix-vscode-remote-add-overlay.md
@@ -1,0 +1,5 @@
+---
+"niivue": patch
+---
+
+Fix **Add Image** / **Add Overlay** silently failing on VS Code Remote-SSH (and any session where the picked file sits outside `localResourceRoots`). Centralise the URL-vs-binary decision in a new `uriToImageBody` helper used by every load entry point, harden `isUriAccessible` to match on scheme + authority + path (so a `file://` workspace can't claim to host a `vscode-remote://` file in single-file mode), and fall back to `vscode.workspace.fs.readFile` whenever `webview.asWebviewUri` can't serve the file.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,48 @@ jobs:
           if-no-files-found: ignore
           retention-days: 1
 
+  test-vscode:
+    needs: [changes, build]
+    if: needs.changes.outputs.vscode == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Restore build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            apps/*/dist
+            apps/*/build
+            apps/*/lib
+            packages/*/dist
+          key: build-artifacts-${{ github.sha }}
+
+      - name: Run VS Code extension vitest coverage
+        run: pnpm --filter=niivue test:coverage
+
+      - name: Upload VS Code vitest coverage artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-unit-vscode
+          path: apps/vscode/coverage/unit/
+          if-no-files-found: ignore
+          retention-days: 1
+
   test-streamlit:
     needs: [changes, build]
     if: needs.changes.outputs.streamlit == 'true'
@@ -338,7 +380,7 @@ jobs:
           retention-days: 1
 
   coverage:
-    needs: [test-pwa, test-jupyter, test-streamlit, e2e-tests]
+    needs: [test-pwa, test-jupyter, test-vscode, test-streamlit, e2e-tests]
     if: |
       always() &&
       !contains(needs.*.result, 'failure') &&
@@ -367,6 +409,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: coverage-unit-jupyter
+          path: .
+        continue-on-error: true
+
+      - name: Download VS Code coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-unit-vscode
           path: .
         continue-on-error: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,10 +413,14 @@ jobs:
         continue-on-error: true
 
       - name: Download VS Code coverage artifacts
+        # upload-artifact@v4 strips the parent path for single-path uploads,
+        # so the artifact's files sit at its root. Extract them back under
+        # apps/vscode/coverage/unit/ so the aggregator's walk (which requires
+        # a `coverage` path segment) picks them up.
         uses: actions/download-artifact@v4
         with:
           name: coverage-unit-vscode
-          path: .
+          path: apps/vscode/coverage/unit/
         continue-on-error: true
 
       - name: Download Streamlit coverage artifacts

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -56,6 +56,8 @@
     "clean": "rm -rf dist niivue",
     "lint": "eslint src --ext .ts,.tsx --report-unused-disable-directives --max-warnings 0",
     "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "package": "pnpm run build && vsce package",
     "publish": "pnpm run build && vsce publish"
   },
@@ -67,7 +69,8 @@
     "esbuild": "^0.25.11",
     "ovsx": "^0.10.6",
     "postcss": "^8.5.6",
-    "tailwindcss": "^3.4.18"
+    "tailwindcss": "^3.4.18",
+    "vitest": "^3.2.4"
   },
   "contributes": {
     "commands": [

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -59,10 +59,13 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "package": "pnpm run build && vsce package",
-    "publish": "pnpm run build && vsce publish"
+    "publish": "pnpm run build && vsce publish",
+    "test:coverage": "vitest run --coverage",
+    "coverage": "pnpm run test:coverage"
   },
   "devDependencies": {
     "@types/vscode": "1.70.0",
+    "@vitest/coverage-v8": "^3.2.4",
     "@vscode/vsce": "^3.6.2",
     "autoprefixer": "^10.4.21",
     "concurrently": "^9.2.1",

--- a/apps/vscode/src/editorProvider.ts
+++ b/apps/vscode/src/editorProvider.ts
@@ -82,8 +82,6 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
     const name = vscode.Uri.parse(uri.toString()).path.split('/').pop()
     const tabName = name ? `web: ${name}` : 'NiiVue Web Panel'
     this.createPanel(context, 'niivue.webview', tabName, uri).then((panel) => {
-      const editor = new NiiVueEditorProvider(context)
-
       let isImageSent = false
       panel.webview.onDidReceiveMessage(async (e) => {
         if (e.type === 'ready' && !isImageSent) {
@@ -91,14 +89,10 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
           this.postInitSettings(panel)
 
           if (uri.path.toLowerCase().endsWith('.mhd')) {
-            await NiiVueEditorProvider.sendMhdMessage(uri, panel.webview, editor.isUriAccessible(uri))
+            await NiiVueEditorProvider.sendMhdMessage(uri, panel.webview)
           } else {
-            // Send file URL instead of reading the entire file
-            const fileUrl = editor.createFileUrl(uri, panel.webview)
-            panel.webview.postMessage({
-              type: 'addImage',
-              body: { uri: fileUrl },
-            })
+            const body = await NiiVueEditorProvider.uriToImageBody(uri, panel.webview)
+            panel.webview.postMessage({ type: 'addImage', body })
           }
         }
       })
@@ -123,8 +117,6 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
   public static async createCompareView(context: vscode.ExtensionContext, items: any) {
     const uris = items.map((item: any) => vscode.Uri.parse(item))
     this.createPanel(context, 'niivue.compare', 'NiiVue Compare Panel', uris[0]).then((panel) => {
-      const editor = new NiiVueEditorProvider(context)
-
       let isImageSent = false
       panel.webview.onDidReceiveMessage(async (e) => {
         if (e.type === 'ready' && !isImageSent) {
@@ -135,13 +127,8 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
             body: { n: uris.length },
           })
           for (const uri of uris) {
-            const fileUrl = editor.createFileUrl(uri, panel.webview)
-            panel.webview.postMessage({
-              type: 'addImage',
-              body: {
-                uri: fileUrl,
-              },
-            })
+            const body = await NiiVueEditorProvider.uriToImageBody(uri, panel.webview)
+            panel.webview.postMessage({ type: 'addImage', body })
           }
         }
       })
@@ -149,8 +136,6 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
   }
 
   private static addCommonListeners(panel: vscode.WebviewPanel) {
-    const editor = new NiiVueEditorProvider(null as any) // Temporary instance for createFileUrl method
-
     panel.webview.onDidReceiveMessage(async (e) => {
       switch (e.type) {
         case 'addOverlay':
@@ -162,15 +147,12 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
               openLabel: 'Open Overlay',
               // filters: fileTypes // doesn't work properly in remote
             })
-            .then((uris) => {
+            .then(async (uris) => {
               if (uris && uris.length > 0) {
-                const fileUrl = editor.createFileUrl(uris[0], panel.webview)
+                const body = await NiiVueEditorProvider.uriToImageBody(uris[0], panel.webview)
                 panel.webview.postMessage({
                   type: e.body.type,
-                  body: {
-                    uri: fileUrl,
-                    index: e.body.index,
-                  },
+                  body: { ...body, index: e.body.index },
                 })
               }
             })
@@ -191,32 +173,12 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
                   body: { n: uris.length },
                 })
                 for (const uri of uris) {
-                  const lowerPath = uri.path.toLowerCase()
-                  if (lowerPath.endsWith('.mhd')) {
-                    // MHD files need paired .raw data
-                    await NiiVueEditorProvider.sendMhdMessage(
-                      uri,
-                      panel.webview,
-                      editor.isUriAccessible(uri),
-                    )
-                  } else if (lowerPath.endsWith('.dcm')) {
-                    // Handle DICOM files differently - send data instead of URL
-                    const data = await vscode.workspace.fs.readFile(uri)
-                    panel.webview.postMessage({
-                      type: 'addImage',
-                      body: {
-                        data: NiiVueEditorProvider.toArrayBuffer(data),
-                        uri: uri.toString(),
-                      },
-                    })
+                  if (uri.path.toLowerCase().endsWith('.mhd')) {
+                    // MHD needs paired .raw resolution; handled separately.
+                    await NiiVueEditorProvider.sendMhdMessage(uri, panel.webview)
                   } else {
-                    const fileUrl = editor.createFileUrl(uri, panel.webview)
-                    panel.webview.postMessage({
-                      type: 'addImage',
-                      body: {
-                        uri: fileUrl,
-                      },
-                    })
+                    const body = await NiiVueEditorProvider.uriToImageBody(uri, panel.webview)
+                    panel.webview.postMessage({ type: 'addImage', body })
                   }
                 }
               }
@@ -283,54 +245,68 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
       if (message.type === 'ready') {
         NiiVueEditorProvider.postInitSettings(webviewPanel)
 
-        // Handle DICOM and MINC files differently - send data instead of URL
-        const lowerCasePath = document.uri.path.toLowerCase()
-        if (lowerCasePath.endsWith('.mhd')) {
-          // MHD files have detached raw data; resolve the paired .raw file
-          await NiiVueEditorProvider.sendMhdMessage(
+        if (document.uri.path.toLowerCase().endsWith('.mhd')) {
+          // MHD files have detached raw data; resolve the paired .raw file.
+          await NiiVueEditorProvider.sendMhdMessage(document.uri, webviewPanel.webview)
+        } else {
+          const body = await NiiVueEditorProvider.uriToImageBody(
             document.uri,
             webviewPanel.webview,
-            this.isUriAccessible(document.uri),
           )
-        } else if (
-          lowerCasePath.endsWith('.dcm') ||
-          lowerCasePath.endsWith('.mnc') ||
-          !this.isUriAccessible(document.uri)
-        ) {
-          const data = await vscode.workspace.fs.readFile(document.uri)
-          webviewPanel.webview.postMessage({
-            type: 'addImage',
-            body: {
-              data: NiiVueEditorProvider.toArrayBuffer(data),
-              uri: document.uri.toString(),
-            },
-          })
-        } else {
-          // Send file URL instead of data for other files
-          const fileUrl = this.createFileUrl(document.uri, webviewPanel.webview)
-          webviewPanel.webview.postMessage({
-            type: 'addImage',
-            body: {
-              uri: fileUrl,
-            },
-          })
+          webviewPanel.webview.postMessage({ type: 'addImage', body })
         }
       }
     })
   }
 
-  private createFileUrl(uri: vscode.Uri, webview: vscode.Webview): string {
-    // Use VS Code's secure webview URI system for serving files
-    return webview.asWebviewUri(uri).toString()
+  /**
+   * Build the message body for an `addImage`/overlay payload.  Prefers a
+   * webview URI (so NiiVue can stream large volumes) but falls back to reading
+   * the file as binary when the URI is not reachable via the webview resource
+   * proxy — i.e. remote workspaces where the file sits outside
+   * `localResourceRoots`, or formats that NiiVue can only ingest as bytes
+   * (`.dcm`, `.mnc`).
+   *
+   * MHD files are handled separately by `sendMhdMessage` because they need
+   * the paired `.raw` voxel file resolved alongside the header.
+   */
+  static async uriToImageBody(
+    uri: vscode.Uri,
+    webview: vscode.Webview,
+  ): Promise<{ uri: string; data?: ArrayBuffer }> {
+    const lowerCasePath = uri.path.toLowerCase()
+    if (
+      lowerCasePath.endsWith('.dcm') ||
+      lowerCasePath.endsWith('.mnc') ||
+      !NiiVueEditorProvider.isUriAccessible(uri)
+    ) {
+      const data = await vscode.workspace.fs.readFile(uri)
+      return {
+        data: NiiVueEditorProvider.toArrayBuffer(data),
+        uri: uri.toString(),
+      }
+    }
+    return { uri: webview.asWebviewUri(uri).toString() }
   }
 
-  private isUriAccessible(uri: vscode.Uri): boolean {
+  /**
+   * Whether `uri` can be served through the webview resource proxy.  Requires
+   * the same scheme *and* authority as one of the workspace folders so that a
+   * `file://` workspace never claims to host a `vscode-remote://` file (which
+   * is what broke menu-driven Add Image / Add Overlay on SSH-remote sessions
+   * in single-file mode).
+   */
+  static isUriAccessible(uri: vscode.Uri): boolean {
     const workspaceFolders = vscode.workspace.workspaceFolders
     if (!workspaceFolders) {
       return false
     }
     for (const folder of workspaceFolders) {
-      if (uri.path.startsWith(folder.uri.path)) {
+      if (
+        uri.scheme === folder.uri.scheme &&
+        uri.authority === folder.uri.authority &&
+        uri.path.startsWith(folder.uri.path)
+      ) {
         return true
       }
     }
@@ -391,17 +367,13 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
    * directly.  When the file is not accessible that way, both files are read
    * and sent as binary buffers.
    */
-  static async sendMhdMessage(
-    uri: vscode.Uri,
-    webview: vscode.Webview,
-    isAccessible: boolean,
-  ): Promise<void> {
+  static async sendMhdMessage(uri: vscode.Uri, webview: vscode.Webview): Promise<void> {
     const mhdData = await vscode.workspace.fs.readFile(uri)
     const mhdText = new TextDecoder().decode(mhdData)
     const rawRef = NiiVueEditorProvider.getMhdPairedRawRef(mhdText)
     const rawUri = rawRef ? NiiVueEditorProvider.resolveMhdPairedRawUri(uri, rawRef) : null
 
-    if (isAccessible) {
+    if (NiiVueEditorProvider.isUriAccessible(uri)) {
       const mhdWebviewUri = webview.asWebviewUri(uri).toString()
       const body: Record<string, unknown> = { uri: mhdWebviewUri }
       if (rawRef) {

--- a/apps/vscode/test/editorProvider.test.ts
+++ b/apps/vscode/test/editorProvider.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NiiVueEditorProvider } from '../src/editorProvider'
+import { __resetMock, Uri, workspace } from './vscode-mock'
+
+/**
+ * These tests pin down the URL-vs-binary decision made by
+ * `NiiVueEditorProvider.uriToImageBody` and `isUriAccessible`.  The bug they
+ * guard against — "Add Image / Add Overlay fails on VS Code Remote-SSH"
+ * (commit 887c819 was lost in a merge once already) — manifests when the
+ * resource proxy can't serve a file but the helper still hands the webview a
+ * `webview.asWebviewUri(...)` URL.
+ */
+
+function makeWebview(): { asWebviewUri: ReturnType<typeof vi.fn> } {
+  // Real `webview.asWebviewUri` returns a Uri whose `.toString()` is a fully
+  // proxied https://*.vscode-cdn.net URL.  Source only calls `.toString()` on
+  // the result, so a stub with just that method is sufficient.
+  return {
+    asWebviewUri: vi.fn((uri: Uri) => ({
+      toString: () => `https://cdn.vscode-cdn.net${uri.path}?scheme=${uri.scheme}`,
+    })),
+  }
+}
+
+beforeEach(() => {
+  __resetMock()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('NiiVueEditorProvider.isUriAccessible', () => {
+  it('returns false when no workspace folder is open', () => {
+    workspace.workspaceFolders = undefined
+    const uri = Uri.parse('file:///home/user/data.nii.gz')
+    expect(NiiVueEditorProvider.isUriAccessible(uri)).toBe(false)
+  })
+
+  it('returns true for a local file inside the workspace', () => {
+    const workspaceUri = Uri.parse('file:///home/user/proj')
+    workspace.workspaceFolders = [{ uri: workspaceUri }]
+    const uri = Uri.parse('file:///home/user/proj/data.nii.gz')
+    expect(NiiVueEditorProvider.isUriAccessible(uri)).toBe(true)
+  })
+
+  it('returns true for a remote file inside a matching remote workspace', () => {
+    const workspaceUri = Uri.parse('vscode-remote://ssh-remote%2Bmyhost/home/user/proj')
+    workspace.workspaceFolders = [{ uri: workspaceUri }]
+    const uri = Uri.parse('vscode-remote://ssh-remote%2Bmyhost/home/user/proj/atlas.nii.gz')
+    expect(NiiVueEditorProvider.isUriAccessible(uri)).toBe(true)
+  })
+
+  it('returns false when authorities differ (remote uri, local workspace)', () => {
+    workspace.workspaceFolders = [{ uri: Uri.parse('file:///home/user/proj') }]
+    const remoteUri = Uri.parse('vscode-remote://ssh-remote%2Bmyhost/home/user/proj/data.nii.gz')
+    expect(NiiVueEditorProvider.isUriAccessible(remoteUri)).toBe(false)
+  })
+
+  it('returns false when schemes differ', () => {
+    workspace.workspaceFolders = [{ uri: Uri.parse('vscode-remote://ssh-remote%2Bmyhost/home') }]
+    const fileUri = Uri.parse('file:///home/data.nii.gz')
+    expect(NiiVueEditorProvider.isUriAccessible(fileUri)).toBe(false)
+  })
+
+  it('returns false for a sibling directory outside the workspace folder', () => {
+    workspace.workspaceFolders = [{ uri: Uri.parse('file:///home/user/proj') }]
+    const outsideUri = Uri.parse('file:///home/user/other-proj/data.nii.gz')
+    expect(NiiVueEditorProvider.isUriAccessible(outsideUri)).toBe(false)
+  })
+})
+
+describe('NiiVueEditorProvider.uriToImageBody', () => {
+  it('returns a webview URL for an accessible local file', async () => {
+    workspace.workspaceFolders = [{ uri: Uri.parse('file:///home/user/proj') }]
+    const webview = makeWebview()
+    const uri = Uri.parse('file:///home/user/proj/data.nii.gz')
+
+    const body = await NiiVueEditorProvider.uriToImageBody(uri, webview as any)
+
+    expect(body.data).toBeUndefined()
+    expect(body.uri).toBe('https://cdn.vscode-cdn.net/home/user/proj/data.nii.gz?scheme=file')
+    expect(webview.asWebviewUri).toHaveBeenCalledOnce()
+    expect(workspace.fs.readFile).not.toHaveBeenCalled()
+  })
+
+  it('returns a webview URL for an accessible remote file', async () => {
+    workspace.workspaceFolders = [
+      { uri: Uri.parse('vscode-remote://ssh-remote%2Bmyhost/home/user/proj') },
+    ]
+    const webview = makeWebview()
+    const uri = Uri.parse('vscode-remote://ssh-remote%2Bmyhost/home/user/proj/atlas.nii.gz')
+
+    const body = await NiiVueEditorProvider.uriToImageBody(uri, webview as any)
+
+    expect(body.data).toBeUndefined()
+    expect(body.uri).toContain('vscode-cdn.net')
+    expect(webview.asWebviewUri).toHaveBeenCalledOnce()
+    expect(workspace.fs.readFile).not.toHaveBeenCalled()
+  })
+
+  it('falls back to binary when the remote file is outside any workspace folder', async () => {
+    // The historical bug: open-dialog can return any path the user picks; on
+    // remote that path isn't covered by `localResourceRoots`, so the URL path
+    // would silently 401.  The helper must spot this and ship bytes instead.
+    workspace.workspaceFolders = [
+      { uri: Uri.parse('vscode-remote://ssh-remote%2Bmyhost/home/user/proj') },
+    ]
+    const payload = new Uint8Array([1, 2, 3, 4])
+    workspace.fs.readFile.mockResolvedValueOnce(payload)
+    const webview = makeWebview()
+    const uri = Uri.parse('vscode-remote://ssh-remote%2Bmyhost/data/atlas.nii.gz')
+
+    const body = await NiiVueEditorProvider.uriToImageBody(uri, webview as any)
+
+    expect(body.data).toBeInstanceOf(ArrayBuffer)
+    expect(new Uint8Array(body.data!)).toEqual(payload)
+    expect(body.uri).toBe('vscode-remote://ssh-remote%2Bmyhost/data/atlas.nii.gz')
+    expect(webview.asWebviewUri).not.toHaveBeenCalled()
+    expect(workspace.fs.readFile).toHaveBeenCalledWith(uri)
+  })
+
+  it('falls back to binary when no workspace folder is open (single-file mode)', async () => {
+    workspace.workspaceFolders = undefined
+    workspace.fs.readFile.mockResolvedValueOnce(new Uint8Array([9, 9, 9]))
+    const webview = makeWebview()
+    const uri = Uri.parse('vscode-remote://ssh-remote%2Bmyhost/home/user/data.nii.gz')
+
+    const body = await NiiVueEditorProvider.uriToImageBody(uri, webview as any)
+
+    expect(body.data).toBeInstanceOf(ArrayBuffer)
+    expect(webview.asWebviewUri).not.toHaveBeenCalled()
+  })
+
+  it('forces binary for .dcm even when the file is in the workspace', async () => {
+    workspace.workspaceFolders = [{ uri: Uri.parse('file:///home/user/proj') }]
+    workspace.fs.readFile.mockResolvedValueOnce(new Uint8Array([0x44, 0x49, 0x43, 0x4d]))
+    const webview = makeWebview()
+    const uri = Uri.parse('file:///home/user/proj/scan.dcm')
+
+    const body = await NiiVueEditorProvider.uriToImageBody(uri, webview as any)
+
+    expect(body.data).toBeInstanceOf(ArrayBuffer)
+    expect(body.uri).toBe('file:///home/user/proj/scan.dcm')
+    expect(webview.asWebviewUri).not.toHaveBeenCalled()
+    expect(workspace.fs.readFile).toHaveBeenCalledWith(uri)
+  })
+
+  it('forces binary for .mnc even when the file is in the workspace', async () => {
+    workspace.workspaceFolders = [{ uri: Uri.parse('file:///home/user/proj') }]
+    workspace.fs.readFile.mockResolvedValueOnce(new Uint8Array([0]))
+    const webview = makeWebview()
+    const uri = Uri.parse('file:///home/user/proj/scan.mnc')
+
+    const body = await NiiVueEditorProvider.uriToImageBody(uri, webview as any)
+
+    expect(body.data).toBeInstanceOf(ArrayBuffer)
+    expect(webview.asWebviewUri).not.toHaveBeenCalled()
+  })
+
+  it('produces a fresh ArrayBuffer (not a view onto a pooled Node Buffer)', async () => {
+    // VS Code returns Uint8Array views that on Node are backed by a shared
+    // ArrayBuffer pool — handing that to postMessage would leak unrelated
+    // memory.  toArrayBuffer must copy.
+    workspace.workspaceFolders = [{ uri: Uri.parse('file:///home/user/proj') }]
+    const shared = new ArrayBuffer(16)
+    const view = new Uint8Array(shared, 4, 4)
+    view.set([1, 2, 3, 4])
+    workspace.fs.readFile.mockResolvedValueOnce(view)
+    const uri = Uri.parse('file:///home/user/proj/scan.dcm')
+
+    const body = await NiiVueEditorProvider.uriToImageBody(uri, makeWebview() as any)
+
+    expect(body.data!.byteLength).toBe(4)
+    expect(body.data).not.toBe(shared)
+    expect(new Uint8Array(body.data!)).toEqual(new Uint8Array([1, 2, 3, 4]))
+  })
+})

--- a/apps/vscode/test/vscode-mock.ts
+++ b/apps/vscode/test/vscode-mock.ts
@@ -1,0 +1,71 @@
+/**
+ * Minimal in-process stand-in for the `vscode` extension API.  Wired up via a
+ * Vite alias in `vitest.config.ts` so that `import * as vscode from 'vscode'`
+ * inside the source code resolves to this file during tests.
+ *
+ * Only the symbols actually exercised by the units under test are provided —
+ * extend as needed.
+ */
+import { vi } from 'vitest'
+
+export class Uri {
+  constructor(public scheme: string, public authority: string, public path: string) {}
+
+  static parse(value: string): Uri {
+    const match = value.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\/([^/?#]*)(\/[^?#]*)?/)
+    if (match) {
+      return new Uri(match[1], match[2] ?? '', match[3] ?? '/')
+    }
+    return new Uri('file', '', value)
+  }
+
+  static file(p: string): Uri {
+    return new Uri('file', '', p)
+  }
+
+  static joinPath(base: Uri, ...parts: string[]): Uri {
+    const tail = parts.join('/').replace(/^\/+/, '')
+    const joined = `${base.path.replace(/\/+$/, '')}/${tail}`.replace(/\/{2,}/g, '/')
+    return new Uri(base.scheme, base.authority, joined || '/')
+  }
+
+  toString(): string {
+    return `${this.scheme}://${this.authority}${this.path}`
+  }
+
+  with(props: { scheme?: string; authority?: string; path?: string }): Uri {
+    return new Uri(
+      props.scheme ?? this.scheme,
+      props.authority ?? this.authority,
+      props.path ?? this.path,
+    )
+  }
+}
+
+export const workspace = {
+  workspaceFolders: undefined as undefined | { uri: Uri }[],
+  fs: {
+    readFile: vi.fn<(uri: Uri) => Promise<Uint8Array>>(),
+    readDirectory: vi.fn(),
+  },
+  getConfiguration: vi.fn(),
+}
+
+export const window = {
+  registerCustomEditorProvider: vi.fn(),
+  createWebviewPanel: vi.fn(),
+  showOpenDialog: vi.fn(),
+}
+
+export const ViewColumn = { One: 1 }
+
+/** Reset all mutable state between tests. */
+export function __resetMock() {
+  workspace.workspaceFolders = undefined
+  workspace.fs.readFile.mockReset()
+  workspace.fs.readDirectory.mockReset()
+  workspace.getConfiguration.mockReset()
+  window.registerCustomEditorProvider.mockReset()
+  window.createWebviewPanel.mockReset()
+  window.showOpenDialog.mockReset()
+}

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const dir = path.dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['test/**/*.{test,spec}.ts'],
+    exclude: ['node_modules/**', 'dist/**'],
+  },
+  resolve: {
+    alias: {
+      vscode: path.resolve(dir, 'test/vscode-mock.ts'),
+    },
+  },
+})

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -10,6 +10,13 @@ export default defineConfig({
     environment: 'node',
     include: ['test/**/*.{test,spec}.ts'],
     exclude: ['node_modules/**', 'dist/**'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'json', 'json-summary'],
+      reportsDirectory: './coverage/unit',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.d.ts'],
+    },
   },
   resolve: {
     alias: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,6 +370,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.18
         version: 3.4.18(yaml@2.8.1)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.9.1)(@vitest/ui@3.2.4)(jiti@1.21.7)(jsdom@26.1.0)(less@4.4.2)(terser@5.44.0)(yaml@2.8.1)
 
   packages/niivue-react:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,6 +349,9 @@ importers:
       '@types/vscode':
         specifier: 1.70.0
         version: 1.70.0
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4)
       '@vscode/vsce':
         specifier: ^3.6.2
         version: 3.6.2


### PR DESCRIPTION
## Summary

- Menu-driven **Add Image** / **Add Overlay** silently failed on VS Code Remote-SSH because `webview.asWebviewUri()` was used unconditionally — when the picked file sat outside `localResourceRoots` the webview resource proxy refused the request and the load died with no UI feedback.
- Centralises the URL-vs-binary decision in a new static `NiiVueEditorProvider.uriToImageBody` helper, wired into all five load entry points (`addOverlay`, `addImages`, `createOrShow`, `createCompareView`, `resolveCustomEditor`).
- Hardens `isUriAccessible` with a scheme + authority match so a `file://` workspace cannot claim to host a `vscode-remote://` file (the single-file-mode case that broke for the user).
- Drops the now-unused `createFileUrl` and the `new NiiVueEditorProvider(null as any)` workaround.
- Adds vitest infrastructure to `apps/vscode` plus 13 unit tests covering the helper + accessibility check.

## Background

Restores and extends the `uriToImageBody` pattern from commit `887c819`, which was inadvertently dropped when the presets PR (#128, branched off pre-fix code) was merged. **Supersedes #132**, which had the same core idea but was stale, narrower (no authority check, didn't touch `createOrShow`/`createCompareView`, no tests, and would conflict with the merged MHD work in #160).

## Test plan

- [x] `pnpm --filter niivue test` — 13/13 unit tests pass
- [x] `pnpm --filter niivue type-check`
- [x] `pnpm --filter niivue lint`
- [ ] Manual smoke on a real Remote-SSH host: open `.nii.gz` via custom editor, then **Add Overlay** → pick a sibling `.nii.gz`. Overlay loads. Repeat with a file *outside* the workspace folder — must also load (binary path).
- [ ] Manual smoke local: same flow still uses URL path (no perf regression on large `.nii.gz`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)