### PR TITLE
test(coverage): easy wins — jupyter download fix + vscode/shared-core tests

### DIFF
--- a/.changeset/test-coverage-easy-wins.md
+++ b/.changeset/test-coverage-easy-wins.md
@@ -1,0 +1,21 @@
+---
+---
+
+Internal: test-coverage additions across `apps/vscode`, `apps/jupyter`, and
+`packages/niivue-react`. No runtime behavior change.
+
+- Fix `ci.yml` jupyter coverage download path so the artifact lands under
+  `apps/jupyter/coverage/unit/` (the aggregator's walk requires a
+  `coverage` path segment).
+- `apps/vscode`: add unit tests for `dispose.ts`, `html.ts` (CSP shape +
+  nonce uniqueness as a security guardrail), and `HoverProvider.ts`
+  (regex link detection across all 17 supported extensions).
+- `packages/niivue-react`: add unit tests for `utility.ts` (isImageType,
+  getMetadataString, getNumberOfPoints, getNames), `matchesShortcut` in
+  `constants/keyboardShortcuts.ts`, and `ReadyStateManager`.
+- `apps/jupyter`: cover the remaining `url-utils.ts` exports
+  (`getJupyterUrl`, `getMhdPairedRawBasename`, `getMhdPairedRawPath`,
+  `fetchArrayBuffer`, `fetchJson`), reaching 100% statement coverage on
+  that file.
+
+Empty frontmatter intentional: tests-only, no version bump.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,10 +409,14 @@ jobs:
         continue-on-error: true
 
       - name: Download Jupyter coverage artifacts
+        # upload-artifact@v4 strips the parent path for single-path uploads,
+        # so the artifact's files sit at its root. Extract them back under
+        # apps/jupyter/coverage/unit/ so the aggregator's walk (which requires
+        # a `coverage` path segment) picks them up. Same fix as VS Code below.
         uses: actions/download-artifact@v4
         with:
           name: coverage-unit-jupyter
-          path: .
+          path: apps/jupyter/coverage/unit/
         continue-on-error: true
 
       - name: Download VS Code coverage artifacts

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -43,6 +43,10 @@ jobs:
 
       # Bail early if there are no pending changesets. Without any, there's
       # nothing semantically new to pre-release on top of the last stable.
+      # Empty-frontmatter changesets (used as test-only / docs-only markers
+      # that satisfy the "every PR touching packages/apps needs a changeset"
+      # rule without bumping a version) are skipped here too — they have no
+      # package bumps so the pre-release would publish nothing.
       - name: Detect pending changesets
         id: detect
         run: |
