### PR TITLE
fix(release): dispatch by new-tag diff + remove conflicting pnpm version pin

### DIFF
--- a/.github/workflows/release-coordinator.yml
+++ b/.github/workflows/release-coordinator.yml
@@ -35,6 +35,17 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      # Snapshot existing tags so we can diff after publish and detect what
+      # changesets just created. Comparing HEAD^..HEAD package.json doesn't
+      # work because the version bump and the publish can happen in
+      # different runs (e.g. the publish run is triggered by a later push
+      # after an earlier publish crashed and left versions un-tagged).
+      - name: Snapshot tags before publish
+        run: |
+          git fetch --tags origin
+          git tag -l > /tmp/pre-publish-tags.txt
+          echo "Tags before publish: $(wc -l < /tmp/pre-publish-tags.txt)"
+
       - name: Create Version PR or Publish
         id: changesets
         uses: changesets/action@v1
@@ -47,9 +58,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # `changeset publish` only tags the private app packages (npm publish is
-      # skipped). Tags pushed by GITHUB_TOKEN don't trigger other workflows, so
-      # dispatch each app's dedicated release workflow when its version
-      # actually changed in the merge commit. Stable release scheme: whatever
+      # skipped). Tags pushed by GITHUB_TOKEN don't trigger other workflows,
+      # so dispatch each app's dedicated release workflow whenever changesets
+      # just created its tag in this run. Stable release scheme: whatever
       # changeset version produced (bare semver / PEP 440) ships as-is; the
       # marketplace and PyPI both accept those formats for stable channels.
       - name: Dispatch per-app release workflows
@@ -58,20 +69,27 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
-          changed() {
-            git diff HEAD^ HEAD -- "$1" | grep -Eq '^[+-][[:space:]]*"version":'
-          }
+          git tag -l > /tmp/post-publish-tags.txt
+          new_tags=$(comm -13 \
+            <(sort -u /tmp/pre-publish-tags.txt) \
+            <(sort -u /tmp/post-publish-tags.txt))
+          if [ -z "$new_tags" ]; then
+            echo "No new tags created in this run; nothing to dispatch."
+            exit 0
+          fi
+          echo "New tags created in this run:"
+          printf '  %s\n' $new_tags
           dispatch() {
-            local app=$1 workflow=$2 pkg=apps/$1/package.json
-            if changed "$pkg"; then
-              local v
-              v=$(node -p "require('./$pkg').version")
-              echo "→ dispatching $workflow for $app v$v"
-              gh workflow run "$workflow" --ref main
+            local pkg_name=$1 workflow=$2
+            local tag
+            tag=$(printf '%s\n' $new_tags | grep -E "^${pkg_name}@" | head -n1 || true)
+            if [ -n "$tag" ]; then
+              echo "→ dispatching $workflow for $tag"
+              gh workflow run "$workflow" --ref "$tag"
             else
-              echo "  skipping $app (no version change)"
+              echo "  skipping $pkg_name (no new tag in this run)"
             fi
           }
-          dispatch vscode    release_vscode.yml
-          dispatch jupyter   release_jupyterlab.yml
-          dispatch streamlit release_streamlit.yml
+          dispatch 'niivue'             release_vscode.yml
+          dispatch '@niivue/jupyter'    release_jupyterlab.yml
+          dispatch '@niivue/streamlit'  release_streamlit.yml

--- a/.github/workflows/release_jupyterlab.yml
+++ b/.github/workflows/release_jupyterlab.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release_streamlit.yml
+++ b/.github/workflows/release_streamlit.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release_vscode.yml
+++ b/.github/workflows/release_vscode.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/Release.md
+++ b/Release.md
@@ -46,7 +46,7 @@ The Release Coordinator then:
 
    The apps are marked `"private": true` in their `package.json` so npm publish is skipped. Tags are still created because `.changeset/config.json` opts into `privatePackages.tag: true`.
 
-2. **Dispatches each app's release workflow** for the apps whose version actually changed in the merge commit. This uses `gh workflow run` rather than the tag-push trigger, because GitHub's recursion guard prevents tags pushed by `GITHUB_TOKEN` from triggering other workflows. `workflow_dispatch` is the documented exception.
+2. **Dispatches each app's release workflow** for the apps whose tag was just created in this run. The coordinator snapshots `git tag -l` before and after `changeset publish`, computes the diff, and matches new tags against each registered app (e.g. a new `niivue@*` tag → dispatch `release_vscode.yml --ref <tag>`). This uses `gh workflow run` rather than the tag-push trigger, because GitHub's recursion guard prevents tags pushed by `GITHUB_TOKEN` from triggering other workflows. `workflow_dispatch` is the documented exception. The tag-based detection is robust to the case where the version bump and the publish happen in different coordinator runs (e.g. an earlier publish failed and left versions un-tagged; a later push then triggers the catch-up publish).
 
 3. The per-app workflows (`release_vscode.yml`, `release_jupyterlab.yml`, `release_streamlit.yml`) each check out `main`, build, and publish the version recorded in `apps/<app>/package.json` (or `pyproject.toml` for Python apps) to the relevant registry:
    - VS Code → VS Code Marketplace and Open VSX


