### PR TITLE
ci(deps): ignore @types/vscode in dependabot to preserve Win7/VS Code 1.70 support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,13 @@ updates:
       - dependency-name: '@niivue/niivue'
         update-types:
           - 'version-update:semver-major'
+      # @types/vscode is a backwards-compat floor, not a routine type update:
+      # per VS Code extension guidance it must be <= engines.vscode in
+      # apps/vscode/package.json, currently pinned to ^1.70.0 because 1.70 is
+      # the last VS Code release that runs on Windows 7. Bumping the types
+      # forces bumping the engine, which is a deliberate policy decision —
+      # not something to auto-PR. Bump manually when dropping Win7 support.
+      - dependency-name: '@types/vscode'
     groups:
       # Type definitions — almost always safe to batch
       types:


### PR DESCRIPTION
## Summary
- Add `@types/vscode` to the npm-group ignore list in `.github/dependabot.yml`.
- Per VS Code extension guidance, `@types/vscode` must be `<=` `engines.vscode`. `apps/vscode/package.json` pins `engines.vscode` to `^1.70.0` because **1.70 is the last VS Code release that runs on Windows 7**, so any types bump is effectively an engine-floor bump.
- This is a deliberate backwards-compat decision, not something to auto-PR. Bump manually when intentionally dropping Win7 support.

## Context
[PR #177](https://github.com/niivue/niivue-vscode/pull/177) is what surfaced this — Dependabot bundled three innocuous type bumps with `@types/vscode` 1.70.0 → 1.120.0. Once this lands, comment `@dependabot recreate` on #177 and it will come back as a clean types-only PR (without the `@types/vscode` row) that's safe to merge.

## Test plan
- [ ] Confirm CI passes (yaml-only change)
- [ ] After merge, comment `@dependabot recreate` on #177 and verify the recreated PR drops `@types/vscode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)