### PR TITLE
ci(coverage): tolerate fork-PR comment failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,14 +519,18 @@ jobs:
           commit_message: 'Publish coverage report to ${{ steps.target.outputs.dest }}'
 
       - name: Comment coverage summary on PR
-        # PRs from forks receive a read-only GITHUB_TOKEN regardless of the
-        # job's permissions block, so this step fails with "Resource not
-        # accessible by integration". Tolerate that — the coverage data is
-        # still uploaded as an artifact and (where possible) deployed to
-        # Pages, so we don't want to fail the whole job over a missing
-        # comment. Same rationale as the deploy step above.
-        if: github.event_name == 'pull_request' && hashFiles('coverage/summary.md') != ''
-        continue-on-error: true
+        # Skip on fork PRs: they receive a read-only GITHUB_TOKEN regardless
+        # of the job's permissions block, so this step would fail with
+        # "Resource not accessible by integration" and red-mark the job
+        # purely due to a permission limitation the contributor can't change.
+        # Coverage data is still uploaded as an artifact for fork PRs; only
+        # the sticky comment is skipped. Same-repo PRs continue to get it,
+        # and any real failure (action misconfig, API outage) still fails
+        # the job loudly.
+        if: |
+          github.event_name == 'pull_request'
+          && hashFiles('coverage/summary.md') != ''
+          && github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           path: coverage/summary.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,7 +519,14 @@ jobs:
           commit_message: 'Publish coverage report to ${{ steps.target.outputs.dest }}'
 
       - name: Comment coverage summary on PR
+        # PRs from forks receive a read-only GITHUB_TOKEN regardless of the
+        # job's permissions block, so this step fails with "Resource not
+        # accessible by integration". Tolerate that — the coverage data is
+        # still uploaded as an artifact and (where possible) deployed to
+        # Pages, so we don't want to fail the whole job over a missing
+        # comment. Same rationale as the deploy step above.
         if: github.event_name == 'pull_request' && hashFiles('coverage/summary.md') != ''
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           path: coverage/summary.md


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to the "Comment coverage summary on PR" step in `.github/workflows/ci.yml` so fork PRs (which receive a read-only `GITHUB_TOKEN`) don't fail the entire coverage job when the sticky-comment action errors with `Resource not accessible by integration`.
- Same rationale as the Pages deploy step right above (which already uses this pattern).
- Same-repo PRs continue to get the coverage comment posted normally; only fork-PR runs now silently skip the comment instead of red-marking the PR.

## Context

Fork PRs currently appear "failed" in the CI check rollup purely because of a permissions limitation outside the contributor's control — the coverage job runs fine, the data is uploaded as an artifact, but the final comment-posting step can't write to the upstream repo's issues API. Surfaced while reviewing #150.

## Test plan

- [ ] After merge, push to a fork-PR branch and confirm the `coverage` job shows green (with the comment step itself either skipped silently or marked yellow/info, depending on how GitHub renders `continue-on-error: true` outcomes).
- [ ] Push to a same-repo branch and confirm the sticky comment is still posted to the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)