### PR TITLE
fix(release): correct gh-release tag + jupyter build step order

### DIFF
--- a/.github/workflows/release_jupyterlab.yml
+++ b/.github/workflows/release_jupyterlab.yml
@@ -44,11 +44,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build extension
-        run: pnpm turbo build --filter=@niivue/jupyter
-
+      # Must run before `Build extension`: the build calls
+      # `jupyter labextension build`, which is provided by the
+      # `jupyterlab` Python package.
       - name: Install Python build tools
         run: python -m pip install "jupyterlab>=4.0.0,<5" build twine
+
+      - name: Build extension
+        run: pnpm turbo build --filter=@niivue/jupyter
 
       - name: Build Python package
         working-directory: ./apps/jupyter
@@ -65,9 +68,17 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
-      - name: Create GitHub Release
+      # Use the package's tag (created by changesets/action) so we attach the
+      # wheel to the existing release rather than failing on `github.ref_name`
+      # being "main" under workflow_dispatch.
+      - name: Resolve release tag
+        id: release_tag
+        run: echo "tag=@niivue/jupyter@$(node -p "require('./apps/jupyter/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Attach wheel to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.release_tag.outputs.tag }}
           files: apps/jupyter/dist/*
           generate_release_notes: true
           prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}

--- a/.github/workflows/release_streamlit.yml
+++ b/.github/workflows/release_streamlit.yml
@@ -65,9 +65,17 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
-      - name: Create GitHub Release
+      # Use the package's tag (created by changesets/action) so we attach the
+      # wheel to the existing release rather than failing on `github.ref_name`
+      # being "main" under workflow_dispatch.
+      - name: Resolve release tag
+        id: release_tag
+        run: echo "tag=@niivue/streamlit@$(node -p "require('./apps/streamlit/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Attach wheel to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.release_tag.outputs.tag }}
           files: apps/streamlit/dist/*
           generate_release_notes: true
           prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}

--- a/.github/workflows/release_vscode.yml
+++ b/.github/workflows/release_vscode.yml
@@ -58,9 +58,17 @@ jobs:
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
 
-      - name: Create GitHub Release
+      # Use the package's tag (created by changesets/action) so we attach the
+      # .vsix to the existing release rather than failing on `github.ref_name`
+      # being "main" under workflow_dispatch.
+      - name: Resolve release tag
+        id: release_tag
+        run: echo "tag=niivue@$(node -p "require('./apps/vscode/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Attach VSIX to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.release_tag.outputs.tag }}
           files: apps/vscode/*.vsix
           generate_release_notes: true
           prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}


### PR DESCRIPTION
## Summary

The three release workflows that PR [#164](https://github.com/niivue/niivue-vscode/pull/164) wired up to be dispatched by Release Coordinator all failed on their first end-to-end run, exposing two more bugs:

| Workflow | Run | Result |
|---|---|---|
| Release VS Code Extension | [25994541173](https://github.com/niivue/niivue-vscode/actions/runs/25994541173) | ✅ Marketplace + Open VSX published `2.9.0` · ❌ `Create GitHub Release` failed |
| Release JupyterLab Extension | [25994542524](https://github.com/niivue/niivue-vscode/actions/runs/25994542524) | ❌ Build failed before publish — `0.2.7` not on PyPI |
| Release Streamlit Component | [25994543887](https://github.com/niivue/niivue-vscode/actions/runs/25994543887) | ✅ PyPI published `0.3.0` · ❌ `Create GitHub Release` failed |

## Bug 1 — `softprops/action-gh-release@v2` errors under workflow_dispatch

```
##[error]⚠️ GitHub Releases requires a tag
```

The action defaults to `github.ref_name`. On the tag-push path (`niivue@*` etc.) that's the tag; on Release Coordinator's dispatch path (`--ref main`) that's `"main"`, which isn't a tag.

**Fix:** resolve the tag explicitly in each workflow from `apps/<app>/package.json`. `changesets/action` already created the GitHub release for that tag during publish, so this step just uploads the built artifact (vsix / wheel) onto the existing release. Step renamed from "Create GitHub Release" to "Attach \<artifact\> to GitHub Release" to reflect what it's actually doing.

## Bug 2 — Jupyter build runs before its toolchain is installed

```
> @niivue/jupyter@0.2.7 build:labextension:dev
> jupyter labextension build --development True .
sh: 1: jupyter: not found
```

`release_jupyterlab.yml` ran `Build extension` before `Install Python build tools`. The build invokes `jupyter labextension build`, which is provided by the `jupyterlab` Python package installed in that step. `prerelease.yml` has the correct order; `release_jupyterlab.yml` didn't.

**Fix:** move `Install Python build tools` before `Build extension`.

## Effect on the stuck stable releases

After this lands, re-dispatching with `--ref main` should:

- **Jupyter**: now actually publish `0.2.7` to PyPI (it failed at build last time, never reached the publish step).
- **VS Code** and **Streamlit**: re-run will be no-ops for the registries (Marketplace / PyPI don't allow re-uploading the same version) but the gh-release upload step will succeed this time and attach the vsix / wheel to the existing release.

## Test plan

- [ ] Merge.
- [ ] `gh workflow run release_jupyterlab.yml --ref main` — must end up with `0.2.7` on PyPI.
- [ ] `gh workflow run release_vscode.yml --ref main` and `gh workflow run release_streamlit.yml --ref main` — must succeed end-to-end this time and leave the existing `niivue@2.9.0` / `@niivue/streamlit@0.3.0` GitHub releases with their respective artifacts attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
