### PR TITLE
ci: split PWA preview + coverage report into trusted/untrusted workflows

### DIFF
--- a/.github/workflows/build_pwa_preview.yml
+++ b/.github/workflows/build_pwa_preview.yml
@@ -1,0 +1,117 @@
+# Builds the PWA from a PR head and uploads the result as an artifact for
+# the trusted "Deploy PWA Preview" workflow to consume.
+#
+# Trust posture: UNTRUSTED.
+#   - `pull_request` runs PR-author code (postinstall scripts, build scripts).
+#   - We hold only `contents: read` and disable credential persistence so the
+#     job has nothing valuable to leak. Fork PRs also have repository secrets
+#     stripped by GitHub automatically.
+#
+# Manual dispatch path: a maintainer can trigger this for a fork PR by clicking
+# Actions → "Build PWA Preview" → Run workflow → entering the PR number. The
+# manual run is treated as trusted (it built what the maintainer asked for),
+# so the downstream deploy auto-fires.
+
+name: Build PWA Preview
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/pwa/**'
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/build_pwa_preview.yml'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to build a preview for (used for fork PRs that don''t auto-deploy)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-pwa-preview-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Manual-dispatch path: resolve which PR head we should check out. The
+      # pr_number input goes through env (never directly into a shell command)
+      # and is validated as digits before any use.
+      - name: Resolve PR head (manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr_number must be digits, got '$PR_NUMBER'"
+            exit 1
+          fi
+          info=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json headRepositoryOwner,headRepository,headRefOid)
+          repo=$(echo "$info" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')
+          ref=$(echo "$info" | jq -r '.headRefOid')
+          {
+            echo "repo=$repo"
+            echo "ref=$ref"
+            echo "number=$PR_NUMBER"
+          } >> "$GITHUB_OUTPUT"
+
+      # pull_request: default checkout uses the PR merge ref (refs/pull/N/merge)
+      # which is what reviewers see in the GitHub diff. Repository is implicit.
+      - name: Checkout PR merge ref (pull_request)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # workflow_dispatch: explicit head OID resolved from the PR. For fork PRs
+      # this checks out the fork repo at the PR's head commit.
+      - name: Checkout PR head (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.pr.outputs.repo }}
+          ref: ${{ steps.pr.outputs.ref }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build PWA
+        env:
+          NODE_ENV: production
+          PR_NUMBER: ${{ steps.pr.outputs.number || github.event.pull_request.number }}
+        run: pnpm turbo build --filter=@niivue/pwa --force
+
+      # Embed PR number alongside the build so the deploy workflow can resolve
+      # which PR this artifact belongs to without trusting workflow_run.pull_requests
+      # (which is empty for fork PRs).
+      - name: Embed PR number in build directory
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number || github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > apps/pwa/build/.pr_number
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pwa-preview
+          path: apps/pwa/build
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/build_pwa_preview.yml
+++ b/.github/workflows/build_pwa_preview.yml
@@ -100,13 +100,29 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number || github.event.pull_request.number }}
         run: pnpm turbo build --filter=@niivue/pwa --force
 
-      # Embed PR number alongside the build so the deploy workflow can resolve
-      # which PR this artifact belongs to without trusting workflow_run.pull_requests
-      # (which is empty for fork PRs).
-      - name: Embed PR number in build directory
+      # Embed PR number AND the actual PR head SHA being built alongside the
+      # build. The deploy workflow uses these as the source of truth instead
+      # of inferring from workflow_run.head_sha (which is the merge SHA for
+      # pull_request events and the dispatch-branch SHA for workflow_dispatch
+      # — both wrong for the deploy gate).
+      - name: Embed build metadata in build directory
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number || github.event.pull_request.number }}
-        run: echo "$PR_NUMBER" > apps/pwa/build/.pr_number
+          PR_HEAD_SHA: ${{ steps.pr.outputs.ref || github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::invalid PR_NUMBER '$PR_NUMBER'"; exit 1
+          fi
+          if ! [[ "$PR_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::invalid PR_HEAD_SHA '$PR_HEAD_SHA'"; exit 1
+          fi
+          cat > apps/pwa/build/.build_meta.json <<EOF
+          {
+            "pr_number": $PR_NUMBER,
+            "pr_head_sha": "$PR_HEAD_SHA"
+          }
+          EOF
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,11 @@ jobs:
           DEST: ${{ steps.target.outputs.dest }}
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Explicit PR head SHA the build was for. Carried in the artifact so
+          # the downstream Coverage Report workflow can validate without
+          # inferring from workflow_run.head_sha (which is the merge SHA for
+          # pull_request, and the dispatch-branch SHA for workflow_dispatch).
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           mkdir -p coverage/publish
@@ -514,14 +519,17 @@ jobs:
           # distinguish "no PR" from "invalid input".
           if [ -n "${PR_NUMBER}" ]; then
             pr_json="$PR_NUMBER"
+            sha_json="\"${PR_HEAD_SHA}\""
           else
             pr_json="null"
+            sha_json="null"
           fi
           cat > coverage/publish/.coverage_meta.json <<EOF
           {
             "event": "${EVENT_NAME}",
             "dest": "${DEST}",
-            "pr_number": ${pr_json}
+            "pr_number": ${pr_json},
+            "pr_head_sha": ${sha_json}
           }
           EOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,15 +380,18 @@ jobs:
           retention-days: 1
 
   coverage:
+    # Aggregates per-package coverage and uploads the publishable directory as
+    # an artifact. The actual gh-pages deploy + PR comment happen in the
+    # "Coverage Report" workflow (triggered by workflow_run of this CI run),
+    # which is the only place that holds write permissions. This split keeps
+    # the trust boundary clean: this job runs after PR code has executed in
+    # the upstream test jobs and must not have any write access.
     needs: [test-pwa, test-jupyter, test-vscode, test-streamlit, e2e-tests]
     if: |
       always() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -494,43 +497,38 @@ jobs:
         # docs-only commits where all test jobs were skipped) — skip staging
         # rather than failing on missing files.
         if: hashFiles('coverage/merged/index.html') != ''
+        env:
+          DEST: ${{ steps.target.outputs.dest }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
           mkdir -p coverage/publish
           # Flatten merged/index.html to publish/ root so the deploy URL serves it directly
           cp coverage/merged/index.html coverage/publish/index.html
           cp coverage/badge.json coverage/publish/
           cp coverage/summary.json coverage/publish/
           cp coverage/summary.md coverage/publish/
+          # Metadata file consumed by the Coverage Report workflow. PR_NUMBER
+          # may be empty (push to main) — emit null in that case so jq can
+          # distinguish "no PR" from "invalid input".
+          if [ -n "${PR_NUMBER}" ]; then
+            pr_json="$PR_NUMBER"
+          else
+            pr_json="null"
+          fi
+          cat > coverage/publish/.coverage_meta.json <<EOF
+          {
+            "event": "${EVENT_NAME}",
+            "dest": "${DEST}",
+            "pr_number": ${pr_json}
+          }
+          EOF
 
-      - name: Deploy coverage report to GitHub Pages
-        if: (github.event_name == 'pull_request' || github.ref == 'refs/heads/main') && hashFiles('coverage/publish/index.html') != ''
-        # Tolerate failures only on PRs (fork PRs have a read-only GITHUB_TOKEN
-        # and will fail the deploy — we still want the sticky comment to post).
-        # On main, a failed deploy means a stale badge, so we fail the build.
-        continue-on-error: ${{ github.event_name == 'pull_request' }}
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload publishable coverage artifact
+        if: hashFiles('coverage/publish/index.html') != ''
+        uses: actions/upload-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./coverage/publish
-          destination_dir: ${{ steps.target.outputs.dest }}
-          keep_files: true
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
-          commit_message: 'Publish coverage report to ${{ steps.target.outputs.dest }}'
-
-      - name: Comment coverage summary on PR
-        # Skip on fork PRs: they receive a read-only GITHUB_TOKEN regardless
-        # of the job's permissions block, so this step would fail with
-        # "Resource not accessible by integration" and red-mark the job
-        # purely due to a permission limitation the contributor can't change.
-        # Coverage data is still uploaded as an artifact for fork PRs; only
-        # the sticky comment is skipped. Same-repo PRs continue to get it,
-        # and any real failure (action misconfig, API outage) still fails
-        # the job loudly.
-        if: |
-          github.event_name == 'pull_request'
-          && hashFiles('coverage/summary.md') != ''
-          && github.event.pull_request.head.repo.full_name == github.repository
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          path: coverage/summary.md
+          name: coverage-publish
+          path: coverage/publish/
+          retention-days: 7

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -1,0 +1,188 @@
+# Publishes the aggregated coverage report produced by the CI workflow.
+#
+# Trust posture: TRUSTED.
+#   - Triggered by workflow_run (always runs the default-branch version of
+#     this file) or by maintainer workflow_dispatch.
+#   - Never runs PR code. Only consumes the coverage-publish artifact CI
+#     uploaded (a static directory of HTML + JSON files) and deploys it.
+#
+# Fork-PR policy:
+#   - Same-repo PR / push to main: auto-fires after CI succeeds.
+#   - Fork PR: skipped on the workflow_run path. A maintainer can manually
+#     dispatch this workflow with the PR number to publish the report after
+#     reviewing the diff.
+
+name: Coverage Report
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number (for fork PRs that did not auto-deploy)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: write
+  actions: read
+
+# Serialize gh-pages mutations so concurrent pushes don't collide.
+concurrency:
+  group: gh-pages-mutation
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    # workflow_run path: only auto-publish for trusted triggers. Fork PRs get
+    # skipped here; the maintainer can republish via workflow_dispatch.
+    # workflow_dispatch path: always allowed (only maintainers can dispatch).
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       (github.event.workflow_run.event == 'workflow_dispatch' ||
+        github.event.workflow_run.event == 'push' ||
+        (github.event.workflow_run.event == 'pull_request' &&
+         github.event.workflow_run.head_repository.full_name == github.repository)))
+    runs-on: ubuntu-latest
+    steps:
+      # workflow_dispatch path: maintainer entered a PR number. Find the most
+      # recent successful CI run for that PR and use its artifact.
+      - name: Resolve CI run for manual dispatch
+        if: github.event_name == 'workflow_dispatch'
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr_number must be digits, got '$PR_NUMBER'"
+            exit 1
+          fi
+          head_branch=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json headRefName --jq '.headRefName')
+          run_id=$(gh run list --repo "${{ github.repository }}" \
+            --workflow=CI --branch="$head_branch" --status=success \
+            --limit 1 --json databaseId --jq '.[0].databaseId')
+          if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+            echo "::error::no successful CI run found for PR #$PR_NUMBER (branch=$head_branch)"
+            exit 1
+          fi
+          head_sha=$(gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json headRefOid --jq '.headRefOid')
+          {
+            echo "run_id=$run_id"
+            echo "head_sha=$head_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download coverage-publish artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-publish
+          path: coverage-publish
+          run-id: ${{ steps.dispatch.outputs.run_id || github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Read and validate the metadata CI embedded in the artifact. For PR
+      # builds, cross-check that the PR's current head SHA matches the run's
+      # head SHA so a stale or forged artifact can't be re-deployed.
+      - name: Read coverage metadata
+        id: meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          meta_file=coverage-publish/.coverage_meta.json
+          if [ ! -f "$meta_file" ]; then
+            echo "::error::artifact missing .coverage_meta.json"
+            exit 1
+          fi
+          event=$(jq -r '.event' "$meta_file")
+          dest=$(jq -r '.dest' "$meta_file")
+          pr_number=$(jq -r '.pr_number // ""' "$meta_file")
+
+          # Validate dest path: only allow coverage/main or coverage/pr-N
+          if ! [[ "$dest" =~ ^coverage/(main|pr-[0-9]+)$ ]]; then
+            echo "::error::invalid dest path '$dest'"
+            exit 1
+          fi
+
+          # PR-context validation
+          if [ -n "$pr_number" ] && [ "$pr_number" != "null" ]; then
+            if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+              echo "::error::invalid pr_number '$pr_number'"
+              exit 1
+            fi
+            api_sha=$(gh api "repos/${{ github.repository }}/pulls/$pr_number" --jq '.head.sha' 2>/dev/null || echo "")
+            build_sha="${{ steps.dispatch.outputs.head_sha || github.event.workflow_run.head_sha }}"
+            if [ -z "$api_sha" ]; then
+              echo "::warning::could not resolve PR #$pr_number; skipping deploy"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            elif [ "$api_sha" != "$build_sha" ]; then
+              echo "::warning::PR #$pr_number head ($api_sha) does not match build head ($build_sha); skipping"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            # No PR number = push to main path. No PR to comment on.
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo "event=$event"
+            echo "dest=$dest"
+            echo "pr_number=$pr_number"
+          } >> "$GITHUB_OUTPUT"
+          rm -f "$meta_file"
+
+      - name: Deploy coverage report to gh-pages
+        if: steps.meta.outputs.skip != 'true'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./coverage-publish
+          destination_dir: ${{ steps.meta.outputs.dest }}
+          keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Publish coverage report to ${{ steps.meta.outputs.dest }}'
+
+      - name: Comment coverage summary on PR
+        if: |
+          steps.meta.outputs.skip != 'true' &&
+          steps.meta.outputs.pr_number != '' &&
+          steps.meta.outputs.pr_number != 'null'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.meta.outputs.pr_number }}
+          path: coverage-publish/summary.md
+
+      - name: Surface coverage status on PR head commit
+        if: |
+          steps.meta.outputs.skip != 'true' &&
+          steps.meta.outputs.pr_number != '' &&
+          steps.meta.outputs.pr_number != 'null'
+        uses: actions/github-script@v7
+        env:
+          DEST: ${{ steps.meta.outputs.dest }}
+          HEAD_SHA: ${{ steps.dispatch.outputs.head_sha || github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const url = `https://niivue.github.io/niivue-vscode/${process.env.DEST}/`;
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.HEAD_SHA,
+              state: 'success',
+              context: 'coverage-report',
+              target_url: url,
+              description: 'Coverage report published',
+            });

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -50,8 +50,12 @@ jobs:
          github.event.workflow_run.head_repository.full_name == github.repository)))
     runs-on: ubuntu-latest
     steps:
-      # workflow_dispatch path: maintainer entered a PR number. Find the most
-      # recent successful CI run for that PR and use its artifact.
+      # workflow_dispatch path: maintainer entered a PR number. Resolve the
+      # PR's head SHA, then ask the API for the most recent successful CI
+      # workflow run whose head_sha matches. Filtering by SHA (not branch
+      # name) avoids the cross-fork branch-name collision problem: two fork
+      # PRs called "feature/foo" have different SHAs, so we always pick the
+      # right run.
       - name: Resolve CI run for manual dispatch
         if: github.event_name == 'workflow_dispatch'
         id: dispatch
@@ -64,19 +68,21 @@ jobs:
             echo "::error::pr_number must be digits, got '$PR_NUMBER'"
             exit 1
           fi
-          head_branch=$(gh pr view "$PR_NUMBER" \
-            --repo "${{ github.repository }}" \
-            --json headRefName --jq '.headRefName')
-          run_id=$(gh run list --repo "${{ github.repository }}" \
-            --workflow=CI --branch="$head_branch" --status=success \
-            --limit 1 --json databaseId --jq '.[0].databaseId')
-          if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
-            echo "::error::no successful CI run found for PR #$PR_NUMBER (branch=$head_branch)"
-            exit 1
-          fi
           head_sha=$(gh pr view "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
             --json headRefOid --jq '.headRefOid')
+          if ! [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::could not resolve head SHA for PR #$PR_NUMBER"
+            exit 1
+          fi
+          runs=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?per_page=50&status=success&head_sha=$head_sha")
+          run_id=$(echo "$runs" | jq -r '.workflow_runs[0].id // empty')
+          if [ -z "$run_id" ]; then
+            echo "::error::no successful CI run found for PR #$PR_NUMBER at head $head_sha"
+            echo "    Push a new commit or re-run CI on the PR, then retry."
+            exit 1
+          fi
           {
             echo "run_id=$run_id"
             echo "head_sha=$head_sha"
@@ -90,9 +96,11 @@ jobs:
           run-id: ${{ steps.dispatch.outputs.run_id || github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Read and validate the metadata CI embedded in the artifact. For PR
-      # builds, cross-check that the PR's current head SHA matches the run's
-      # head SHA so a stale or forged artifact can't be re-deployed.
+      # Read and validate the metadata CI embedded in the artifact. The
+      # artifact contains the explicit PR head SHA the build was for; cross-
+      # check that against the PR's current head SHA via the API. Mismatch
+      # means a new commit was pushed (stale artifact) or the artifact was
+      # forged — skip either way.
       - name: Read coverage metadata
         id: meta
         env:
@@ -107,6 +115,7 @@ jobs:
           event=$(jq -r '.event' "$meta_file")
           dest=$(jq -r '.dest' "$meta_file")
           pr_number=$(jq -r '.pr_number // ""' "$meta_file")
+          pr_head_sha=$(jq -r '.pr_head_sha // ""' "$meta_file")
 
           # Validate dest path: only allow coverage/main or coverage/pr-N
           if ! [[ "$dest" =~ ^coverage/(main|pr-[0-9]+)$ ]]; then
@@ -120,13 +129,16 @@ jobs:
               echo "::error::invalid pr_number '$pr_number'"
               exit 1
             fi
+            if ! [[ "$pr_head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::invalid pr_head_sha '$pr_head_sha' for PR build"
+              exit 1
+            fi
             api_sha=$(gh api "repos/${{ github.repository }}/pulls/$pr_number" --jq '.head.sha' 2>/dev/null || echo "")
-            build_sha="${{ steps.dispatch.outputs.head_sha || github.event.workflow_run.head_sha }}"
             if [ -z "$api_sha" ]; then
               echo "::warning::could not resolve PR #$pr_number; skipping deploy"
               echo "skip=true" >> "$GITHUB_OUTPUT"
-            elif [ "$api_sha" != "$build_sha" ]; then
-              echo "::warning::PR #$pr_number head ($api_sha) does not match build head ($build_sha); skipping"
+            elif [ "$api_sha" != "$pr_head_sha" ]; then
+              echo "::warning::PR #$pr_number current head ($api_sha) does not match artifact head ($pr_head_sha) — stale or forged, skipping"
               echo "skip=true" >> "$GITHUB_OUTPUT"
             else
               echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -140,6 +152,7 @@ jobs:
             echo "event=$event"
             echo "dest=$dest"
             echo "pr_number=$pr_number"
+            echo "head_sha=$pr_head_sha"
           } >> "$GITHUB_OUTPUT"
           rm -f "$meta_file"
 
@@ -173,7 +186,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           DEST: ${{ steps.meta.outputs.dest }}
-          HEAD_SHA: ${{ steps.dispatch.outputs.head_sha || github.event.workflow_run.head_sha }}
+          HEAD_SHA: ${{ steps.meta.outputs.head_sha }}
         with:
           script: |
             const url = `https://niivue.github.io/niivue-vscode/${process.env.DEST}/`;

--- a/.github/workflows/deploy_pwa_preview.yml
+++ b/.github/workflows/deploy_pwa_preview.yml
@@ -1,114 +1,147 @@
-# Workflow for deploying PWA previews to GitHub Pages for PRs
+# Deploys the artifact produced by "Build PWA Preview" to the gh-pages branch
+# and comments the preview URL on the PR.
+#
+# Trust posture: TRUSTED.
+#   - Triggered by workflow_run, which always runs the default-branch version
+#     of this file. Attackers cannot modify this workflow through a PR.
+#   - Never runs PR code: only downloads a pre-built artifact (static files)
+#     and a validated PR number, then deploys via official actions.
+#   - For fork PRs (event=pull_request, head_repository != github.repository)
+#     this skips auto-deploy. A maintainer triggers Build PWA Preview manually
+#     for fork PRs; the resulting workflow_run event = workflow_dispatch and
+#     this workflow deploys normally.
+
 name: Deploy PWA Preview
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'apps/pwa/**'
-      - 'packages/**'
-      - '.github/workflows/deploy_pwa_preview.yml'
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'PR number (used for destination_dir pr-N and PR comment)'
-        required: true
-      ref:
-        description: 'Branch name or commit SHA to build'
-        required: true
+  workflow_run:
+    workflows: ['Build PWA Preview']
+    types: [completed]
 
 permissions:
   contents: write
   pull-requests: write
+  statuses: write
+  actions: read
 
-# Allow only one deployment per PR at a time
+# Serialize gh-pages mutations across all preview/cleanup workflows so concurrent
+# pushes don't fail with non-fast-forward errors. Matches the group used by
+# cleanup_pwa_preview.yml and cleanup_coverage_preview.yml.
 concurrency:
-  group: pwa-preview-${{ github.event.pull_request.number || inputs.pr_number }}
-  cancel-in-progress: true
+  group: gh-pages-mutation
+  cancel-in-progress: false
 
 jobs:
-  deploy-preview:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+  deploy:
+    # Conditions:
+    #  - upstream build must have succeeded
+    #  - allow workflow_dispatch (maintainer triggered) and same-repo pull_request
+    #  - block fork pull_request: maintainer must manually dispatch Build PWA Preview
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event == 'workflow_dispatch' ||
+       (github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.head_repository.full_name == github.repository))
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          ref: ${{ inputs.ref || github.event.pull_request.head.sha }}
+          name: pwa-preview
+          path: pwa-preview
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build PWA with PR-specific base URL
+      # The artifact came from a job that ran PR code, so the embedded PR
+      # number is untrusted input. Validate as digits, then cross-check against
+      # GitHub: the resolved PR's current head SHA must equal the build run's
+      # head_sha. This blocks "swap artifact, then re-trigger deploy" attempts.
+      - name: Read and validate PR number
+        id: pr
         env:
-          NODE_ENV: production
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-        run: pnpm turbo build --filter=@niivue/pwa --force
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          raw=$(head -c 10 pwa-preview/.pr_number 2>/dev/null | tr -cd '0-9')
+          if [ -z "$raw" ]; then
+            echo "::error::artifact missing or invalid .pr_number"
+            exit 1
+          fi
+          api_sha=$(gh api "repos/${{ github.repository }}/pulls/$raw" --jq '.head.sha' 2>/dev/null || echo "")
+          build_sha="${{ github.event.workflow_run.head_sha }}"
+          if [ -z "$api_sha" ]; then
+            echo "::warning::could not resolve PR #$raw via API; skipping deploy"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif [ "$api_sha" != "$build_sha" ]; then
+            echo "::warning::PR #$raw head ($api_sha) does not match build head ($build_sha); skipping deploy"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "number=$raw" >> "$GITHUB_OUTPUT"
+          rm -f pwa-preview/.pr_number
 
-      - name: Deploy to GitHub Pages (PR Preview)
+      - name: Deploy to gh-pages
+        if: steps.pr.outputs.skip != 'true'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./apps/pwa/build
-          destination_dir: pr-${{ github.event.pull_request.number || inputs.pr_number }}
+          publish_dir: ./pwa-preview
+          destination_dir: pr-${{ steps.pr.outputs.number }}
           keep_files: true
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
-          commit_message: 'Deploy PR #${{ github.event.pull_request.number || inputs.pr_number }} preview'
+          commit_message: 'Deploy PR #${{ steps.pr.outputs.number }} preview'
 
-      - name: Comment on PR with preview URL
+      - name: Comment preview URL on PR
+        if: steps.pr.outputs.skip != 'true'
         uses: actions/github-script@v7
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
             const prNumber = Number(process.env.PR_NUMBER);
-            const previewUrl = `https://niivue.github.io/niivue-vscode/pr-${prNumber}/`;
-            
-            // Find existing preview comment
-            const comments = await github.rest.issues.listComments({
+            const url = `https://niivue.github.io/niivue-vscode/pr-${prNumber}/`;
+            const marker = '<!-- pwa-preview-comment -->';
+            const body = `${marker}\n## 🚀 PWA Preview Deployment\n\nYour PWA preview has been deployed!\n\n**Preview URL:** ${url}\n\n---\n<sub>This preview will be updated automatically when you push new commits to this PR.</sub>`;
+            const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
             });
-            
-            const previewComment = comments.data.find(comment => 
-              comment.user.type === 'Bot' && 
-              comment.body.includes('PWA Preview Deployment')
-            );
-            
-            const body = `## 🚀 PWA Preview Deployment
-            
-            Your PWA preview has been deployed!
-            
-            **Preview URL:** ${previewUrl}
-            
-            ---
-            <sub>This preview will be updated automatically when you push new commits to this PR.</sub>`;
-            
-            if (previewComment) {
-              // Update existing comment
+            const existing = comments.find(c => c.body?.includes(marker));
+            if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                comment_id: previewComment.id,
-                body: body
+                comment_id: existing.id,
+                body,
               });
             } else {
-              // Create new comment
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
-                body: body
+                body,
               });
             }
+
+      # Reviewers need a check on the PR's checks tab that links to the preview.
+      # workflow_run workflows don't appear there by default, so we publish a
+      # commit status on the PR head SHA.
+      - name: Surface preview status on PR head commit
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.workflow_run.head_sha,
+              state: 'success',
+              context: 'pwa-preview',
+              target_url: `https://niivue.github.io/niivue-vscode/pr-${process.env.PR_NUMBER}/`,
+              description: 'Preview deployed',
+            });

--- a/.github/workflows/deploy_pwa_preview.yml
+++ b/.github/workflows/deploy_pwa_preview.yml
@@ -52,52 +52,63 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # The artifact came from a job that ran PR code, so the embedded PR
-      # number is untrusted input. Validate as digits, then cross-check against
-      # GitHub: the resolved PR's current head SHA must equal the build run's
-      # head_sha. This blocks "swap artifact, then re-trigger deploy" attempts.
-      - name: Read and validate PR number
-        id: pr
+      # The artifact came from a job that ran PR code, so the embedded values
+      # are untrusted. Validate format, then cross-check: the PR head SHA the
+      # build recorded must equal the PR's current head SHA. If they differ,
+      # either a new commit was pushed (artifact is stale) or the artifact
+      # was swapped — skip the deploy either way.
+      - name: Read and validate build metadata
+        id: meta
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          raw=$(head -c 10 pwa-preview/.pr_number 2>/dev/null | tr -cd '0-9')
-          if [ -z "$raw" ]; then
-            echo "::error::artifact missing or invalid .pr_number"
+          meta=pwa-preview/.build_meta.json
+          if [ ! -f "$meta" ]; then
+            echo "::error::artifact missing .build_meta.json"
             exit 1
           fi
-          api_sha=$(gh api "repos/${{ github.repository }}/pulls/$raw" --jq '.head.sha' 2>/dev/null || echo "")
-          build_sha="${{ github.event.workflow_run.head_sha }}"
+          pr_number=$(jq -r '.pr_number' "$meta")
+          pr_head_sha=$(jq -r '.pr_head_sha' "$meta")
+          if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "::error::invalid pr_number '$pr_number'"; exit 1
+          fi
+          if ! [[ "$pr_head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::invalid pr_head_sha '$pr_head_sha'"; exit 1
+          fi
+          api_sha=$(gh api "repos/${{ github.repository }}/pulls/$pr_number" --jq '.head.sha' 2>/dev/null || echo "")
           if [ -z "$api_sha" ]; then
-            echo "::warning::could not resolve PR #$raw via API; skipping deploy"
+            echo "::warning::could not resolve PR #$pr_number via API; skipping deploy"
             echo "skip=true" >> "$GITHUB_OUTPUT"
-          elif [ "$api_sha" != "$build_sha" ]; then
-            echo "::warning::PR #$raw head ($api_sha) does not match build head ($build_sha); skipping deploy"
+          elif [ "$api_sha" != "$pr_head_sha" ]; then
+            echo "::warning::PR #$pr_number current head ($api_sha) does not match artifact head ($pr_head_sha) — artifact is stale or forged, skipping deploy"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "number=$raw" >> "$GITHUB_OUTPUT"
-          rm -f pwa-preview/.pr_number
+          {
+            echo "number=$pr_number"
+            echo "head_sha=$pr_head_sha"
+          } >> "$GITHUB_OUTPUT"
+          rm -f "$meta"
 
       - name: Deploy to gh-pages
-        if: steps.pr.outputs.skip != 'true'
+        if: steps.meta.outputs.skip != 'true'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./pwa-preview
-          destination_dir: pr-${{ steps.pr.outputs.number }}
+          destination_dir: pr-${{ steps.meta.outputs.number }}
           keep_files: true
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
-          commit_message: 'Deploy PR #${{ steps.pr.outputs.number }} preview'
+          commit_message: 'Deploy PR #${{ steps.meta.outputs.number }} preview'
 
       - name: Comment preview URL on PR
-        if: steps.pr.outputs.skip != 'true'
+        if: steps.meta.outputs.skip != 'true'
         uses: actions/github-script@v7
         env:
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_NUMBER: ${{ steps.meta.outputs.number }}
         with:
           script: |
             const prNumber = Number(process.env.PR_NUMBER);
@@ -130,16 +141,17 @@ jobs:
       # workflow_run workflows don't appear there by default, so we publish a
       # commit status on the PR head SHA.
       - name: Surface preview status on PR head commit
-        if: steps.pr.outputs.skip != 'true'
+        if: steps.meta.outputs.skip != 'true'
         uses: actions/github-script@v7
         env:
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_NUMBER: ${{ steps.meta.outputs.number }}
+          HEAD_SHA: ${{ steps.meta.outputs.head_sha }}
         with:
           script: |
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: context.payload.workflow_run.head_sha,
+              sha: process.env.HEAD_SHA,
               state: 'success',
               context: 'pwa-preview',
               target_url: `https://niivue.github.io/niivue-vscode/pr-${process.env.PR_NUMBER}/`,


### PR DESCRIPTION
## Summary

Adopt the canonical two-workflow pattern from [GitHub Security Lab's "Preventing pwn requests"](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) for both the **PWA preview** and the **coverage report**. The unsafe half (runs PR code) and the trusted half (holds write tokens) are now separate workflows joined only by a static artifact — neither holds both privileges and untrusted code at the same time.

## What changes

### PWA preview

| Before | After |
|---|---|
| `deploy_pwa_preview.yml` — single workflow, `pull_request` trigger, holds `contents: write` + `pull-requests: write`, checks out PR code (with same-repo gate added in #168 as a workaround). | `build_pwa_preview.yml` — only `contents: read`, builds PR code, uploads `pwa-preview` artifact. <br>`deploy_pwa_preview.yml` — rewritten to `workflow_run` trigger; downloads the artifact, deploys to gh-pages, comments, surfaces a commit status. Never checks out PR code. |

### Coverage report

| Before | After |
|---|---|
| `ci.yml` `coverage` job: holds `contents: write` + `pull-requests: write`, deploys gh-pages + posts sticky comment in the same job that just ran PR build/tests. PR #166 added `continue-on-error` to mask fork-PR comment failures. | `ci.yml` `coverage` job: just aggregates + uploads `coverage-publish` artifact, no write perms. <br>`coverage_report.yml` (new) — `workflow_run` of CI + `workflow_dispatch`, downloads the artifact, deploys + comments. |

## Fork-PR policy

**Builds and tests still auto-run** for fork PRs — GitHub strips repository secrets from fork-PR contexts automatically, so they have nothing to leak. Reviewers get green/red signal as usual.

**Auto-deploy** (gh-pages push + PR comment) fires for:
- same-repo PRs ✅
- pushes to `main` ✅
- workflow_dispatch (a maintainer clicked "Run workflow") ✅

**For fork PRs, the maintainer manually clicks:**

- **PWA preview**: Actions → "Build PWA Preview" → Run workflow → enter PR number → the manual run uploads the artifact → downstream "Deploy PWA Preview" treats `workflow_run.event == 'workflow_dispatch'` as trusted and deploys.
- **Coverage**: Actions → "Coverage Report" → Run workflow → enter PR number → workflow looks up the most recent successful CI run for that PR's head branch and publishes its coverage.

This preserves the current manual-click UX you asked for, but without the security pitfalls #171/#168 were navigating.

## Security improvements vs. PR #171's approach

#171 tried to make the existing single-workflow design dispatch builds for fork PRs. Copilot flagged three issues, all of which this PR avoids structurally:

| #171 concern | This PR |
|---|---|
| `inputs.pr_number` interpolated into a `run:` shell block → script injection | Goes through env var + `[[ "$PR_NUMBER" =~ ^[0-9]+$ ]]` validation before any use. |
| `head_repository` override checked out under a job with `contents: write` + `pull-requests: write` | Untrusted code lives only in `build_pwa_preview.yml` which holds only `contents: read` and `persist-credentials: false`. |
| Persisted GitHub token reachable from postinstall scripts of fork code | Same as above — no write token reaches any job that runs PR code. |

Plus an extra defence the artifact bridge provides: the embedded PR number is cross-checked against the PR's current head SHA before deploy, so a forged/swapped artifact can't be deployed under another PR's preview URL.

## Files

- **add** `.github/workflows/build_pwa_preview.yml`
- **rewrite** `.github/workflows/deploy_pwa_preview.yml`
- **add** `.github/workflows/coverage_report.yml`
- **modify** `.github/workflows/ci.yml` (coverage job: drop write perms, drop in-job deploy/comment, upload publishable artifact instead)

Unchanged: `cleanup_pwa_preview.yml`, `cleanup_coverage_preview.yml`, `deploy_pwa.yml`, `prerelease.yml`, `release-coordinator.yml`, `release_*.yml` — all already safe (no PR-code execution under write tokens).

## Audit of other workflows for similar issues

| Workflow | Verdict |
|---|---|
| `cleanup_pwa_preview.yml`, `cleanup_coverage_preview.yml` | Safe — fires on `pull_request: closed`, only consumes `pull_request.number` (integer from event payload), checks out `gh-pages` not PR code. |
| `deploy_pwa.yml` | Safe — `workflow_run` of CI, gated to `main` branch only, runs trusted default-branch code. |
| `prerelease.yml`, `release-coordinator.yml`, `release_*.yml` | Safe — `push: main` only; protected by branch protection / merge review. |

## Closes

- Supersedes [#171](https://github.com/niivue/niivue-vscode/pull/171) (extend-deploy-to-forks via `head_repository` override — three unaddressed security flags from Copilot; obsolete after this split).
- Supersedes [korbinian90#2](https://github.com/korbinian90/niivue-vscode/pull/2) (the duplicate cross-repo PR on the fork).
- Makes PR #168's same-repo gate redundant — the unsafe job no longer has any privileges to gate.
- Makes PR #166's `continue-on-error` fork-PR comment workaround redundant — fork PRs flow through the manual-dispatch path which always has write perms.

## Test plan

- [ ] Open this PR (same-repo) → Build PWA Preview auto-runs → Deploy PWA Preview auto-fires → comment + commit status land.
- [ ] Open this PR → CI runs → Coverage Report auto-fires → coverage gh-pages dir under `coverage/pr-{this}/`, sticky comment lands, commit status shows.
- [ ] Merge → push to main → coverage publishes under `coverage/main/`, no PR comment (no PR to comment on).
- [ ] After merge, open a follow-up fork PR (or simulate by manually dispatching with any open fork PR's number) → CI runs but no auto-deploy → maintainer clicks Build PWA Preview / Coverage Report → deploys land.
- [ ] Verify `cleanup_pwa_preview.yml` still removes `pr-{this}/` on close (no changes there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)