### PR TITLE
fix(jupyter): preserve caught error as cause in fetchArrayBuffer

### DIFF
--- a/apps/jupyter/src/url-utils.ts
+++ b/apps/jupyter/src/url-utils.ts
@@ -39,6 +39,7 @@ export async function fetchArrayBuffer(
   } catch (error) {
     throw new Error(
       `Request failed (${url}): ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
     )
   }
 

--- a/apps/jupyter/tsconfig.json
+++ b/apps/jupyter/tsconfig.json
@@ -18,6 +18,7 @@
     "sourceMap": true,
     "strictNullChecks": true,
     "target": "es2018",
+    "lib": ["ES2018", "ES2022.Error", "DOM", "DOM.Iterable"],
     "outDir": "lib",
     "rootDir": "src",
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- `fetchArrayBuffer` rethrew a wrapper `Error` without attaching the original error as `cause`, dropping the upstream stack trace. Adds `{ cause: error }`.
- Unblocks #197 (ESLint 10 upgrade) — ESLint 10 introduces the `preserve-caught-error` rule which flagged this exact line.

## Test plan
- [x] `pnpm --filter @niivue/jupyter run lint:eslint` passes locally (ESLint 9)
- [ ] After merge, rebase #197; the lint-and-typecheck step should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)