### PR DESCRIPTION
## Summary

Follow-up to [#163](https://github.com/niivue/niivue-vscode/pull/163). The publish path landed correctly — [coordinator run 25989030676](https://github.com/niivue/niivue-vscode/actions/runs/25989030676) successfully tagged `niivue@2.9.0`, `@niivue/jupyter@0.2.7`, and `@niivue/streamlit@0.3.0` (the catch-up tag-creation from the previously-crashed `fa69613` release). But two more bugs surfaced that this PR fixes.

## Bug 1 — dispatch step skipped all the apps

Commit `8b299e7`. The previous heuristic was `git diff HEAD^ HEAD apps/<app>/package.json` — "dispatch if the version line changed in the merge commit". That assumes the version bump and the publish happen in the same commit, which they didn't:

- `fa69613` (Version Packages PR #140 merge) bumped versions, but the publish crashed with ENEEDAUTH so nothing got tagged.
- `1dd6cc4` (#163 merge) landed the ENEEDAUTH fix. Coordinator on this commit ran `changeset publish`, found the un-tagged versions from `fa69613`, and tagged them now. But `HEAD^..HEAD` on `1dd6cc4` is just the docs/workflow diff from #163 — no version-line changes — so the dispatcher skipped all three apps.

**Fix:** snapshot `git tag -l` before `changeset publish`, diff after, dispatch any release workflow whose package's new tag is in the diff. That's the actual signal, independent of where the version bump originally came from. Uses the new tag as `--ref` for the dispatched workflow.

## Bug 2 — per-app workflows can't start (`pnpm/action-setup` conflict)

Commit `a92a2bb`. Once I dispatched the three release workflows manually to test the catch-up path, they all failed within seconds at the `Setup pnpm` step:

```
Error: Multiple versions of pnpm specified:
  - version latest in the GitHub Action config with the key "version"
  - version pnpm@10.18.3 in the package.json with the key "packageManager"
```

All three `release_*.yml` workflows declared `pnpm/action-setup@v4 with: version: latest`, but the root package.json pins `packageManager: pnpm@10.18.3`. `pnpm/action-setup@v4` errors on the conflict. This was unnoticed because the per-app workflows had never run end-to-end before (tag triggers don't fire under `GITHUB_TOKEN`, and the dispatch path was the bug above).

**Fix:** drop the `with: version: latest` block from all three. `release-coordinator.yml` and `prerelease.yml` already use this pattern and work fine.

Failed runs that exposed this:
- VS Code: [25990629970](https://github.com/niivue/niivue-vscode/actions/runs/25990629970)
- JupyterLab: [25990631904](https://github.com/niivue/niivue-vscode/actions/runs/25990631904)
- Streamlit: [25990635274](https://github.com/niivue/niivue-vscode/actions/runs/25990635274)

## Stuck releases — re-dispatch after merge

The tags `niivue@2.9.0`, `@niivue/jupyter@0.2.7`, `@niivue/streamlit@0.3.0` already exist (created by the catch-up publish). When re-dispatching, **use `--ref main` not `--ref <tag>`**: `gh workflow run` reads the workflow file from the specified ref, and the tag refs point at `1dd6cc4` which doesn't include the pnpm fix yet. After this PR merges, `main` will have both fixes; `apps/<app>/package.json` versions at main are still 2.9.0 / 0.2.7 / 0.3.0 (unchanged since #163), so the build produces the right artifact.

```bash
gh workflow run release_vscode.yml      --ref main
gh workflow run release_jupyterlab.yml  --ref main
gh workflow run release_streamlit.yml   --ref main
```

## Test plan

- [ ] Merge this PR.
- [ ] Re-dispatch the three release workflows with `--ref main` to ship the stuck 2.9.0 / 0.2.7 / 0.3.0 stable releases.
- [ ] Confirm Marketplace, Open VSX, and PyPI now show the stable versions.
- [ ] Next Version Packages PR merge: Release Coordinator detects the new tags via the snapshot-diff and auto-dispatches the per-app workflows end-to-end with no manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
