### PR TITLE
ci(preview): gate fork-PR builds + rename production deploy workflow

### DIFF
--- a/.github/workflows/build_pwa_preview.yml
+++ b/.github/workflows/build_pwa_preview.yml
@@ -38,6 +38,15 @@ concurrency:
 
 jobs:
   build:
+    # Fork PRs do NOT auto-build. The maintainer triggers the build manually
+    # via workflow_dispatch after reviewing the diff. This saves CI minutes on
+    # drive-by fork PRs and gives the maintainer an explicit consent point
+    # before running PR-author code on our infra (even read-only).
+    # Same-repo PRs and maintainer workflow_dispatch always build.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       # Manual-dispatch path: resolve which PR head we should check out. The

--- a/.github/workflows/deploy_pwa_preview.yml
+++ b/.github/workflows/deploy_pwa_preview.yml
@@ -33,10 +33,16 @@ concurrency:
 
 jobs:
   deploy:
-    # Conditions:
-    #  - upstream build must have succeeded
-    #  - allow workflow_dispatch (maintainer triggered) and same-repo pull_request
-    #  - block fork pull_request: maintainer must manually dispatch Build PWA Preview
+    # No standalone workflow_dispatch here: the only entry point for previews
+    # is "Build PWA Preview" (which has its own workflow_dispatch). Re-deploys
+    # without rebuilding turned out rare enough to not justify a second button
+    # — if a deploy fails, re-running Build PWA Preview rebuilds and re-deploys
+    # in one step.
+    #
+    # Fork-PR gating: the primary gate is on Build PWA Preview's job-level if;
+    # fork PRs skip the build, so the workflow_run conclusion isn't 'success'
+    # and this if naturally filters them out. The same-repo check below is
+    # defense-in-depth in case the build's gate is ever loosened.
     if: |
       github.event.workflow_run.conclusion == 'success' &&
       (github.event.workflow_run.event == 'workflow_dispatch' ||

--- a/.github/workflows/deploy_pwa_production.yml
+++ b/.github/workflows/deploy_pwa_production.yml
@@ -1,5 +1,7 @@
-# Modern workflow for deploying PWA to GitHub Pages
-name: Deploy PWA to Github Pages
+# Deploys the production PWA build (main branch) to the gh-pages root.
+# Counterpart to deploy_pwa_preview.yml, which deploys per-PR previews
+# under gh-pages/pr-N/.
+name: Deploy PWA Production
 
 on:
   workflow_run:


### PR DESCRIPTION
## Summary

Recovery PR for two commits that were pushed to the [#173](https://github.com/niivue/niivue-vscode/pull/173) branch (`fix/coverage-badge-and-fork-publish`) **after** that PR had already been squash-merged. The commits never made it into `main`. This PR brings them in cleanly.

The merged squash of #173 landed at `58d67fc` on 2026-05-17 23:28 UTC. Commits `8c4f5b7` (deploy_pwa rename) and `f5484e2` (fork-PR build gate) were authored on the same branch at 23:50 UTC — 22 minutes later — so they never appeared in #173's squash.

## Changes (3 files, +23 / -6)

- **`build_pwa_preview.yml`**: job-level `if:` skips auto-builds for fork PRs. Same-repo PRs auto-build; fork PRs require maintainer `workflow_dispatch`. Saves CI minutes on drive-by fork PRs and gives an explicit consent point.
- **`deploy_pwa_preview.yml`**: comment refresh reflecting that Build PWA Preview is now the sole entry point. The previously-mooted `workflow_dispatch` button on Deploy was dropped — re-running Build rebuilds + re-deploys in one step.
- **`deploy_pwa.yml` → `deploy_pwa_production.yml`**: rename for clarity next to `deploy_pwa_preview.yml`.

## Verification

Branch-vs-main diff hash matches the orphan-commits-vs-main diff hash exactly (sha256 `a5255200…`), so no content drift from the original commits — just packaged onto a fresh branch with the squash already in place.

## Net UX

For any preview operation on a fork PR: maintainer clicks **Build PWA Preview** → Run workflow → enter PR number. Coverage Report's dispatch is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)