### PR TITLE
feat(coverage): embed per-package summary at top of HTML report

### DIFF
--- a/scripts/coverage/aggregate.mjs
+++ b/scripts/coverage/aggregate.mjs
@@ -332,7 +332,90 @@ function buildMarkdownTable(summary, opts = {}) {
   return lines.join('\n')
 }
 
-function buildHtmlReport(mergedData) {
+/**
+ * Escape user-controlled strings before they go into HTML.
+ */
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[c])
+}
+
+/**
+ * BUCKETS labels are written as Markdown for the PR sticky comment — e.g.
+ * ``Shared core (`packages/niivue-react`)``. For the HTML report we want the
+ * backticked spans to render as `<code>` rather than literal backticks.
+ * Escape first (so any `<`/`>` in a future label is safe), then promote the
+ * surviving backtick pairs to `<code>` tags.
+ */
+function labelToHtml(label) {
+  return escapeHtml(label).replace(/`([^`]+)`/g, '<code>$1</code>')
+}
+
+/**
+ * Render the per-package summary table — same shape as the markdown table
+ * used in PR sticky comments — to embed at the top of the HTML report so
+ * visitors landing on the published page see headline numbers before the
+ * long per-file Istanbul table.
+ */
+function buildHtmlSummarySection(summary, baseline) {
+  const overall = summary._overall?.stats?.lines ?? null
+  const baseOverall = baseline?._overall?.stats?.lines ?? null
+
+  let anyStale = false
+  const rows = BUCKETS.map((b) => {
+    const s = summary[b.id]?.stats ?? {}
+    const baseStats = baseline?.[b.id]?.stats ?? {}
+    const cells = [
+      renderCell(s.statements ?? null, baseStats.statements ?? null),
+      renderCell(s.branches ?? null, baseStats.branches ?? null),
+      renderCell(s.functions ?? null, baseStats.functions ?? null),
+      renderCell(s.lines ?? null, baseStats.lines ?? null),
+    ]
+    if (cells.some((c) => c.stale)) anyStale = true
+    return `      <tr><td>${labelToHtml(b.label)}</td>${cells
+      .map((c) => `<td>${escapeHtml(c.text)}</td>`)
+      .join('')}</tr>`
+  }).join('\n')
+
+  const overallCell = renderCell(overall, baseOverall)
+  let overallLine = ''
+  if (overallCell.text !== 'N/A') {
+    if (overallCell.stale) anyStale = true
+    if (overall !== null) {
+      const delta = deltaStr(overall, baseOverall)
+      overallLine = `<p class="overall"><strong>Overall line coverage: ${pctStr(overall)}${
+        delta ? ` <span class="delta">${escapeHtml(delta.trim())} vs <code>main</code></span>` : ''
+      }</strong></p>`
+    } else {
+      overallLine = `<p class="overall"><strong>Overall line coverage: ${escapeHtml(overallCell.text)}</strong></p>`
+    }
+  }
+
+  const stalenote = anyStale
+    ? '<p class="stale-note"><em>* value carried over from <code>main</code> — this run did not produce coverage for that cell.</em></p>'
+    : ''
+
+  return `  <section class="summary">
+    <h2>Coverage by package</h2>
+    ${overallLine}
+    <table class="summary-table">
+      <thead>
+        <tr><th>Package</th><th>Statements</th><th>Branches</th><th>Functions</th><th>Lines</th></tr>
+      </thead>
+      <tbody>
+${rows}
+      </tbody>
+    </table>
+    ${stalenote}
+  </section>`
+}
+
+function buildHtmlReport(mergedData, summary, baseline) {
   const fileRows = Object.entries(mergedData)
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([file, cov]) => {
@@ -340,9 +423,11 @@ function buildHtmlReport(mergedData) {
       const stmtCovered = Object.values(cov.s).filter((c) => c > 0).length
       const pct = stmtTotal === 0 ? 'N/A' : `${Math.round((stmtCovered / stmtTotal) * 100)}%`
       const relPath = file.replace(repoRoot, '').replace(/^[\\/]/, '')
-      return `<tr><td>${relPath}</td><td>${pct} (${stmtCovered}/${stmtTotal})</td></tr>`
+      return `<tr><td>${escapeHtml(relPath)}</td><td>${pct} (${stmtCovered}/${stmtTotal})</td></tr>`
     })
     .join('\n')
+
+  const summarySection = summary ? buildHtmlSummarySection(summary, baseline) : ''
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -350,22 +435,37 @@ function buildHtmlReport(mergedData) {
   <meta charset="UTF-8" />
   <title>NiiVue Coverage Report</title>
   <style>
-    body { font-family: sans-serif; margin: 2rem; }
+    body { font-family: sans-serif; margin: 2rem; max-width: 60rem; }
+    h1 { margin-bottom: 0.25rem; }
+    .generated { color: #666; font-size: 0.85rem; margin: 0 0 1.5rem; }
+    section.summary { margin-bottom: 2.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid #ddd; }
+    section.summary h2 { margin-top: 0; }
+    p.overall { font-size: 1.05rem; }
+    .delta { color: #555; font-weight: normal; }
+    .stale-note { color: #666; font-size: 0.85rem; }
     table { border-collapse: collapse; width: 100%; }
     th, td { border: 1px solid #ccc; padding: 0.4rem 0.8rem; text-align: left; }
     th { background: #f4f4f4; }
     tr:nth-child(even) { background: #fafafa; }
+    table.summary-table td:not(:first-child),
+    table.summary-table th:not(:first-child) { text-align: right; }
+    h2.files-heading { margin-top: 0; }
+    code { background: #f4f4f4; padding: 0 0.25rem; border-radius: 3px; }
   </style>
 </head>
 <body>
   <h1>NiiVue Coverage Report</h1>
-  <p>Generated: ${new Date().toISOString()}</p>
-  <table>
-    <thead><tr><th>File</th><th>Statements</th></tr></thead>
-    <tbody>
+  <p class="generated">Generated: ${new Date().toISOString()}</p>
+${summarySection}
+  <section>
+    <h2 class="files-heading">Per-file coverage</h2>
+    <table>
+      <thead><tr><th>File</th><th>Statements</th></tr></thead>
+      <tbody>
 ${fileRows}
-    </tbody>
-  </table>
+      </tbody>
+    </table>
+  </section>
 </body>
 </html>
 `
