### PR TITLE
ci: skip preview deploy on fork PRs, allow manual dispatch

### DIFF
--- a/.github/workflows/deploy_pwa_preview.yml
+++ b/.github/workflows/deploy_pwa_preview.yml
@@ -8,6 +8,14 @@ on:
       - 'apps/pwa/**'
       - 'packages/**'
       - '.github/workflows/deploy_pwa_preview.yml'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number (used for destination_dir pr-N and PR comment)'
+        required: true
+      ref:
+        description: 'Branch name or commit SHA to build'
+        required: true
 
 permissions:
   contents: write
@@ -15,15 +23,18 @@ permissions:
 
 # Allow only one deployment per PR at a time
 concurrency:
-  group: pwa-preview-${{ github.event.pull_request.number }}
+  group: pwa-preview-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   deploy-preview:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -40,7 +51,7 @@ jobs:
       - name: Build PWA with PR-specific base URL
         env:
           NODE_ENV: production
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: pnpm turbo build --filter=@niivue/pwa --force
 
       - name: Deploy to GitHub Pages (PR Preview)
@@ -48,17 +59,19 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./apps/pwa/build
-          destination_dir: pr-${{ github.event.pull_request.number }}
+          destination_dir: pr-${{ github.event.pull_request.number || inputs.pr_number }}
           keep_files: true
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
-          commit_message: 'Deploy PR #${{ github.event.pull_request.number }} preview'
+          commit_message: 'Deploy PR #${{ github.event.pull_request.number || inputs.pr_number }} preview'
 
       - name: Comment on PR with preview URL
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         with:
           script: |
-            const prNumber = context.payload.pull_request.number;
+            const prNumber = Number(process.env.PR_NUMBER);
             const previewUrl = `https://niivue.github.io/niivue-vscode/pr-${prNumber}/`;
             
             // Find existing preview comment


### PR DESCRIPTION
Forked-source PRs only get a read-scoped GITHUB_TOKEN, so the peaceiris/actions-gh-pages push fails with exit 128 and the deploy job turns red — even though nothing in the PR is wrong.

Mirror the gate pattern from #102 (Deploy PWA workflow):
- Add a job-level `if:` that short-circuits to `workflow_dispatch`, otherwise checks the PR head repo equals the workflow repo. Fork PRs are now skipped (gray), not failed.
- Add a `workflow_dispatch` trigger with `pr_number` + `ref` inputs so a maintainer can deploy a preview for a fork PR from the Actions tab after reviewing the code.
- Plumb the inputs through every site that read `github.event.pull_request.number` (concurrency group, build env, destination_dir, commit message, the github-script comment step).

https://claude.ai/code/session_01MZgGydjXWry6uru8UGNstP