### PR TITLE
ci(deps): add dependabot config with grouping and python ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,158 @@
+# Dependabot config for the niivue-vscode monorepo.
+# - npm at the repo root covers all pnpm workspaces (apps/*, packages/*) via the shared pnpm-lock.yaml
+# - Updates are grouped to avoid PR sprawl in a 4-app monorepo
+# - @niivue/niivue is intentionally pinned to ^0.68.x while the mono (1.x) migration is planned;
+#   ignore major bumps so they don't surface as auto-PRs
+
+version: 2
+
+updates:
+  # GitHub Actions used by the workflows in .github/workflows
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'ci'
+      include: 'scope'
+    labels:
+      - 'dependencies'
+      - 'github-actions'
+    groups:
+      actions:
+        patterns:
+          - '*'
+
+  # npm / pnpm workspaces — root pnpm-lock.yaml covers apps/* and packages/*
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 10
+    versioning-strategy: 'increase-if-necessary'
+    commit-message:
+      prefix: 'chore'
+      prefix-development: 'chore'
+      include: 'scope'
+    labels:
+      - 'dependencies'
+      - 'javascript'
+    ignore:
+      # @niivue/niivue 0.68.x → 1.x is a deliberate, planned migration (mono rewrite).
+      # Bump manually; don't open auto-PRs for major bumps in the meantime.
+      - dependency-name: '@niivue/niivue'
+        update-types:
+          - 'version-update:semver-major'
+    groups:
+      # Type definitions — almost always safe to batch
+      types:
+        patterns:
+          - '@types/*'
+      # ESLint + linting stack
+      eslint:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@eslint/*'
+          - '@typescript-eslint/*'
+          - 'typescript-eslint'
+      # Vitest unit tests
+      vitest:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
+      # Playwright E2E
+      playwright:
+        patterns:
+          - 'playwright'
+          - '@playwright/*'
+      # Vite + plugins
+      vite:
+        patterns:
+          - 'vite'
+          - '@vitejs/*'
+          - 'vite-plugin-*'
+          - 'vite-tsconfig-paths'
+      # Turborepo
+      turbo:
+        patterns:
+          - 'turbo'
+          - '@turbo/*'
+      # JupyterLab extension framework (apps/jupyter)
+      jupyterlab:
+        patterns:
+          - '@jupyterlab/*'
+          - '@jupyter/*'
+          - '@lumino/*'
+      # React/Preact stack
+      react-preact:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - 'preact'
+          - '@preact/*'
+          - 'react-*'
+      # Tailwind + PostCSS
+      tailwind:
+        patterns:
+          - 'tailwindcss'
+          - 'tailwindcss-*'
+          - '@tailwindcss/*'
+          - 'postcss'
+          - 'postcss-*'
+          - 'autoprefixer'
+      # Prettier + format tooling
+      prettier:
+        patterns:
+          - 'prettier'
+          - 'prettier-*'
+          - 'eslint-config-prettier'
+      # esbuild (used by apps/vscode)
+      esbuild:
+        patterns:
+          - 'esbuild'
+          - 'esbuild-*'
+          - '@esbuild/*'
+      # Changesets
+      changesets:
+        patterns:
+          - '@changesets/*'
+
+  # Python — Streamlit component (published to PyPI as niivue-streamlit)
+  - package-ecosystem: 'pip'
+    directory: '/apps/streamlit'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    labels:
+      - 'dependencies'
+      - 'python'
+    groups:
+      streamlit-python:
+        patterns:
+          - '*'
+
+  # Python — JupyterLab extension (published to PyPI as jupyterlab_niivue)
+  - package-ecosystem: 'pip'
+    directory: '/apps/jupyter'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    labels:
+      - 'dependencies'
+      - 'python'
+    groups:
+      jupyter-python:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,14 +51,23 @@ updates:
       types:
         patterns:
           - '@types/*'
-      # ESLint + linting stack
+      # Prettier + format tooling — must be declared BEFORE the eslint group
+      # so that eslint-config-prettier / eslint-plugin-prettier match here
+      # (Dependabot assigns each dep to its first matching group).
+      prettier:
+        patterns:
+          - 'prettier'
+          - 'prettier-*'
+          - 'eslint-config-prettier'
+          - 'eslint-plugin-prettier'
+      # ESLint + linting stack (eslint-plugin-prettier already grabbed above)
       eslint:
         patterns:
           - 'eslint'
-          - 'eslint-*'
           - '@eslint/*'
           - '@typescript-eslint/*'
           - 'typescript-eslint'
+          - 'eslint-plugin-*'
       # Vitest unit tests
       vitest:
         patterns:
@@ -87,14 +96,15 @@ updates:
           - '@jupyterlab/*'
           - '@jupyter/*'
           - '@lumino/*'
-      # React/Preact stack
+      # React/Preact core only. Intentionally NOT using `react-*` so that
+      # unrelated React-ecosystem packages (e.g. react-router-dom v7) get
+      # their own ungrouped PRs and aren't bundled with a core React bump.
       react-preact:
         patterns:
           - 'react'
           - 'react-dom'
           - 'preact'
           - '@preact/*'
-          - 'react-*'
       # Tailwind + PostCSS
       tailwind:
         patterns:
@@ -104,12 +114,6 @@ updates:
           - 'postcss'
           - 'postcss-*'
           - 'autoprefixer'
-      # Prettier + format tooling
-      prettier:
-        patterns:
-          - 'prettier'
-          - 'prettier-*'
-          - 'eslint-config-prettier'
       # esbuild (used by apps/vscode)
       esbuild:
         patterns:


### PR DESCRIPTION
## Summary

Adds a real `.github/dependabot.yml` so Dependabot starts watching this repo. Tuned for a 4-app pnpm monorepo so we don't get drowned in per-package update PRs.

GitHub's vulnerability scanner currently reports **66 open advisories** on `main` (1 critical / 37 high / 24 moderate / 4 low). Turning on Dependabot is the cheapest first step toward burning that down.

### What's covered

- **npm at `/`** — one entry covers all pnpm workspaces (`apps/*`, `packages/*`) via the shared `pnpm-lock.yaml`.
- **GitHub Actions** — weekly, grouped.
- **pip at `apps/streamlit` and `apps/jupyter`** — both ship to PyPI, mostly for security-advisory visibility.

### Grouping (the main reason this isn't the default config)

npm bumps are grouped so a typical Monday produces ~one PR per group instead of dozens:

| Group | Examples |
|---|---|
| `types` | `@types/*` |
| `eslint` | `eslint`, `@typescript-eslint/*`, `eslint-plugin-*` |
| `vitest` | `vitest`, `@vitest/*` |
| `playwright` | `playwright`, `@playwright/*` |
| `vite` | `vite`, `@vitejs/*`, `vite-plugin-*` |
| `turbo` | `turbo`, `@turbo/*` |
| `jupyterlab` | `@jupyterlab/*`, `@jupyter/*`, `@lumino/*` |
| `react-preact` | `react`, `react-dom`, `preact`, `@preact/*` |
| `tailwind` | `tailwindcss`, `postcss`, `autoprefixer` |
| `prettier` | `prettier`, `eslint-config-prettier` |
| `esbuild` | `esbuild`, `@esbuild/*` |
| `changesets` | `@changesets/*` |

Anything not in a group still gets its own PR — that's intentional for high-risk individual deps.

### Ignore: `@niivue/niivue` majors

`@niivue/niivue ^0.68.0` is intentionally pinned. The 0.68.x → 1.x bump is a planned migration to the mono rewrite (different API, non-trivial) and will be done manually. The ignore rule keeps Dependabot from opening an auto-PR every time mono ships a new `1.0.0-rc.x`.

Minor and patch bumps within 0.68.x are still tracked.

### Commit-message convention

- npm/pip → `chore(deps): bump …`
- github-actions → `ci(deps): bump …`

Matches the existing `chore(release)`, `ci(coverage)`, `fix(vscode)` style in the repo history.

### Open-PR limits

- npm: 10 (groups + un-grouped together)
- actions: 5
- each pip: 3

## Test plan

- [ ] Merge to `main` and confirm the first Dependabot run picks up the config (check `https://github.com/niivue/niivue-vscode/network/updates` after merge).
- [ ] First Monday after merge: verify PRs land grouped and tagged with the `dependencies` label.
- [ ] Spot-check that `@niivue/niivue` doesn't get a 1.0.0-rc PR.

## Follow-ups (not in this PR)

- Once Dependabot starts producing PRs, decide whether to add `reviewers: [korbinian90]` so they auto-assign.
- The 66 existing GitHub Security advisories should be triaged separately — Dependabot will only address ones that map to npm/pip/actions versions; some may be transitive and need overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)