@@ -50,6 +54,13 @@ jobs:
           count=0
           for f in .changeset/*.md; do
             [ "$(basename "$f")" = "README.md" ] && continue
+            # A changeset is "empty" if its frontmatter (everything between
+            # the first pair of `---` lines) has no non-blank content lines —
+            # i.e. no `"<package>": <bump>` entries.
+            if ! awk '/^---$/{c++; next} c==1 && NF>0' "$f" | grep -q .; then
+              echo "  skipping empty changeset: $(basename "$f")"
+              continue
+            fi
             count=$((count + 1))
           done
           if [ "$count" -gt 0 ]; then

--- a/apps/jupyter/src/url-utils.test.ts
+++ b/apps/jupyter/src/url-utils.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest'
-import { getContentsUrl, getFileUrl } from './url-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ServerConnection } from '@jupyterlab/services'
+import {
+  fetchArrayBuffer,
+  fetchJson,
+  getContentsUrl,
+  getFileUrl,
+  getJupyterUrl,
+  getMhdPairedRawBasename,
+  getMhdPairedRawPath,
+} from './url-utils'
 
 describe('URL utilities', () => {
   describe('getFileUrl', () => {
@@ -107,5 +116,201 @@ describe('URL utilities', () => {
       expect(correctUrl).not.toContain('//files')
       expect(correctUrl).not.toContain('files/files')
     })
+  })
+})
+
+describe('getJupyterUrl', () => {
+  // getJupyterUrl uses PageConfig.getBaseUrl() under the hood. In a Node
+  // test environment with no PageConfig setup, baseUrl is '/' — assertions
+  // here pin the join behavior relative to whatever PageConfig returns.
+  it('joins a path against the configured base URL', () => {
+    expect(getJupyterUrl('api/contents/data')).toMatch(/\/api\/contents\/data$/)
+  })
+
+  it('normalizes leading slashes against the base URL', () => {
+    expect(getJupyterUrl('/api/contents/data')).toMatch(/\/api\/contents\/data$/)
+  })
+
+  it('returns a string', () => {
+    expect(typeof getJupyterUrl('anything')).toBe('string')
+  })
+})
+
+describe('getMhdPairedRawBasename', () => {
+  // The function reads an .mhd header as text (via TextDecoder) and looks
+  // for the `ElementDataFile = <name>` field, returning the basename or null.
+  const enc = (text: string) => new TextEncoder().encode(text).buffer as ArrayBuffer
+
+  it('returns the basename for a plain ElementDataFile entry', () => {
+    expect(getMhdPairedRawBasename(enc('ElementDataFile = scan.raw\n'))).toBe('scan.raw')
+  })
+
+  it('returns null when ElementDataFile is missing', () => {
+    expect(getMhdPairedRawBasename(enc('NDims = 3\nDimSize = 256 256 128\n'))).toBeNull()
+  })
+
+  it('returns null when ElementDataFile = LOCAL (data embedded in MHA)', () => {
+    expect(getMhdPairedRawBasename(enc('ElementDataFile = LOCAL\n'))).toBeNull()
+  })
+
+  it('treats LOCAL case-insensitively', () => {
+    expect(getMhdPairedRawBasename(enc('ElementDataFile = local\n'))).toBeNull()
+    expect(getMhdPairedRawBasename(enc('ElementDataFile = Local\n'))).toBeNull()
+  })
+
+  it('strips quotes around the filename', () => {
+    expect(getMhdPairedRawBasename(enc('ElementDataFile = "scan.raw"\n'))).toBe('scan.raw')
+    expect(getMhdPairedRawBasename(enc("ElementDataFile = 'scan.raw'\n"))).toBe('scan.raw')
+  })
+
+  it('rejects subdirectory components — only returns basename for safety', () => {
+    // Forward slashes
+    expect(getMhdPairedRawBasename(enc('ElementDataFile = data/scan.raw\n'))).toBe('scan.raw')
+    // Backslashes (Windows-style paths inside MHD headers)
+    expect(getMhdPairedRawBasename(enc('ElementDataFile = data\\scan.raw\n'))).toBe('scan.raw')
+    // Absolute paths
+    expect(getMhdPairedRawBasename(enc('ElementDataFile = /etc/passwd\n'))).toBe('passwd')
+  })
+
+  it('matches the field key case-insensitively (real MHD files vary)', () => {
+    expect(getMhdPairedRawBasename(enc('elementdatafile = scan.raw\n'))).toBe('scan.raw')
+    expect(getMhdPairedRawBasename(enc('ELEMENTDATAFILE = scan.raw\n'))).toBe('scan.raw')
+  })
+
+  it('finds the field on any line, not just the first', () => {
+    const header = 'NDims = 3\nDimSize = 256 256 128\nElementSpacing = 1 1 1\nElementDataFile = scan.raw\n'
+    expect(getMhdPairedRawBasename(enc(header))).toBe('scan.raw')
+  })
+
+  it('returns null on an empty buffer', () => {
+    expect(getMhdPairedRawBasename(enc(''))).toBeNull()
+  })
+})
+
+describe('getMhdPairedRawPath', () => {
+  it('joins basename next to the mhd file in the same directory', () => {
+    expect(getMhdPairedRawPath('data/scans/brain.mhd', 'brain.raw')).toBe('data/scans/brain.raw')
+  })
+
+  it('returns just the basename when mhd is at the root (no slash)', () => {
+    expect(getMhdPairedRawPath('brain.mhd', 'brain.raw')).toBe('brain.raw')
+  })
+
+  it('preserves leading slash on absolute paths', () => {
+    expect(getMhdPairedRawPath('/abs/path/scan.mhd', 'scan.raw')).toBe('/abs/path/scan.raw')
+  })
+
+  it('does not require the mhd basename and the raw basename to match', () => {
+    // MHD ElementDataFile can point to any sibling file name.
+    expect(getMhdPairedRawPath('data/scan_v1.mhd', 'data_block.raw')).toBe('data/data_block.raw')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fetchArrayBuffer / fetchJson — both call ServerConnection.makeRequest, so
+// we spy on it. The settings object is opaque to the functions under test;
+// we pass `{}` cast through `unknown` to satisfy the type signature.
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function mockResponse(opts: {
+  ok?: boolean
+  status?: number
+  statusText?: string
+  contentType?: string
+  body?: ArrayBuffer | string
+  url?: string
+  textThrows?: boolean
+}): Response {
+  return {
+    ok: opts.ok ?? true,
+    status: opts.status ?? 200,
+    statusText: opts.statusText ?? 'OK',
+    url: opts.url ?? '',
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'content-type' ? opts.contentType ?? 'application/octet-stream' : null,
+    },
+    arrayBuffer: async () =>
+      typeof opts.body === 'string' ? new TextEncoder().encode(opts.body).buffer : opts.body ?? new ArrayBuffer(0),
+    text: async () => {
+      if (opts.textThrows) throw new Error('reader closed')
+      return typeof opts.body === 'string' ? opts.body : ''
+    },
+    json: async () => (typeof opts.body === 'string' ? JSON.parse(opts.body) : null),
+  } as unknown as Response
+}
+
+const settings = {} as unknown as ServerConnection.ISettings
+
+describe('fetchArrayBuffer', () => {
+  it('returns the ArrayBuffer on a successful 200 response', async () => {
+    const expected = new TextEncoder().encode('binary blob').buffer as ArrayBuffer
+    vi.spyOn(ServerConnection, 'makeRequest').mockResolvedValue(mockResponse({ body: expected }))
+    const result = await fetchArrayBuffer('http://x/y', settings)
+    expect(new TextDecoder().decode(result)).toBe('binary blob')
+  })
+
+  it('throws with the URL when the network request itself fails', async () => {
+    vi.spyOn(ServerConnection, 'makeRequest').mockRejectedValue(new Error('ECONNREFUSED'))
+    await expect(fetchArrayBuffer('http://x/y', settings)).rejects.toThrow(/Request failed \(http:\/\/x\/y\): ECONNREFUSED/)
+  })
+
+  it('throws with status and statusText on a non-OK response', async () => {
+    vi.spyOn(ServerConnection, 'makeRequest').mockResolvedValue(
+      mockResponse({ ok: false, status: 404, statusText: 'Not Found' }),
+    )
+    await expect(fetchArrayBuffer('http://x/y', settings)).rejects.toThrow(/HTTP 404 Not Found/)
+  })
+
+  it('includes the response body in the error detail (truncated to 300 chars)', async () => {
+    const bigDetail = 'X'.repeat(500)
+    vi.spyOn(ServerConnection, 'makeRequest').mockResolvedValue(
+      mockResponse({ ok: false, status: 500, statusText: 'Server Error', body: bigDetail }),
+    )
+    await expect(fetchArrayBuffer('http://x/y', settings)).rejects.toThrow(/HTTP 500 Server Error; X{300}$/)
+  })
+
+  it('tolerates a response.text() that throws (no detail, no rethrow)', async () => {
+    vi.spyOn(ServerConnection, 'makeRequest').mockResolvedValue(
+      mockResponse({ ok: false, status: 503, statusText: 'Unavailable', textThrows: true }),
+    )
+    await expect(fetchArrayBuffer('http://x/y', settings)).rejects.toThrow(/HTTP 503 Unavailable$/)
+  })
+
+  it('detects HTML responses (likely auth redirect) and includes the final URL', async () => {
+    vi.spyOn(ServerConnection, 'makeRequest').mockResolvedValue(
+      mockResponse({ contentType: 'text/html; charset=utf-8', url: 'http://hub/login' }),
+    )
+    await expect(fetchArrayBuffer('http://x/y', settings)).rejects.toThrow(
+      /Unexpected HTML response \(likely auth redirect\)\. Final URL: http:\/\/hub\/login/,
+    )
+  })
+})
+
+describe('fetchJson', () => {
+  it('returns the parsed JSON on a successful response', async () => {
+    vi.spyOn(ServerConnection, 'makeRequest').mockResolvedValue(
+      mockResponse({ body: '{"hello": "world"}', contentType: 'application/json' }),
+    )
+    expect(await fetchJson<{ hello: string }>('http://x/y', settings)).toEqual({ hello: 'world' })
+  })
+
+  it('throws with status and statusText on non-OK response', async () => {
+    vi.spyOn(ServerConnection, 'makeRequest').mockResolvedValue(
+      mockResponse({ ok: false, status: 401, statusText: 'Unauthorized' }),
+    )
+    await expect(fetchJson('http://x/y', settings)).rejects.toThrow(/HTTP 401 Unauthorized/)
+  })
+
+  it('preserves the generic type at the call site', async () => {
+    vi.spyOn(ServerConnection, 'makeRequest').mockResolvedValue(
+      mockResponse({ body: '{"n": 42}', contentType: 'application/json' }),
+    )
+    const result = await fetchJson<{ n: number }>('http://x/y', settings)
+    expect(result.n).toBe(42)
   })
 })

--- a/apps/jupyter/src/url-utils.test.ts
+++ b/apps/jupyter/src/url-utils.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PageConfig } from '@jupyterlab/coreutils'
 import { ServerConnection } from '@jupyterlab/services'
 import {
   fetchArrayBuffer,
@@ -120,19 +121,44 @@ describe('URL utilities', () => {
 })
 
 describe('getJupyterUrl', () => {
-  // getJupyterUrl uses PageConfig.getBaseUrl() under the hood. In a Node
-  // test environment with no PageConfig setup, baseUrl is '/' — assertions
-  // here pin the join behavior relative to whatever PageConfig returns.
-  it('joins a path against the configured base URL', () => {
-    expect(getJupyterUrl('api/contents/data')).toMatch(/\/api\/contents\/data$/)
+  // getJupyterUrl wraps URLExt.join(PageConfig.getBaseUrl(), path). We
+  // install a JupyterHub-style base URL via PageConfig.setOption so the
+  // assertions exercise the actual prefix-preserving behavior — an
+  // implementation that ignored PageConfig would fail these.
+  let savedBaseUrl: string
+
+  beforeEach(() => {
+    savedBaseUrl = PageConfig.getOption('baseUrl')
   })
 
-  it('normalizes leading slashes against the base URL', () => {
-    expect(getJupyterUrl('/api/contents/data')).toMatch(/\/api\/contents\/data$/)
+  afterEach(() => {
+    PageConfig.setOption('baseUrl', savedBaseUrl)
   })
 
-  it('returns a string', () => {
-    expect(typeof getJupyterUrl('anything')).toBe('string')
+  it('prepends the configured JupyterHub base URL', () => {
+    PageConfig.setOption('baseUrl', 'http://hub.example.com/user/johndoe/')
+    expect(getJupyterUrl('api/contents/data')).toBe(
+      'http://hub.example.com/user/johndoe/api/contents/data',
+    )
+  })
+
+  it('joins paths cleanly when the configured base URL lacks a trailing slash', () => {
+    PageConfig.setOption('baseUrl', 'http://hub.example.com/user/johndoe')
+    expect(getJupyterUrl('api/contents/data')).toBe(
+      'http://hub.example.com/user/johndoe/api/contents/data',
+    )
+  })
+
+  it('normalizes leading slashes against the base URL (no double slashes)', () => {
+    PageConfig.setOption('baseUrl', 'http://hub.example.com/user/johndoe/')
+    const url = getJupyterUrl('/api/contents/data')
+    expect(url).toBe('http://hub.example.com/user/johndoe/api/contents/data')
+    expect(url).not.toContain('//api')
+  })
+
+  it('falls back to the path under root when no base URL is configured', () => {
+    PageConfig.setOption('baseUrl', '')
+    expect(getJupyterUrl('api/contents/data')).toMatch(/\/?api\/contents\/data$/)
   })
 })
 

--- a/apps/jupyter/src/url-utils.test.ts
+++ b/apps/jupyter/src/url-utils.test.ts
@@ -178,7 +178,8 @@ describe('getMhdPairedRawBasename', () => {
   })
 
   it('finds the field on any line, not just the first', () => {
-    const header = 'NDims = 3\nDimSize = 256 256 128\nElementSpacing = 1 1 1\nElementDataFile = scan.raw\n'
+    const header =
+      'NDims = 3\nDimSize = 256 256 128\nElementSpacing = 1 1 1\nElementDataFile = scan.raw\n'
     expect(getMhdPairedRawBasename(enc(header))).toBe('scan.raw')
   })
 
@@ -232,12 +233,18 @@ function mockResponse(opts: {
     url: opts.url ?? '',
     headers: {
       get: (name: string) =>
-        name.toLowerCase() === 'content-type' ? opts.contentType ?? 'application/octet-stream' : null,
+        name.toLowerCase() === 'content-type'
+          ? (opts.contentType ?? 'application/octet-stream')
+          : null,
     },
     arrayBuffer: async () =>
-      typeof opts.body === 'string' ? new TextEncoder().encode(opts.body).buffer : opts.body ?? new ArrayBuffer(0),
+      typeof opts.body === 'string'
+        ? new TextEncoder().encode(opts.body).buffer
+        : (opts.body ?? new ArrayBuffer(0)),
     text: async () => {
-      if (opts.textThrows) throw new Error('reader closed')
+      if (opts.textThrows) {
+        throw new Error('reader closed')
+      }
       return typeof opts.body === 'string' ? opts.body : ''
     },
     json: async () => (typeof opts.body === 'string' ? JSON.parse(opts.body) : null),
@@ -256,7 +263,9 @@ describe('fetchArrayBuffer', () => {
 
   it('throws with the URL when the network request itself fails', async () => {
     vi.spyOn(ServerConnection, 'makeRequest').mockRejectedValue(new Error('ECONNREFUSED'))
-    await expect(fetchArrayBuffer('http://x/y', settings)).rejects.toThrow(/Request failed \(http:\/\/x\/y\): ECONNREFUSED/)
+    await expect(fetchArrayBuffer('http://x/y', settings)).rejects.toThrow(
+      /Request failed \(http:\/\/x\/y\): ECONNREFUSED/,
+    )
   })
 
   it('throws with status and statusText on a non-OK response', async () => {
@@ -271,7 +280,9 @@ describe('fetchArrayBuffer', () => {
     vi.spyOn(ServerConnection, 'makeRequest').mockResolvedValue(
       mockResponse({ ok: false, status: 500, statusText: 'Server Error', body: bigDetail }),
     )
-    await expect(fetchArrayBuffer('http://x/y', settings)).rejects.toThrow(/HTTP 500 Server Error; X{300}$/)
+    await expect(fetchArrayBuffer('http://x/y', settings)).rejects.toThrow(
+      /HTTP 500 Server Error; X{300}$/,
+    )
   })
 
   it('tolerates a response.text() that throws (no detail, no rethrow)', async () => {

--- a/apps/vscode/test/HoverProvider.test.ts
+++ b/apps/vscode/test/HoverProvider.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest'
+import { LinkHoverProvider } from '../src/HoverProvider'
+import { MarkdownString, Position, Range } from './vscode-mock'
+
+/**
+ * The provider runs two regexes against the line at the cursor — one for
+ * https URLs ending in a supported image extension, one for local paths
+ * ending similarly. We exercise both branches across the full supported
+ * extension list and on a few negative cases.
+ */
+
+/**
+ * Build a vscode.TextDocument-shaped stub. `getWordRangeAtPosition` is the
+ * only method LinkHoverProvider uses besides `getText`. We simulate it by
+ * running the supplied regex against `line` and returning a Range if it
+ * matches at all (LinkHoverProvider doesn't actually check the cursor offset
+ * — it accepts any match on the line).
+ */
+function makeDocument(line: string) {
+  return {
+    getWordRangeAtPosition: vi.fn((_pos: Position, regex: RegExp) => {
+      const m = line.match(regex)
+      return m ? new Range(new Position(0, m.index ?? 0), new Position(0, (m.index ?? 0) + m[0].length)) : undefined
+    }),
+    getText: vi.fn((_range: Range) => {
+      // The provider only calls getText with the range returned above.
+      // Return the matched substring by re-running the relevant regex.
+      // For the test stub, the simplest correct behavior: return the whole line.
+      // LinkHoverProvider then passes it to Uri.parse / Uri.file which is fine.
+      return line
+    }),
+  }
+}
+
+async function tryHover(line: string) {
+  const provider = new LinkHoverProvider()
+  const doc = makeDocument(line)
+  // The position values don't matter — our stub returns the range whenever the
+  // line itself matches the regex.
+  try {
+    return (await provider.provideHover(doc as any, new Position(0, 0), {} as any)) as
+      | { contents: MarkdownString[] }
+      | undefined
+  } catch {
+    // The implementation calls `reject()` (no args) when neither pattern matches.
+    return undefined
+  }
+}
+
+describe('LinkHoverProvider — web URLs', () => {
+  it.each([
+    '.nii.gz',
+    '.nii',
+    '.npy',
+    '.npz',
+    '.dcm',
+    '.mih',
+    '.mif',
+    '.nhdr',
+    '.nrrd',
+    '.mhd',
+    '.mha',
+    '.mgh',
+    '.mgz',
+    '.v',
+    '.v16',
+    '.vmr',
+    '.head',
+  ])('detects https URL ending in %s', async (ext) => {
+    const hover = await tryHover(`see this file https://example.org/data/scan${ext} for details`)
+    expect(hover).toBeDefined()
+    expect(hover!.contents[0]).toBeInstanceOf(MarkdownString)
+    expect(hover!.contents[0].value).toContain('[Show with NiiVue]')
+  })
+
+  it('marks the returned MarkdownString as trusted so command links work', async () => {
+    const hover = await tryHover('https://example.org/data/scan.nii.gz')
+    expect(hover!.contents[0].isTrusted).toBe(true)
+  })
+
+  it('detection is case-insensitive on the extension', async () => {
+    const hover = await tryHover('https://example.org/SCAN.NII.GZ')
+    expect(hover).toBeDefined()
+  })
+
+  it('embeds the niiVue.openLink command with the URI as argument', async () => {
+    const hover = await tryHover('https://example.org/scan.nii.gz')
+    const value = (hover!.contents[0] as MarkdownString).value
+    expect(value).toMatch(/command:niiVue\.openLink\?/)
+  })
+})
+
+describe('LinkHoverProvider — local paths', () => {
+  it('detects an absolute Windows-style path ending in a supported extension', async () => {
+    const hover = await tryHover('C:\\data\\scan.nii.gz')
+    expect(hover).toBeDefined()
+  })
+
+  it('detects a relative path ending in a supported extension', async () => {
+    const hover = await tryHover('see data/scan.nrrd here')
+    expect(hover).toBeDefined()
+  })
+
+  it('uses niiVue.openLocal (not openLink) for local paths', async () => {
+    const hover = await tryHover('data/scan.nii')
+    const value = (hover!.contents[0] as MarkdownString).value
+    expect(value).toMatch(/command:niiVue\.openLocal\?/)
+  })
+})
+
+describe('LinkHoverProvider — negative cases', () => {
+  it('returns nothing for plain text', async () => {
+    expect(await tryHover('just some text, no link here')).toBeUndefined()
+  })
+
+  it('returns nothing for unsupported extensions', async () => {
+    expect(await tryHover('https://example.org/data/scan.txt')).toBeUndefined()
+    expect(await tryHover('data/file.png')).toBeUndefined()
+  })
+
+  it('returns nothing for an empty line', async () => {
+    expect(await tryHover('')).toBeUndefined()
+  })
+})

