### PR TITLE
ci(deps): tighten dependabot pace and add minor/patch catch-all

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,12 +26,16 @@ updates:
           - '*'
 
   # npm / pnpm workspaces — root pnpm-lock.yaml covers apps/* and packages/*
+  # Keep open-pull-requests-limit low: every npm PR touches the shared
+  # pnpm-lock.yaml, so each merge forces every other open PR to rebase.
+  # Dependabot still tracks the full backlog and surfaces additional PRs
+  # as we merge — lowering the limit reduces churn, not coverage.
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
       day: 'monday'
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     versioning-strategy: 'increase-if-necessary'
     commit-message:
       prefix: 'chore'
@@ -131,6 +135,17 @@ updates:
       changesets:
         patterns:
           - '@changesets/*'
+      # Catch-all for the long tail of minor/patch bumps that don't belong
+      # to a tool-specific group. Folds quiet weekly updates (e.g. workbox-*,
+      # @testing-library/*, concurrent utility libs) into one PR so the
+      # 3-PR limit isn't wasted on individual minor bumps. Major bumps fall
+      # through and get their own PRs — which is what we want for bisecting.
+      minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
 
   # Python — Streamlit component (published to PyPI as niivue-streamlit)
   - package-ecosystem: 'pip'


### PR DESCRIPTION
## Summary
Every npm Dependabot PR rewrites the shared root `pnpm-lock.yaml`, so with `open-pull-requests-limit: 10` the open queue constantly invalidates itself — merging one forces all others to rebase and re-run CI. This was visible last week when 10 npm PRs went up Monday and we couldn't merge any of them without triggering a cascade.

Two changes to dial the noise down without losing coverage:

- **Drop `open-pull-requests-limit` 10 → 3 for the npm ecosystem.** Dependabot still tracks the full backlog; it just surfaces fewer PRs at once and opens the next as we merge. No updates are missed.
- **Add a `minor-and-patch` catch-all group** as the last entry under `groups:`. Folds the long tail of quiet minor/patch bumps (workbox-*, @testing-library/*, side-channel utility libs that don't belong to a tool-specific group) into one weekly PR. Major bumps fall through and get isolated PRs — which is what we want, since those are where bisecting matters.

`github-actions` (limit 5) and `pip` (limit 3) are untouched: low traffic, no shared lockfile pressure.

## Test plan
- [ ] CI passes (yaml-only change)
- [ ] Next Monday's auto-PRs: confirm at most 3 npm PRs open, and check whether a `minor-and-patch` group PR appears in place of several individual bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)