@@ -417,7 +517,7 @@ async function main() {
   const badgeUrl = process.env.COVERAGE_BADGE_URL || null
 
   const markdownTable = buildMarkdownTable(summary, { baseline, reportUrl, badgeUrl })
-  const htmlReport = buildHtmlReport(mergedData)
+  const htmlReport = buildHtmlReport(mergedData, summary, baseline)
   const badgeJson = buildBadgeJson(summary)
 
   // Write outputs


### PR DESCRIPTION
## Summary

The published coverage report at [`/coverage/main/`](https://niivue.github.io/niivue-vscode/coverage/main/) currently shows only the Istanbul-style per-file table — ~50 rows of filenames + percentages with no quick "is this repo healthy?" signal at the top. The nicer per-package overview table exists, but only as a sidecar `summary.md` file (which nobody knows to look for) and inside PR sticky comments.

This PR embeds that same overview table at the top of the HTML report.

## What it looks like after merge

```
NiiVue Coverage Report
└─ Coverage by package
     Overall line coverage: 31.5% (−3.4 vs main)
     ┌─ Package ─────────────────────────┬─ Statements ─┬─ Branches ─┬─ Functions ─┬─ Lines ─┐
     │ Shared core (packages/niivue-react) │ 36.9%      │ 66.1%    │ 52.2%      │ 36.9% │
     │ apps/pwa                          │ 53.1%      │ 55%      │ 69.2%      │ 53.1% │
     │ apps/jupyter                      │ 10.1%      │ 86.7%    │ 100%       │ 10.1% │
     │ apps/streamlit                    │ 15.9%      │ 70.6%    │ 55.6%      │ 15.9% │
     │ apps/vscode                       │ 27.5%      │ 89.5%    │ 75%        │ 27.5% │
└─ Per-file coverage
     [unchanged Istanbul-style file table]
```

(Numbers from the current `main` summary — for illustration.)

## Implementation

Single file changed: [`scripts/coverage/aggregate.mjs`](scripts/coverage/aggregate.mjs).

- `buildHtmlReport(mergedData)` → `buildHtmlReport(mergedData, summary, baseline)`. `summary` is optional so the function still works for callers that only want the file table.
- New `buildHtmlSummarySection(summary, baseline)` mirrors `buildMarkdownTable`'s row/cell logic — same `renderCell`, `deltaStr`, `pctStr`, stale-cell handling — so the HTML and Markdown tables stay in lockstep. No divergence on what counts as N/A vs stale vs current.
- New `labelToHtml(label)` escapes HTML entities first, then promotes surviving markdown backticks (e.g., `` `apps/pwa` ``) to `<code>` tags. The `BUCKETS` labels are deliberately markdown for the PR comment; this lets the same labels render correctly in HTML.
- `escapeHtml(s)` defensively applied to the per-file path cells too (was previously interpolated raw — fine in practice, but the bar is "would never break with a future BUCKETS label change").
- Layout: 60rem max-width, divider between summary and per-file sections, right-aligned percentage columns in the summary table, `<code>` styling.

No change to `buildMarkdownTable`, `buildBadgeJson`, `summary.json`, or `summary.md` — the PR sticky comment and the shields badge are byte-identical.

## Activation

`workflow_run`-triggered `Coverage Report` only runs after a CI run that produced a `coverage-publish` artifact. The next push to `main` that touches `apps/*` or `packages/*` will regenerate the published page with the new HTML. To refresh sooner, a maintainer can manually dispatch the Coverage Report workflow against the latest CI run.

## Test plan

- [x] Verified locally by running the aggregator against local coverage data — HTML parses, summary section renders, backticks → `<code>`, per-file table follows below, no broken assets.
- [x] Code-review pass via subagent — no blockers, no behavioral divergence from the markdown rendering.
- [ ] After merge: confirm the next `/coverage/main/` deploy shows the new summary at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)