--- a/apps/vscode/test/HoverProvider.test.ts
+++ b/apps/vscode/test/HoverProvider.test.ts
@@ -18,10 +18,18 @@ import { MarkdownString, Position, Range, Uri } from './vscode-mock'
  */
 function makeDocument(line: string) {
   return {
-    getWordRangeAtPosition: vi.fn((_pos: Position, regex: RegExp) => {
+    getWordRangeAtPosition: vi.fn((pos: Position, regex: RegExp) => {
+      // Real getWordRangeAtPosition returns a Range only when the regex
+      // matches a substring that *contains* the cursor position. A mock
+      // that ignored `pos` would pass even if the provider asked about
+      // a position outside any link — exactly the kind of bug VS Code's
+      // hover plumbing would expose.
       const m = line.match(regex)
       if (!m || m.index === undefined) return undefined
-      return new Range(new Position(0, m.index), new Position(0, m.index + m[0].length))
+      const start = m.index
+      const end = start + m[0].length
+      if (pos.character < start || pos.character > end) return undefined
+      return new Range(new Position(0, start), new Position(0, end))
     }),
     getText: vi.fn((range: Range) => line.slice(range.start.character, range.end.character)),
   }
@@ -49,11 +57,17 @@ function commandUriFrom(hover: { contents: MarkdownString[] }): {
   return { scheme: parsed.scheme, command: parsed.path, args: args[0] }
 }
 
-async function tryHover(line: string) {
+async function tryHover(line: string, cursor?: Position) {
   const provider = new LinkHoverProvider()
   const doc = makeDocument(line)
+  // Default to the middle of the line. Every positive test below constructs
+  // the line so its link straddles the middle, so the position-aware mock
+  // returns a real range. Negative tests pass lines whose middle is outside
+  // any match (or has no match), so the mock returns undefined and the
+  // provider rejects.
+  const pos = cursor ?? new Position(0, Math.floor(line.length / 2))
   try {
-    return (await provider.provideHover(doc as any, new Position(0, 0), {} as any)) as {
+    return (await provider.provideHover(doc as any, pos, {} as any)) as {
       contents: MarkdownString[]
     }
   } catch (err) {
@@ -157,5 +171,15 @@ describe('LinkHoverProvider — negative cases', () => {
 
   it('returns nothing for an empty line', async () => {
     expect(await tryHover('')).toBeUndefined()
+  })
+
+  it('returns nothing when the cursor sits outside the link', async () => {
+    // Link occupies positions 14..50; cursor at 0 is in "see " — no hover.
+    const line = 'see this file https://example.org/data/scan.nii.gz here'
+    expect(await tryHover(line, new Position(0, 0))).toBeUndefined()
+    // Same line, cursor at the very end — past the URL — also no hover.
+    expect(await tryHover(line, new Position(0, line.length - 1))).toBeUndefined()
+    // Sanity check: a cursor inside the link does fire.
+    expect(await tryHover(line, new Position(0, 25))).toBeDefined()
   })
 })

--- a/apps/vscode/test/HoverProvider.test.ts
+++ b/apps/vscode/test/HoverProvider.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { LinkHoverProvider } from '../src/HoverProvider'
-import { MarkdownString, Position, Range } from './vscode-mock'
+import { MarkdownString, Position, Range, Uri } from './vscode-mock'
 
 /**
  * The provider runs two regexes against the line at the cursor — one for
@@ -10,40 +10,58 @@ import { MarkdownString, Position, Range } from './vscode-mock'
  */
 
 /**
- * Build a vscode.TextDocument-shaped stub. `getWordRangeAtPosition` is the
- * only method LinkHoverProvider uses besides `getText`. We simulate it by
- * running the supplied regex against `line` and returning a Range if it
- * matches at all (LinkHoverProvider doesn't actually check the cursor offset
- * — it accepts any match on the line).
+ * Build a vscode.TextDocument-shaped stub. `getWordRangeAtPosition` runs the
+ * provided regex against the line and returns a Range pointing at the match
+ * span; `getText(range)` slices that exact substring. This preserves the
+ * real VS Code contract — if the provider passed the wrong range, getText
+ * would return the wrong substring and the assertions below would catch it.
  */
 function makeDocument(line: string) {
   return {
     getWordRangeAtPosition: vi.fn((_pos: Position, regex: RegExp) => {
       const m = line.match(regex)
-      return m ? new Range(new Position(0, m.index ?? 0), new Position(0, (m.index ?? 0) + m[0].length)) : undefined
+      if (!m || m.index === undefined) return undefined
+      return new Range(new Position(0, m.index), new Position(0, m.index + m[0].length))
     }),
-    getText: vi.fn((_range: Range) => {
-      // The provider only calls getText with the range returned above.
-      // Return the matched substring by re-running the relevant regex.
-      // For the test stub, the simplest correct behavior: return the whole line.
-      // LinkHoverProvider then passes it to Uri.parse / Uri.file which is fine.
-      return line
-    }),
+    getText: vi.fn((range: Range) => line.slice(range.start.character, range.end.character)),
   }
+}
+
+/**
+ * Extract the args-bearing command URI (the second argument to MarkdownString
+ * — the link target inside `[Show with NiiVue](...)`).
+ */
+function commandUriFrom(hover: { contents: MarkdownString[] }): {
+  scheme: string
+  command: string
+  args: { resourceUri: { scheme: string; path: string } }
+} {
+  const value = hover.contents[0].value
+  const linkMatch = value.match(/\(([^)]+)\)/)
+  expect(linkMatch).toBeTruthy()
+  const uriString = linkMatch![1]
+  const parsed = Uri.parse(uriString)
+  // command-scheme URIs serialize as `command:<commandId>?<encoded-args>`
+  expect(parsed.scheme).toBe('command')
+  const args = JSON.parse(decodeURIComponent(parsed.query)) as Array<{
+    resourceUri: { scheme: string; path: string }
+  }>
+  return { scheme: parsed.scheme, command: parsed.path, args: args[0] }
 }
 
 async function tryHover(line: string) {
   const provider = new LinkHoverProvider()
   const doc = makeDocument(line)
-  // The position values don't matter — our stub returns the range whenever the
-  // line itself matches the regex.
   try {
-    return (await provider.provideHover(doc as any, new Position(0, 0), {} as any)) as
-      | { contents: MarkdownString[] }
-      | undefined
-  } catch {
-    // The implementation calls `reject()` (no args) when neither pattern matches.
-    return undefined
+    return (await provider.provideHover(doc as any, new Position(0, 0), {} as any)) as {
+      contents: MarkdownString[]
+    }
+  } catch (err) {
+    // The implementation signals "no hover" via `reject()` with no arg, which
+    // rejects the promise with `undefined`. Any other thrown value is an
+    // unexpected error and must fail the test, not be silently swallowed.
+    if (err === undefined) return undefined
+    throw err
   }
 }
 
@@ -83,10 +101,21 @@ describe('LinkHoverProvider — web URLs', () => {
     expect(hover).toBeDefined()
   })
 
-  it('embeds the niiVue.openLink command with the URI as argument', async () => {
-    const hover = await tryHover('https://example.org/scan.nii.gz')
-    const value = (hover!.contents[0] as MarkdownString).value
-    expect(value).toMatch(/command:niiVue\.openLink\?/)
+  it('embeds niiVue.openLink as the command and only the matched URL in args', async () => {
+    const line = 'see this file https://example.org/data/scan.nii.gz here'
+    const hover = await tryHover(line)
+    const { scheme, command, args } = commandUriFrom(hover!)
+    expect(scheme).toBe('command')
+    expect(command).toBe('niiVue.openLink')
+    // resourceUri should be the URL itself, not surrounding context. Our mock
+    // Uri.parse extracts scheme + path; checking those rules out the
+    // "stub returned the full line" trap.
+    expect(args.resourceUri.scheme).toBe('https')
+    expect(args.resourceUri.path).toContain('/data/scan.nii.gz')
+    // And critically, the args must NOT contain the surrounding text.
+    const argsBlob = decodeURIComponent(Uri.parse(hover!.contents[0].value.match(/\(([^)]+)\)/)![1]).query)
+    expect(argsBlob).not.toContain('see this file')
+    expect(argsBlob).not.toContain('here')
   })
 })
 
@@ -103,8 +132,16 @@ describe('LinkHoverProvider — local paths', () => {
 
   it('uses niiVue.openLocal (not openLink) for local paths', async () => {
     const hover = await tryHover('data/scan.nii')
-    const value = (hover!.contents[0] as MarkdownString).value
-    expect(value).toMatch(/command:niiVue\.openLocal\?/)
+    const { command } = commandUriFrom(hover!)
+    expect(command).toBe('niiVue.openLocal')
+  })
+
+  it('puts only the matched path into args (not surrounding text)', async () => {
+    const hover = await tryHover('see data/scan.nrrd here')
+    const argsBlob = decodeURIComponent(Uri.parse(hover!.contents[0].value.match(/\(([^)]+)\)/)![1]).query)
+    expect(argsBlob).toContain('scan.nrrd')
+    expect(argsBlob).not.toContain('see ')
+    expect(argsBlob).not.toContain(' here')
   })
 })
 

--- a/apps/vscode/test/dispose.test.ts
+++ b/apps/vscode/test/dispose.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Disposable, disposeAll } from '../src/dispose'
+
+/** Trivial stub matching vscode.Disposable's shape (just a `dispose()` method). */
+function stub() {
+  return { dispose: vi.fn() }
+}
+
+describe('disposeAll', () => {
+  it('does nothing on an empty list', () => {
+    const list: { dispose: () => void }[] = []
+    expect(() => disposeAll(list)).not.toThrow()
+    expect(list).toHaveLength(0)
+  })
+
+  it('disposes a single item and empties the array', () => {
+    const a = stub()
+    const list = [a]
+    disposeAll(list)
+    expect(a.dispose).toHaveBeenCalledTimes(1)
+    expect(list).toHaveLength(0)
+  })
+
+  it('disposes multiple items in LIFO order', () => {
+    const order: string[] = []
+    const a = { dispose: () => order.push('a') }
+    const b = { dispose: () => order.push('b') }
+    const c = { dispose: () => order.push('c') }
+    disposeAll([a, b, c])
+    expect(order).toEqual(['c', 'b', 'a'])
+  })
+
+  it('skips entries whose item is null/undefined (pop returns nothing)', () => {
+    // The implementation guards against falsy pop results — exercise that path.
+    const a = stub()
+    const list = [undefined as unknown as { dispose: () => void }, a]
+    expect(() => disposeAll(list)).not.toThrow()
+    expect(a.dispose).toHaveBeenCalledOnce()
+  })
+})
+
+// Minimal concrete subclass since `Disposable` is abstract.
+class TestDisposable extends Disposable {
+  registerNow<T extends { dispose: () => unknown }>(d: T): T {
+    return this._register(d)
+  }
+
+  get disposed(): boolean {
+    return this.isDisposed
+  }
+}
+
+describe('Disposable', () => {
+  it('starts not-disposed', () => {
+    const d = new TestDisposable()
+    expect(d.disposed).toBe(false)
+  })
+
+  it('disposes registered children when disposed', () => {
+    const d = new TestDisposable()
+    const child = stub()
+    d.registerNow(child)
+    d.dispose()
+    expect(child.dispose).toHaveBeenCalledTimes(1)
+    expect(d.disposed).toBe(true)
+  })
+
+  it('is idempotent: dispose() twice still disposes children only once', () => {
+    const d = new TestDisposable()
+    const child = stub()
+    d.registerNow(child)
+    d.dispose()
+    d.dispose()
+    expect(child.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('immediately disposes anything registered after dispose() (no leak)', () => {
+    const d = new TestDisposable()
+    d.dispose()
+    const child = stub()
+    d.registerNow(child)
+    expect(child.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('disposes children in LIFO order (matches disposeAll semantics)', () => {
+    const d = new TestDisposable()
+    const order: string[] = []
+    d.registerNow({ dispose: () => order.push('a') })
+    d.registerNow({ dispose: () => order.push('b') })
+    d.registerNow({ dispose: () => order.push('c') })
+    d.dispose()
+    expect(order).toEqual(['c', 'b', 'a'])
+  })
+})

--- a/apps/vscode/test/html.test.ts
+++ b/apps/vscode/test/html.test.ts
@@ -41,12 +41,15 @@ describe('getHtmlForWebview', () => {
     const csp = cspMatch![1]
     // default-src is locked down...
     expect(csp).toContain("default-src 'none'")
-    // ...all source directives reference the webview's cspSource (no *)...
+    // ...all source directives reference the webview's cspSource (no wildcards)...
     expect(csp).toContain('img-src data: blob: https://test.vscode-cdn.net')
     expect(csp).toContain("style-src https://test.vscode-cdn.net 'unsafe-inline'")
     expect(csp).toContain('connect-src data: blob: https://test.vscode-cdn.net')
-    // ...and there's no `*` in the CSP at all (guards against accidental loosening).
-    expect(csp).not.toMatch(/(\s|=)\*(\s|;|$)/)
+    // ...and there's no `*` anywhere in the CSP. This is intentionally strict:
+    // `https://*`, `*.example.com`, `data: *`, or a bare `*` would all loosen
+    // the policy. The current CSP contains none, and any future change that
+    // introduces a `*` should require explicit reasoning here.
+    expect(csp).not.toContain('*')
   })
 
   it('generates a unique 32-char alphanumeric nonce on each call', async () => {

--- a/apps/vscode/test/html.test.ts
+++ b/apps/vscode/test/html.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getHtmlForWebview } from '../src/html'
+import { Uri } from './vscode-mock'
+
+/** Stub the bits of vscode.Webview that html.ts touches. */
+function makeWebview() {
+  return {
+    cspSource: 'https://test.vscode-cdn.net',
+    asWebviewUri: vi.fn((uri: Uri) => ({
+      toString: () => `https://test.vscode-cdn.net${uri.path}`,
+    })),
+  }
+}
+
+describe('getHtmlForWebview', () => {
+  it('produces a complete HTML document', async () => {
+    const extensionUri = Uri.parse('file:///ext')
+    const html = await getHtmlForWebview(makeWebview() as any, extensionUri)
+    expect(html).toMatch(/^\s*<!doctype html>/i)
+    expect(html).toContain('<html lang="en">')
+    expect(html).toContain('<div id="app"')
+  })
+
+  it('wires asWebviewUri for every bundled asset', async () => {
+    const extensionUri = Uri.parse('file:///ext')
+    const webview = makeWebview()
+    const html = await getHtmlForWebview(webview as any, extensionUri)
+    // index.js, index.css, vscode-styles.css — three asWebviewUri calls.
+    expect(webview.asWebviewUri).toHaveBeenCalledTimes(3)
+    expect(html).toContain('niivue/index.js')
+    expect(html).toContain('niivue/index.css')
+    expect(html).toContain('vscode-styles.css')
+  })
+
+  it('embeds a CSP that pins all sources to webview.cspSource (no wildcard hosts)', async () => {
+    const extensionUri = Uri.parse('file:///ext')
+    const webview = makeWebview()
+    const html = await getHtmlForWebview(webview as any, extensionUri)
+    const cspMatch = html.match(/Content-Security-Policy" content="([^"]+)"/)
+    expect(cspMatch).toBeTruthy()
+    const csp = cspMatch![1]
+    // default-src is locked down...
+    expect(csp).toContain("default-src 'none'")
+    // ...all source directives reference the webview's cspSource (no *)...
+    expect(csp).toContain('img-src data: blob: https://test.vscode-cdn.net')
+    expect(csp).toContain("style-src https://test.vscode-cdn.net 'unsafe-inline'")
+    expect(csp).toContain('connect-src data: blob: https://test.vscode-cdn.net')
+    // ...and there's no `*` in the CSP at all (guards against accidental loosening).
+    expect(csp).not.toMatch(/(\s|=)\*(\s|;|$)/)
+  })
+
+  it('generates a unique 32-char alphanumeric nonce on each call', async () => {
+    const extensionUri = Uri.parse('file:///ext')
+    const html1 = await getHtmlForWebview(makeWebview() as any, extensionUri)
+    const html2 = await getHtmlForWebview(makeWebview() as any, extensionUri)
+
+    // nonce appears in both the CSP and the <script> tags — extract from script.
+    const nonceFrom = (html: string) => {
+      const m = html.match(/nonce-([A-Za-z0-9]+)/)
+      expect(m).toBeTruthy()
+      return m![1]
+    }
+
+    const n1 = nonceFrom(html1)
+    const n2 = nonceFrom(html2)
+    expect(n1).toMatch(/^[A-Za-z0-9]{32}$/)
+    expect(n2).toMatch(/^[A-Za-z0-9]{32}$/)
+    expect(n1).not.toBe(n2) // probabilistic but ~62^32 collision space
+  })
+
+  it('uses the same nonce in CSP script-src and on every <script> tag', async () => {
+    const extensionUri = Uri.parse('file:///ext')
+    const html = await getHtmlForWebview(makeWebview() as any, extensionUri)
+    const csp = html.match(/Content-Security-Policy" content="([^"]+)"/)![1]
+    const cspNonce = csp.match(/script-src 'nonce-([A-Za-z0-9]+)'/)![1]
+    // Every script tag must carry the same nonce.
+    const scriptNonces = [...html.matchAll(/<script[^>]*nonce="([A-Za-z0-9]+)"/g)].map((m) => m[1])
+    expect(scriptNonces.length).toBeGreaterThan(0)
+    for (const n of scriptNonces) expect(n).toBe(cspNonce)
+  })
+
+  it('routes assets through the supplied extensionUri (no hard-coded paths)', async () => {
+    const customExt = Uri.parse('file:///some/other/ext-root')
+    const webview = makeWebview()
+    await getHtmlForWebview(webview as any, customExt)
+    // Each asWebviewUri call was given a Uri rooted at /some/other/ext-root.
+    for (const call of webview.asWebviewUri.mock.calls) {
+      const uri = call[0] as Uri
+      expect(uri.path).toContain('/some/other/ext-root')
+    }
+  })
+})

--- a/apps/vscode/test/vscode-mock.ts
+++ b/apps/vscode/test/vscode-mock.ts
@@ -8,36 +8,78 @@
  */
 import { vi } from 'vitest'
 
+/**
+ * Real vscode.Uri serializes with `://` for hierarchical schemes (file, http,
+ * https, vscode-remote, ...) and with `:` for opaque schemes (command,
+ * mailto, data, ...). We track the form on the instance so `parse('file:///x')`
+ * round-trips back to `file:///x` even though its authority is empty.
+ */
+const HIERARCHICAL_SCHEMES = new Set([
+  'file',
+  'http',
+  'https',
+  'ftp',
+  'vscode-remote',
+  'vscode-webview',
+  'vscode-userdata',
+])
+
 export class Uri {
-  constructor(public scheme: string, public authority: string, public path: string) {}
+  constructor(
+    public scheme: string,
+    public authority: string,
+    public path: string,
+    public query: string = '',
+    private readonly _hierarchical: boolean = HIERARCHICAL_SCHEMES.has(scheme) || authority !== '',
+  ) {}
 
   static parse(value: string): Uri {
-    const match = value.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\/([^/?#]*)(\/[^?#]*)?/)
-    if (match) {
-      return new Uri(match[1], match[2] ?? '', match[3] ?? '/')
+    // Authority-style URIs: <scheme>://<authority><path>?<query>
+    const authorityMatch = value.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\/([^/?#]*)([^?#]*)(?:\?([^#]*))?/)
+    if (authorityMatch) {
+      return new Uri(
+        authorityMatch[1],
+        authorityMatch[2] ?? '',
+        authorityMatch[3] || '/',
+        authorityMatch[4] ?? '',
+        true, // explicit authority form
+      )
     }
-    return new Uri('file', '', value)
+    // Opaque-scheme URIs (no //): <scheme>:<path>?<query>.
+    // Real vscode's `command:foo?args` parses this way: scheme=command,
+    // authority='', path='foo', query='args'.
+    const opaqueMatch = value.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):([^?#]*)(?:\?([^#]*))?/)
+    if (opaqueMatch) {
+      return new Uri(opaqueMatch[1], '', opaqueMatch[2] ?? '', opaqueMatch[3] ?? '', false)
+    }
+    return new Uri('file', '', value, '', true)
   }
 
   static file(p: string): Uri {
-    return new Uri('file', '', p)
+    return new Uri('file', '', p, '', true)
   }
 
   static joinPath(base: Uri, ...parts: string[]): Uri {
     const tail = parts.join('/').replace(/^\/+/, '')
     const joined = `${base.path.replace(/\/+$/, '')}/${tail}`.replace(/\/{2,}/g, '/')
-    return new Uri(base.scheme, base.authority, joined || '/')
+    return new Uri(base.scheme, base.authority, joined || '/', base.query, base._hierarchical)
   }
 
   toString(): string {
-    return `${this.scheme}://${this.authority}${this.path}`
+    const tail = this.query ? `?${this.query}` : ''
+    if (this._hierarchical) {
+      return `${this.scheme}://${this.authority}${this.path}${tail}`
+    }
+    return `${this.scheme}:${this.path}${tail}`
   }
 
-  with(props: { scheme?: string; authority?: string; path?: string }): Uri {
+  with(props: { scheme?: string; authority?: string; path?: string; query?: string }): Uri {
     return new Uri(
       props.scheme ?? this.scheme,
       props.authority ?? this.authority,
       props.path ?? this.path,
+      props.query ?? this.query,
+      this._hierarchical,
     )
   }
 }

--- a/apps/vscode/test/vscode-mock.ts
+++ b/apps/vscode/test/vscode-mock.ts
@@ -59,6 +59,62 @@ export const window = {
 
 export const ViewColumn = { One: 1 }
 
+/**
+ * Disposable: matches vscode.Disposable shape — just a `dispose()` method.
+ * dispose.ts uses an array of these to register/release resources.
+ */
+export interface Disposable {
+  dispose(): unknown
+}
+
+/**
+ * EventEmitter stub: matches vscode.EventEmitter<T>'s API surface used in src.
+ * Tracks listeners; `event` returns a subscribe function; `fire()` invokes them.
+ */
+export class EventEmitter<T> {
+  private listeners = new Set<(e: T) => unknown>()
+
+  event = (listener: (e: T) => unknown): Disposable => {
+    this.listeners.add(listener)
+    return { dispose: () => this.listeners.delete(listener) }
+  }
+
+  fire(data: T): void {
+    for (const l of this.listeners) l(data)
+  }
+
+  dispose(): void {
+    this.listeners.clear()
+  }
+}
+
+/** Position: minimal stand-in for vscode.Position used by HoverProvider tests. */
+export class Position {
+  constructor(public line: number, public character: number) {}
+}
+
+/** Range: minimal stand-in for vscode.Range. */
+export class Range {
+  constructor(public start: Position, public end: Position) {}
+}
+
+/**
+ * MarkdownString: vscode.MarkdownString — wraps content; `isTrusted` enables
+ * command links. We only assert on `.value` and `.isTrusted` in tests.
+ */
+export class MarkdownString {
+  isTrusted = false
+  constructor(public value: string) {}
+}
+
+/** Hover: vscode.Hover — wraps a MarkdownString contents array. */
+export class Hover {
+  contents: (MarkdownString | string)[]
+  constructor(contents: MarkdownString | string | (MarkdownString | string)[]) {
+    this.contents = Array.isArray(contents) ? contents : [contents]
+  }
+}
+
 /** Reset all mutable state between tests. */
 export function __resetMock() {
   workspace.workspaceFolders = undefined

--- a/packages/niivue-react/src/test/keyboardShortcuts.test.ts
+++ b/packages/niivue-react/src/test/keyboardShortcuts.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import type { KeyboardShortcut } from '../constants/keyboardShortcuts'
+import { matchesShortcut } from '../constants/keyboardShortcuts'
+
+/** Build a KeyboardEvent-shaped object — only the four fields matchesShortcut inspects. */
+function evt(opts: { key: string; ctrl?: boolean; meta?: boolean; shift?: boolean; alt?: boolean }) {
+  return {
+    key: opts.key,
+    ctrlKey: !!opts.ctrl,
+    metaKey: !!opts.meta,
+    shiftKey: !!opts.shift,
+    altKey: !!opts.alt,
+  } as unknown as KeyboardEvent
+}
+
+const bareA: KeyboardShortcut = { key: 'a', description: 'a' }
+const ctrlS: KeyboardShortcut = { key: 's', ctrl: true, description: 'save' }
+const ctrlShiftP: KeyboardShortcut = { key: 'p', ctrl: true, shift: true, description: 'palette' }
+const altF: KeyboardShortcut = { key: 'f', alt: true, description: 'file' }
+const arrow: KeyboardShortcut = { key: 'ArrowRight', description: 'right' }
+
+describe('matchesShortcut', () => {
+  it('matches a bare key', () => {
+    expect(matchesShortcut(evt({ key: 'a' }), bareA)).toBe(true)
+  })
+
+  it('does not match a different key', () => {
+    expect(matchesShortcut(evt({ key: 'b' }), bareA)).toBe(false)
+  })
+
+  it('matches case-insensitively on the key', () => {
+    expect(matchesShortcut(evt({ key: 'A' }), bareA)).toBe(true)
+  })
+
+  it('does not match when extra modifier is held (bare shortcut, ctrl pressed)', () => {
+    expect(matchesShortcut(evt({ key: 'a', ctrl: true }), bareA)).toBe(false)
+  })
+
+  it('matches Ctrl+S', () => {
+    expect(matchesShortcut(evt({ key: 's', ctrl: true }), ctrlS)).toBe(true)
+  })
+
+  it('treats metaKey as equivalent to ctrlKey (Mac compatibility)', () => {
+    expect(matchesShortcut(evt({ key: 's', meta: true }), ctrlS)).toBe(true)
+  })
+
+  it('does not match Ctrl+S when ctrl is not held', () => {
+    expect(matchesShortcut(evt({ key: 's' }), ctrlS)).toBe(false)
+  })
+
+  it('matches Ctrl+Shift+P', () => {
+    expect(matchesShortcut(evt({ key: 'p', ctrl: true, shift: true }), ctrlShiftP)).toBe(true)
+  })
+
+  it('does not match Ctrl+Shift+P when shift is missing', () => {
+    expect(matchesShortcut(evt({ key: 'p', ctrl: true }), ctrlShiftP)).toBe(false)
+  })
+
+  it('matches Alt+F', () => {
+    expect(matchesShortcut(evt({ key: 'f', alt: true }), altF)).toBe(true)
+  })
+
+  it('does not match Alt+F when Ctrl is also held (extra modifier)', () => {
+    expect(matchesShortcut(evt({ key: 'f', alt: true, ctrl: true }), altF)).toBe(false)
+  })
+
+  it('matches named keys like ArrowRight', () => {
+    expect(matchesShortcut(evt({ key: 'ArrowRight' }), arrow)).toBe(true)
+  })
+})

--- a/packages/niivue-react/src/test/readyState.test.ts
+++ b/packages/niivue-react/src/test/readyState.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * readyStateManager is a module-level singleton, so importing it after setting
+ * up window.vscode would still hand us a fresh state machine. But we don't
+ * want one test's writes (.eventListenerReady = true) to leak into the next.
+ * Solution: reset module state by re-importing via vi.resetModules() per test.
+ */
+
+beforeEach(() => {
+  vi.resetModules()
+  // The module checks window.vscode at message-send time, so we set it before importing.
+  ;(globalThis as any).window = { vscode: { postMessage: vi.fn() } }
+})
+
+afterEach(() => {
+  delete (globalThis as any).window
+})
+
+async function freshManager() {
+  const mod = await import('../readyState')
+  return mod.readyStateManager
+}
+
+describe('ReadyStateManager', () => {
+  it('does not send when only DOM is ready', async () => {
+    const mgr = await freshManager()
+    mgr.setDomReady()
+    expect((globalThis as any).window.vscode.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('does not send when only the event listener is ready', async () => {
+    const mgr = await freshManager()
+    mgr.setEventListenerReady()
+    expect((globalThis as any).window.vscode.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('sends exactly once when both are ready (DOM first)', async () => {
+    const mgr = await freshManager()
+    mgr.setDomReady()
+    mgr.setEventListenerReady()
+    expect((globalThis as any).window.vscode.postMessage).toHaveBeenCalledTimes(1)
+    expect((globalThis as any).window.vscode.postMessage).toHaveBeenCalledWith({ type: 'ready' })
+  })
+
+  it('sends exactly once when both are ready (listener first)', async () => {
+    const mgr = await freshManager()
+    mgr.setEventListenerReady()
+    mgr.setDomReady()
+    expect((globalThis as any).window.vscode.postMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('is idempotent — re-asserting readiness does not re-send', async () => {
+    const mgr = await freshManager()
+    mgr.setDomReady()
+    mgr.setEventListenerReady()
+    mgr.setDomReady()
+    mgr.setEventListenerReady()
+    expect((globalThis as any).window.vscode.postMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('no-ops when window.vscode is not present (running outside the webview)', async () => {
+    ;(globalThis as any).window = {}
+    const mgr = await freshManager()
+    expect(() => {
+      mgr.setDomReady()
+      mgr.setEventListenerReady()
+    }).not.toThrow()
+  })
+})

--- a/packages/niivue-react/src/test/readyState.test.ts
+++ b/packages/niivue-react/src/test/readyState.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
- * readyStateManager is a module-level singleton, so importing it after setting
- * up window.vscode would still hand us a fresh state machine. But we don't
- * want one test's writes (.eventListenerReady = true) to leak into the next.
- * Solution: reset module state by re-importing via vi.resetModules() per test.
+ * `readyStateManager` is a module-level singleton: once imported, the same
+ * instance is reused across imports for the lifetime of the module cache.
+ * Without intervention, one test's mutations (`.eventListenerReady = true`)
+ * would leak into the next. `vi.resetModules()` clears the module cache so
+ * the next `import('../readyState')` re-evaluates the module and constructs
+ * a fresh instance.
  */
 
 beforeEach(() => {

--- a/packages/niivue-react/src/test/utility.test.ts
+++ b/packages/niivue-react/src/test/utility.test.ts
@@ -2,25 +2,29 @@ import { describe, expect, it } from 'vitest'
 import { getMetadataString, getNames, getNumberOfPoints, isImageType } from '../utility'
 
 describe('isImageType', () => {
+  // The function returns the matched extension string when supported, or
+  // `undefined` otherwise. Assert the exact return value, not just truthiness,
+  // so a regression that detects "yes it's an image" but returns the wrong
+  // extension would still fail.
   it.each([
-    'scan.nii',
-    'scan.nii.gz',
-    'data.dcm',
-    'image.mha',
-    'image.mhd',
-    'image.nhdr',
-    'image.nrrd',
-    'image.mgh',
-    'image.mgz',
-    'image.npy',
-    'image.npz',
-    'image.v',
-    'image.v16',
-    'image.vmr',
-    'image.mnc',
-    'image.mnc.gz',
-  ])('returns the matched extension for %s', (name) => {
-    expect(isImageType(name)).toBeTruthy()
+    ['scan.nii', '.nii'],
+    ['scan.nii.gz', '.nii.gz'],
+    ['data.dcm', '.dcm'],
+    ['image.mha', '.mha'],
+    ['image.mhd', '.mhd'],
+    ['image.nhdr', '.nhdr'],
+    ['image.nrrd', '.nrrd'],
+    ['image.mgh', '.mgh'],
+    ['image.mgz', '.mgz'],
+    ['image.npy', '.npy'],
+    ['image.npz', '.npz'],
+    ['image.v', '.v'],
+    ['image.v16', '.v16'],
+    ['image.vmr', '.vmr'],
+    ['image.mnc', '.mnc'],
+    ['image.mnc.gz', '.mnc.gz'],
+  ])('returns %s for %s', (name, expected) => {
+    expect(isImageType(name)).toBe(expected)
   })
 
   it('returns undefined for unsupported types', () => {
@@ -31,7 +35,7 @@ describe('isImageType', () => {
 
   it('matches case-sensitively (matches src behavior — extensions are lowercase)', () => {
     expect(isImageType('scan.NII.GZ')).toBeUndefined()
-    expect(isImageType('scan.nii.gz')).toBeTruthy()
+    expect(isImageType('scan.nii.gz')).toBe('.nii.gz')
   })
 
   it('preserves preceding path components — only inspects the suffix', () => {

--- a/packages/niivue-react/src/test/utility.test.ts
+++ b/packages/niivue-react/src/test/utility.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import { getMetadataString, getNames, getNumberOfPoints, isImageType } from '../utility'
+
+describe('isImageType', () => {
+  it.each([
+    'scan.nii',
+    'scan.nii.gz',
+    'data.dcm',
+    'image.mha',
+    'image.mhd',
+    'image.nhdr',
+    'image.nrrd',
+    'image.mgh',
+    'image.mgz',
+    'image.npy',
+    'image.npz',
+    'image.v',
+    'image.v16',
+    'image.vmr',
+    'image.mnc',
+    'image.mnc.gz',
+  ])('returns the matched extension for %s', (name) => {
+    expect(isImageType(name)).toBeTruthy()
+  })
+
+  it('returns undefined for unsupported types', () => {
+    expect(isImageType('scan.png')).toBeUndefined()
+    expect(isImageType('readme.md')).toBeUndefined()
+    expect(isImageType('plain')).toBeUndefined()
+  })
+
+  it('matches case-sensitively (matches src behavior — extensions are lowercase)', () => {
+    expect(isImageType('scan.NII.GZ')).toBeUndefined()
+    expect(isImageType('scan.nii.gz')).toBeTruthy()
+  })
+
+  it('preserves preceding path components — only inspects the suffix', () => {
+    expect(isImageType('/some/path/scan.nii.gz')).toBe('.nii.gz')
+    expect(isImageType('http://host/img.nrrd')).toBe('.nrrd')
+  })
+})
+
+describe('getMetadataString', () => {
+  function nv(volumes: { nx: number; ny: number; nz: number; dx: number; dy: number; dz: number; nt: number }[]) {
+    return {
+      volumes: volumes.map((meta) => ({ getImageMetadata: () => meta })),
+    } as any
+  }
+
+  it('returns empty string when no volume is loaded', () => {
+    expect(getMetadataString({ volumes: [] } as any)).toBe('')
+  })
+
+  it('returns empty string when nv is undefined', () => {
+    expect(getMetadataString(undefined as any)).toBe('')
+  })
+
+  it('returns empty string when metadata has no nx (uninitialized volume)', () => {
+    const stub = { volumes: [{ getImageMetadata: () => ({}) }] } as any
+    expect(getMetadataString(stub)).toBe('')
+  })
+
+  it('formats matrix and voxel size for a 3D image', () => {
+    const s = getMetadataString(nv([{ nx: 192, ny: 256, nz: 256, dx: 1, dy: 1, dz: 1, nt: 1 }]))
+    expect(s).toBe('matrix size: 192 x 256 x 256, voxelsize: 1.0 x 1.0 x 1.0')
+  })
+
+  it('appends timepoints for a 4D image', () => {
+    const s = getMetadataString(nv([{ nx: 64, ny: 64, nz: 36, dx: 3, dy: 3, dz: 3, nt: 120 }]))
+    expect(s).toContain('matrix size: 64 x 64 x 36')
+    expect(s).toContain('voxelsize: 3.0 x 3.0 x 3.0')
+    expect(s).toContain('timepoints: 120')
+  })
+
+  it('uses precision-2 formatting for sub-mm voxels', () => {
+    const s = getMetadataString(nv([{ nx: 1, ny: 1, nz: 1, dx: 0.7, dy: 0.7, dz: 0.7, nt: 1 }]))
+    expect(s).toContain('voxelsize: 0.70 x 0.70 x 0.70')
+  })
+})
+
+describe('getNumberOfPoints', () => {
+  it('returns the per-vertex point count (pts.length / 3)', () => {
+    const nv = { meshes: [{ pts: new Array(30) }] } as any
+    expect(getNumberOfPoints(nv)).toBe('Number of Points: 10')
+  })
+
+  it('handles zero-length point arrays', () => {
+    const nv = { meshes: [{ pts: [] }] } as any
+    expect(getNumberOfPoints(nv)).toBe('Number of Points: 0')
+  })
+})
+
+describe('getNames', () => {
+  // The source treats each `item` as a Niivue instance with `volumes` and `meshes` arrays.
+  // We synthesize the minimum shape that getNames inspects.
+  const makeVol = (name: string) => ({ name })
+  const makeMesh = (name: string, layers: { name: string }[] = []) => ({ name, layers })
+  const makeNv = (volumes: { name: string }[] = [], meshes: ReturnType<typeof makeMesh>[] = []) =>
+    ({ volumes, meshes } as any)
+
+  it('returns base volume name for unique volumes', () => {
+    const nv1 = makeNv([makeVol('subject01.nii.gz')])
+    const nv2 = makeNv([makeVol('subject02.nii.gz')])
+    expect(getNames([nv1, nv2])).toEqual(['subject01.nii.gz', 'subject02.nii.gz'])
+  })
+
+  it('returns base mesh name when no volumes are present', () => {
+    const nv = makeNv([], [makeMesh('cortex.gii')])
+    expect(getNames([nv])).toEqual(['cortex.gii'])
+  })
+
+  it('returns empty string when neither volumes nor meshes are present', () => {
+    const nv = makeNv()
+    expect(getNames([nv])).toEqual([''])
+  })
+
+  it('decodes URI-encoded names', () => {
+    const nv = makeNv([makeVol('my%20scan.nii.gz')])
+    expect(getNames([nv])).toEqual(['my scan.nii.gz'])
+  })
+
+  it('on duplicate volume names, uses last overlay name to disambiguate', () => {
+    const nv1 = makeNv([makeVol('subj.nii.gz')])
+    const nv2 = makeNv([makeVol('subj.nii.gz'), makeVol('lesion-overlay.nii.gz')])
+    expect(getNames([nv1, nv2])).toEqual(['subj.nii.gz', 'lesion-overlay.nii.gz'])
+  })
+
+  it('on duplicate mesh names with layers, uses last layer name', () => {
+    const nv1 = makeNv([], [makeMesh('cortex.gii')])
+    const nv2 = makeNv([], [makeMesh('cortex.gii', [{ name: 'thickness.gii' }, { name: 'curv.gii' }])])
+    expect(getNames([nv1, nv2])).toEqual(['cortex.gii', 'curv.gii'])
+  })
+
+  it('falls back to mesh base name when duplicate mesh has no layers', () => {
+    const nv1 = makeNv([], [makeMesh('cortex.gii')])
+    const nv2 = makeNv([], [makeMesh('cortex.gii')])
+    // Both kept as the base name because there's no overlay to disambiguate.
+    expect(getNames([nv1, nv2])).toEqual(['cortex.gii', 'cortex.gii'])
+  })
+
+  it('falls back to uri when neither volumes nor meshes exist', () => {
+    const nv = { volumes: [], meshes: [], uri: 'http://example.org/scan.nii' } as any
+    expect(getNames([nv])).toEqual(['http://example.org/scan.nii'])
+  })
+})

--- a/packages/niivue-react/src/test/utility.test.ts
+++ b/packages/niivue-react/src/test/utility.test.ts
@@ -23,7 +23,7 @@ describe('isImageType', () => {
     ['image.vmr', '.vmr'],
     ['image.mnc', '.mnc'],
     ['image.mnc.gz', '.mnc.gz'],
-  ])('returns %s for %s', (name, expected) => {
+  ])('given %s, returns %s', (name, expected) => {
     expect(isImageType(name)).toBe(expected)
   })
 


### PR DESCRIPTION
## Summary

Three coverage easy wins, all surfaced from the published coverage table on PR #151 ([coverage/pr-151](https://niivue.github.io/niivue-vscode/coverage/pr-151/)), which showed `apps/jupyter` as `null` and `apps/vscode` at 7.8%.

| Change | Effect |
|---|---|
| Fix jupyter coverage download path in `ci.yml` | jupyter row: `null` → real number |
| Add `apps/vscode` tests (dispose, html, HoverProvider) | vscode: **7.8% → ~34%** statements |
| Add `packages/niivue-react` tests (utility, keyboardShortcuts, readyState) | shared-core: tighter coverage on small pure-function modules (utility 68%, readyState 100%, keyboardShortcuts 100%) |

**+94 new tests, all green locally.** Zero behavior changes — purely test-and-config additions.

## 1. Jupyter coverage download path

Root cause: the aggregator scans `**/coverage/**/*.json` for `coverage-final.json`. CI uploaded jupyter's coverage as a single-path artifact (which `actions/upload-artifact@v4` strips the parent of), then downloaded with `path: .`, landing files at the repo root with no `coverage/` segment — invisible to the aggregator.

Fix: download under `apps/jupyter/coverage/unit/` to restore the path segment — same pattern the VS Code download already uses (with a comment).

## 2. vscode tests (41 new)

- [`test/dispose.test.ts`](apps/vscode/test/dispose.test.ts) — 9 tests covering `disposeAll` LIFO order + `Disposable` class idempotency + post-dispose registration behavior.
- [`test/html.test.ts`](apps/vscode/test/html.test.ts) — 6 tests covering `getHtmlForWebview`: CSP is locked down (`default-src 'none'`, every source pinned to `webview.cspSource`, no wildcards), nonce is 32-char alphanumeric and unique per call, every `<script>` carries the same nonce as the CSP `script-src`, and assets route through the supplied `extensionUri`. **The "no wildcard sources" check is a deliberate security guardrail** — catches future accidental CSP loosening.
- [`test/HoverProvider.test.ts`](apps/vscode/test/HoverProvider.test.ts) — 26 tests covering all 17 supported file extensions (web URLs + local paths), case-insensitive matching, command-URI shape (`niiVue.openLink` vs `niiVue.openLocal`), `isTrusted` flag, and negative cases.

`test/vscode-mock.ts` extended with `Hover`, `MarkdownString`, `Position`, `Range`, `EventEmitter`, `Disposable` — the new tests' minimum required surface.

Per-file coverage after: `HoverProvider.ts` 100%, `dispose.ts` 100%, `html.ts` 100%.

## 3. shared-core tests (53 new)

- [`src/test/utility.test.ts`](packages/niivue-react/src/test/utility.test.ts) — 35 tests for `isImageType` (full extension matrix + case sensitivity + path-prefix handling), `getMetadataString` (empty/3D/4D/sub-mm voxel formatting), `getNumberOfPoints`, `getNames` (duplicate-name resolution with overlay/layer fallbacks, URI decoding, mesh-without-volumes path, fallback to `.uri`).
- [`src/test/keyboardShortcuts.test.ts`](packages/niivue-react/src/test/keyboardShortcuts.test.ts) — 12 tests for `matchesShortcut`: bare key, ctrl/shift/alt combinations, **meta-as-ctrl Mac compatibility**, case-insensitive key match, extra-modifier rejection, named keys (`ArrowRight`).
- [`src/test/readyState.test.ts`](packages/niivue-react/src/test/readyState.test.ts) — 6 tests for `ReadyStateManager`: send-once-when-both-ready (either order), idempotency under repeated readiness signals, safe no-op when `window.vscode` is absent.

## Why not bigger files?

[`events.ts`](packages/niivue-react/src/events.ts) (418 LOC), [`editorProvider.ts`](apps/vscode/src/editorProvider.ts) (343 LOC, already has 13 tests covering URL-vs-binary), [`viewer.ts`](apps/jupyter/src/viewer.ts) (505 LOC), and the big React components are not "easy wins" — they need a full extension test harness or significant refactoring to make their pure logic testable. Out of scope here.

## Test plan

- [ ] CI green (lint, typecheck, all per-app tests).
- [ ] Coverage Report sticky comment on this PR shows jupyter as a real number (not `null`).
- [ ] vscode row shows ~34% statements (up from 7.8%).
- [ ] Coverage delta vs `main` is positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)