### PR TITLE
fix(coverage): synthesise overall from baseline for unmeasured buckets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Type check
         run: pnpm turbo type-check
 
+      - name: Coverage aggregator unit tests
+        run: pnpm coverage:report:test
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "changeset": "changeset",
     "version": "changeset version && node scripts/release/sync-pyproject-versions.mjs && pnpm install --no-frozen-lockfile",
     "release": "changeset publish",
-    "coverage:report": "node scripts/coverage/aggregate.mjs"
+    "coverage:report": "node scripts/coverage/aggregate.mjs",
+    "coverage:report:test": "node scripts/coverage/aggregate.test.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/scripts/coverage/aggregate.mjs
+++ b/scripts/coverage/aggregate.mjs
@@ -155,6 +155,10 @@ function mergeCoverageFinal(files) {
 // 4. Compute per-bucket percentages from merged Istanbul data
 // ---------------------------------------------------------------------------
 
+function pctOf(n) {
+  return n.total === 0 ? null : Math.round((n.covered / n.total) * 1000) / 10
+}
+
 function computeStats(istanbulData) {
   const totals = {
     statements: { covered: 0, total: 0 },
@@ -196,12 +200,22 @@ function computeStats(istanbulData) {
     totals.lines.covered += coveredLines.size
   }
 
-  const pct = (n) => (n.total === 0 ? null : Math.round((n.covered / n.total) * 1000) / 10)
   return {
-    statements: pct(totals.statements),
-    branches: pct(totals.branches),
-    functions: pct(totals.functions),
-    lines: pct(totals.lines),
+    // Percentages: the existing shape, kept for backward compatibility
+    // with consumers that only read `.stats.lines` etc.
+    stats: {
+      statements: pctOf(totals.statements),
+      branches: pctOf(totals.branches),
+      functions: pctOf(totals.functions),
+      lines: pctOf(totals.lines),
+    },
+    // Raw covered/total counts per metric. Persisted in summary.json so that
+    // a partial coverage run (only some apps' tests ran) can synthesise a
+    // honest overall by folding in baseline counts for the buckets this run
+    // didn't measure — see `synthesiseOverall` below. Without raw counts,
+    // the only thing we could compare is "this-run-mean" vs "baseline-mean",
+    // which mixes different denominators and produces large fake deltas.
+    counts: totals,
   }
 }
 
@@ -212,10 +226,69 @@ function bucketData(istanbulData) {
     for (const [key, value] of Object.entries(istanbulData)) {
       if (bucket.match(key)) subset[key] = value
     }
-    result[bucket.id] = { label: bucket.label, stats: computeStats(subset) }
+    const { stats, counts } = computeStats(subset)
+    result[bucket.id] = { label: bucket.label, stats, counts }
   }
-  result._overall = { label: 'Overall', stats: computeStats(istanbulData) }
+  const { stats, counts } = computeStats(istanbulData)
+  result._overall = { label: 'Overall', stats, counts }
   return result
+}
+
+/**
+ * Construct a fair overall for the current run by folding in baseline counts
+ * for any bucket this run did not measure. Without this, a PR that only ran
+ * one app's tests would emit an "overall" computed from that single app —
+ * misleadingly compared against main's whole-codebase overall (e.g. the
+ * desktop-only +50% delta that prompted this fix).
+ *
+ * Returns `{ stats, counts, partial }` where `partial` is true iff at least
+ * one bucket's counts came from the baseline rather than this run. Returns
+ * `null` if the baseline lacks per-bucket counts (old schema) — in that case
+ * the caller should suppress the delta.
+ */
+function synthesiseOverall(summary, baseline) {
+  if (!baseline) return null
+  // Detect old-schema baseline (percentages only, no counts): we can't
+  // synthesise without raw counts, so the caller falls back to the partial
+  // run's own overall (and suppresses the delta).
+  const baselineHasCounts = BUCKETS.some((b) => baseline[b.id]?.counts)
+  if (!baselineHasCounts) return null
+
+  const totals = {
+    statements: { covered: 0, total: 0 },
+    branches: { covered: 0, total: 0 },
+    functions: { covered: 0, total: 0 },
+    lines: { covered: 0, total: 0 },
+  }
+  let partial = false
+
+  for (const bucket of BUCKETS) {
+    const here = summary[bucket.id]?.counts
+    const ranThisTime = here && here.lines.total > 0
+    // Mark partial whenever this run skipped a bucket, regardless of whether
+    // the baseline could fill in for it. Without this, "summary measured one
+    // bucket, baseline also only knows about that one bucket" would emit a
+    // single-bucket overall *without* the partial disclosure — the exact
+    // misleading-overall problem this function exists to prevent.
+    if (!ranThisTime) partial = true
+    const source = ranThisTime ? here : baseline[bucket.id]?.counts
+    if (!source) continue
+    for (const metric of ['statements', 'branches', 'functions', 'lines']) {
+      totals[metric].covered += source[metric]?.covered ?? 0
+      totals[metric].total += source[metric]?.total ?? 0
+    }
+  }
+
+  return {
+    stats: {
+      statements: pctOf(totals.statements),
+      branches: pctOf(totals.branches),
+      functions: pctOf(totals.functions),
+      lines: pctOf(totals.lines),
+    },
+    counts: totals,
+    partial,
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -246,8 +319,12 @@ function badgeColor(pct) {
   return 'red'
 }
 
-function buildBadgeJson(summary) {
-  const overall = summary._overall?.stats?.lines
+function buildBadgeJson(summary, baseline = null) {
+  // Prefer the synthesised whole-codebase overall so the badge tracks
+  // codebase-wide coverage even on PRs that only ran one app's tests.
+  // Falls back to this run's bare overall when no baseline counts exist.
+  const synth = synthesiseOverall(summary, baseline)
+  const overall = synth ? synth.stats.lines : summary._overall?.stats?.lines
   return {
     schemaVersion: 1,
     label: 'coverage',
@@ -270,11 +347,51 @@ function renderCell(curr, prev) {
   return { text: 'N/A', stale: false }
 }
 
+/**
+ * Resolve the line coverage to display as "Overall" and the value to delta
+ * against the baseline. Three cases:
+ *
+ *   1. Full run + new-schema baseline → synthesis is a no-op (every bucket
+ *      ran here, so `source` is always `here`). Display this run's overall;
+ *      delta against baseline's overall.
+ *   2. Partial run + new-schema baseline → synthesis folds in baseline
+ *      counts for buckets that didn't run here, producing a "what would
+ *      the codebase overall be if only the parts we measured had changed?"
+ *      number. Apples-to-apples vs the baseline overall.
+ *   3. Partial run + old-schema baseline (no counts) → no honest comparison
+ *      possible. Display this run's overall, suppress the delta with a note.
+ */
+function resolveOverall(summary, baseline) {
+  const thisRun = summary._overall?.stats?.lines ?? null
+  const baseOverall = baseline?._overall?.stats?.lines ?? null
+  const synth = synthesiseOverall(summary, baseline)
+
+  if (synth) {
+    return {
+      display: synth.stats.lines,
+      deltaAgainst: baseOverall,
+      partial: synth.partial,
+      synthesised: synth.partial, // partial run that we patched up
+      deltaSuppressed: false,
+    }
+  }
+  // No new-schema baseline. If the current run is partial (any bucket
+  // missing), we can't honestly compare against main's full overall.
+  const isPartial = BUCKETS.some((b) => {
+    const c = summary[b.id]?.counts
+    return !c || c.lines.total === 0
+  })
+  return {
+    display: thisRun,
+    deltaAgainst: baseOverall,
+    partial: isPartial,
+    synthesised: false,
+    deltaSuppressed: isPartial,
+  }
+}
+
 function buildMarkdownTable(summary, opts = {}) {
   const { baseline = null, reportUrl = null, badgeUrl = null } = opts
-
-  const overall = summary._overall?.stats?.lines ?? null
-  const baseOverall = baseline?._overall?.stats?.lines ?? null
 
   let anyStale = false
   const rows = BUCKETS.map((b) => {
@@ -304,15 +421,18 @@ function buildMarkdownTable(summary, opts = {}) {
     lines.push('')
   }
 
-  const overallCell = renderCell(overall, baseOverall)
-  if (overallCell.text !== 'N/A') {
-    if (overallCell.stale) anyStale = true
-    if (overall !== null) {
-      const delta = deltaStr(overall, baseOverall)
-      lines.push(`**Overall line coverage: ${pctStr(overall)}${delta ? ` ${delta.trim()} vs \`main\`` : ''}**`)
-    } else {
-      lines.push(`**Overall line coverage: ${overallCell.text}**`)
-    }
+  const { display, deltaAgainst, synthesised, deltaSuppressed } = resolveOverall(summary, baseline)
+  if (display !== null) {
+    const delta = deltaSuppressed ? '' : deltaStr(display, deltaAgainst)
+    const suffix = deltaSuppressed
+      ? ' _(partial run — delta unavailable until baseline includes per-bucket counts)_'
+      : delta
+        ? ` ${delta.trim()} vs \`main\``
+        : ''
+    const note = synthesised
+      ? ' _(includes carried-over baseline for unmeasured packages)_'
+      : ''
+    lines.push(`**Overall line coverage: ${pctStr(display)}${suffix}${note}**`)
     lines.push('')
   }
 
@@ -363,9 +483,6 @@ function labelToHtml(label) {
  * long per-file Istanbul table.
  */
 function buildHtmlSummarySection(summary, baseline) {
-  const overall = summary._overall?.stats?.lines ?? null
-  const baseOverall = baseline?._overall?.stats?.lines ?? null
-
   let anyStale = false
   const rows = BUCKETS.map((b) => {
     const s = summary[b.id]?.stats ?? {}
@@ -382,18 +499,19 @@ function buildHtmlSummarySection(summary, baseline) {
       .join('')}</tr>`
   }).join('\n')
 
-  const overallCell = renderCell(overall, baseOverall)
+  const { display, deltaAgainst, synthesised, deltaSuppressed } = resolveOverall(summary, baseline)
   let overallLine = ''
-  if (overallCell.text !== 'N/A') {
-    if (overallCell.stale) anyStale = true
-    if (overall !== null) {
-      const delta = deltaStr(overall, baseOverall)
-      overallLine = `<p class="overall"><strong>Overall line coverage: ${pctStr(overall)}${
-        delta ? ` <span class="delta">${escapeHtml(delta.trim())} vs <code>main</code></span>` : ''
-      }</strong></p>`
-    } else {
-      overallLine = `<p class="overall"><strong>Overall line coverage: ${escapeHtml(overallCell.text)}</strong></p>`
-    }
+  if (display !== null) {
+    const delta = deltaSuppressed ? '' : deltaStr(display, deltaAgainst)
+    const suffix = deltaSuppressed
+      ? ' <span class="delta">(partial run — delta unavailable until baseline includes per-bucket counts)</span>'
+      : delta
+        ? ` <span class="delta">${escapeHtml(delta.trim())} vs <code>main</code></span>`
+        : ''
+    const note = synthesised
+      ? ' <span class="delta">(includes carried-over baseline for unmeasured packages)</span>'
+      : ''
+    overallLine = `<p class="overall"><strong>Overall line coverage: ${pctStr(display)}</strong>${suffix}${note}</p>`
   }
 
   const stalenote = anyStale
@@ -518,7 +636,7 @@ async function main() {
 
   const markdownTable = buildMarkdownTable(summary, { baseline, reportUrl, badgeUrl })
   const htmlReport = buildHtmlReport(mergedData, summary, baseline)
-  const badgeJson = buildBadgeJson(summary)
+  const badgeJson = buildBadgeJson(summary, baseline)
 
   // Write outputs
   const outDir = path.join(repoRoot, 'coverage')
@@ -538,7 +656,14 @@ async function main() {
   console.log(`   coverage/badge.json`)
 }
 
-main().catch((err) => {
-  console.error('❌ aggregate.mjs failed:', err)
-  process.exit(1)
-})
+// Run main() only when invoked as a script; importable for unit tests.
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error('❌ aggregate.mjs failed:', err)
+    process.exit(1)
+  })
+}
+
+// Exported for unit tests in aggregate.test.mjs.
+export { synthesiseOverall, resolveOverall, buildBadgeJson, buildMarkdownTable, computeStats, BUCKETS }

--- a/scripts/coverage/aggregate.test.mjs
+++ b/scripts/coverage/aggregate.test.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/**
+ * scripts/coverage/aggregate.test.mjs
+ *
+ * Unit tests for the overall + delta synthesis in aggregate.mjs.
+ *
+ * Runs standalone with `node`: no Vitest, no test runner — just node:assert
+ * with a tiny `test` shim. The aggregator is a one-off CI script with no
+ * test framework dependency, and adding one would mean pulling Vitest into
+ * the root package; not worth it for a few assertions.
+ *
+ *   node scripts/coverage/aggregate.test.mjs
+ *
+ * Bucket-agnostic: tests use BUCKETS[0] as the "this run measured" bucket
+ * and the rest as "from baseline", so the suite is unaffected by future
+ * BUCKETS additions or removals.
+ */
+import assert from 'node:assert/strict'
+import { synthesiseOverall, resolveOverall, buildBadgeJson, BUCKETS } from './aggregate.mjs'
+
+// The bucket-agnostic fixtures below assume BUCKETS has at least 2 entries
+// (one to mark "measured this run", at least one more to receive "filled
+// from baseline"). If the project layout ever collapses to a single bucket,
+// the tests should fail loudly rather than vacuously pass.
+assert.ok(BUCKETS.length >= 2, 'tests assume at least 2 buckets')
+
+let passed = 0
+let failed = 0
+
+function test(name, fn) {
+  try {
+    fn()
+    console.log(`  ✓ ${name}`)
+    passed++
+  } catch (err) {
+    console.log(`  ✗ ${name}`)
+    console.log(`    ${err.message}`)
+    failed++
+  }
+}
+
+const zeroCounts = () => ({
+  statements: { covered: 0, total: 0 },
+  branches: { covered: 0, total: 0 },
+  functions: { covered: 0, total: 0 },
+  lines: { covered: 0, total: 0 },
+})
+
+const pct = (n) => (n.total === 0 ? null : Math.round((n.covered / n.total) * 1000) / 10)
+
+// Build a summary stub matching what bucketData() produces.
+// `measured` maps bucket index → per-metric counts (only `lines` required;
+// others default to zero). Indices not present produce a zero-counts bucket.
+function summaryWith(measured, overallLines = null) {
+  const result = {}
+  for (let i = 0; i < BUCKETS.length; i++) {
+    const b = BUCKETS[i]
+    const m = measured[i]
+    const counts = zeroCounts()
+    if (m?.lines) counts.lines = m.lines
+    if (m?.statements) counts.statements = m.statements
+    if (m?.branches) counts.branches = m.branches
+    if (m?.functions) counts.functions = m.functions
+    result[b.id] = {
+      label: b.label,
+      stats: {
+        statements: pct(counts.statements),
+        branches: pct(counts.branches),
+        functions: pct(counts.functions),
+        lines: pct(counts.lines),
+      },
+      counts,
+    }
+  }
+  result._overall = {
+    label: 'Overall',
+    stats: { statements: null, branches: null, functions: null, lines: overallLines },
+    counts: zeroCounts(),
+  }
+  return result
+}
+
+// Same as summaryWith but omits `counts` everywhere — simulates an old-schema
+// baseline (the one currently deployed at niivue.github.io/.../coverage/main/).
+function legacySummary(measuredPctByIndex, overallLines = null) {
+  const result = {}
+  for (let i = 0; i < BUCKETS.length; i++) {
+    const b = BUCKETS[i]
+    result[b.id] = { label: b.label, stats: { lines: measuredPctByIndex[i] ?? null } }
+  }
+  result._overall = { label: 'Overall', stats: { lines: overallLines } }
+  return result
+}
+
+console.log('synthesiseOverall')
+
+test('returns null when there is no baseline', () => {
+  const summary = summaryWith({ 0: { lines: { covered: 43, total: 51 } } })
+  assert.equal(synthesiseOverall(summary, null), null)
+})
+
+test('returns null when baseline lacks per-bucket counts (old schema)', () => {
+  const summary = summaryWith({ 0: { lines: { covered: 43, total: 51 } } })
+  const baseline = legacySummary({ 0: 84.3 }, 33.8)
+  assert.equal(synthesiseOverall(summary, baseline), null)
+})
+
+test('folds baseline counts for unmeasured buckets, this run for measured', () => {
+  // This run measured bucket 0 only.
+  const summary = summaryWith({ 0: { lines: { covered: 43, total: 51 } } })
+  // Baseline: bucket 0 = 30/51, every other bucket = 50/100.
+  const baselineMeasured = { 0: { lines: { covered: 30, total: 51 } } }
+  let baselineOtherCovered = 0
+  let baselineOtherTotal = 0
+  for (let i = 1; i < BUCKETS.length; i++) {
+    baselineMeasured[i] = { lines: { covered: 50, total: 100 } }
+    baselineOtherCovered += 50
+    baselineOtherTotal += 100
+  }
+  const baseline = summaryWith(baselineMeasured)
+
+  const synth = synthesiseOverall(summary, baseline)
+  assert.equal(synth.partial, true)
+  // This run's bucket 0 (43/51) + baseline for the remaining N-1 buckets.
+  assert.equal(synth.counts.lines.covered, 43 + baselineOtherCovered)
+  assert.equal(synth.counts.lines.total, 51 + baselineOtherTotal)
+})
+
+test('partial = true when a bucket is missing from both this run AND baseline', () => {
+  // Regression for the case where, e.g., a new bucket was just added to
+  // BUCKETS in this PR but baseline (from a previous main run) doesn't
+  // know about it yet. Synthesis previously reported partial=false here,
+  // which suppressed the "carried-over" disclosure on the overall — i.e.
+  // the misleading-overall bug this function exists to prevent.
+  const summary = summaryWith({ 0: { lines: { covered: 43, total: 51 } } })
+  // Baseline knows about bucket 0 only.
+  const baseline = summaryWith({ 0: { lines: { covered: 30, total: 51 } } })
+  const synth = synthesiseOverall(summary, baseline)
+  assert.equal(synth.partial, true, 'should flag partial even when baseline has no data for skipped buckets')
+})
+
+test('partial = false when every bucket ran this time', () => {
+  const measured = {}
+  let totalCovered = 0
+  let totalLines = 0
+  for (let i = 0; i < BUCKETS.length; i++) {
+    measured[i] = { lines: { covered: 10 + i, total: 50 } }
+    totalCovered += 10 + i
+    totalLines += 50
+  }
+  const summary = summaryWith(measured)
+  // Baseline has different (stale) numbers — should be ignored when this run
+  // measured the same bucket.
+  const baseline = summaryWith({ 0: { lines: { covered: 1, total: 50 } } })
+
+  const synth = synthesiseOverall(summary, baseline)
+  assert.equal(synth.partial, false)
+  assert.equal(synth.counts.lines.covered, totalCovered)
+  assert.equal(synth.counts.lines.total, totalLines)
+})
+
+console.log('\nresolveOverall')
+
+test('partial run with new baseline → synthesised + apples-to-apples delta', () => {
+  const summary = summaryWith({ 0: { lines: { covered: 43, total: 51 } } })
+  // Baseline: bucket 0 was 30/51, others were 50/100 each.
+  const baselineMeasured = { 0: { lines: { covered: 30, total: 51 } } }
+  for (let i = 1; i < BUCKETS.length; i++) {
+    baselineMeasured[i] = { lines: { covered: 50, total: 100 } }
+  }
+  const baseline = summaryWith(baselineMeasured, 50.7)
+
+  const r = resolveOverall(summary, baseline)
+  assert.equal(r.synthesised, true)
+  assert.equal(r.deltaSuppressed, false)
+  // synth bumped 30→43 covered in a 51-total bucket; expect a small positive
+  // delta vs baseline's stored _overall (50.7).
+  assert.ok(r.display > 50 && r.display < 55, `expected ~51%, got ${r.display}`)
+  assert.equal(r.deltaAgainst, 50.7)
+})
+
+test('partial run with legacy baseline → delta suppressed, displays this run', () => {
+  const summary = summaryWith({ 0: { lines: { covered: 43, total: 51 } } })
+  summary._overall.stats.lines = 84.3
+  const baseline = legacySummary({ 0: 30 }, 33.8)
+  const r = resolveOverall(summary, baseline)
+  assert.equal(r.synthesised, false)
+  assert.equal(r.deltaSuppressed, true)
+  assert.equal(r.partial, true)
+  assert.equal(r.display, 84.3)
+})
+
+test('full run with legacy baseline → no synthesis, delta shown', () => {
+  const measured = {}
+  for (let i = 0; i < BUCKETS.length; i++) {
+    measured[i] = { lines: { covered: 30, total: 100 } }
+  }
+  const summary = summaryWith(measured)
+  summary._overall.stats.lines = 30.0
+  const baseline = legacySummary({}, 25.0)
+  const r = resolveOverall(summary, baseline)
+  assert.equal(r.synthesised, false)
+  assert.equal(r.deltaSuppressed, false)
+  assert.equal(r.partial, false)
+  assert.equal(r.display, 30.0)
+  assert.equal(r.deltaAgainst, 25.0)
+})
+
+console.log('\nbuildBadgeJson')
+
+test('badge uses synthesised value when baseline allows', () => {
+  const summary = summaryWith({ 0: { lines: { covered: 43, total: 51 } } })
+  summary._overall.stats.lines = 84.3 // bare partial-run value
+  const baselineMeasured = { 0: { lines: { covered: 30, total: 51 } } }
+  for (let i = 1; i < BUCKETS.length; i++) {
+    baselineMeasured[i] = { lines: { covered: 50, total: 100 } }
+  }
+  const baseline = summaryWith(baselineMeasured)
+  const badge = buildBadgeJson(summary, baseline)
+  // Should NOT be the misleading 84.3% — should be the synthesised whole-
+  // codebase number.
+  assert.notEqual(badge.message, '84.3%')
+  const value = Number(badge.message.replace('%', ''))
+  assert.ok(value > 40 && value < 60, `expected ~50%, got ${badge.message}`)
+})
+
+test('badge falls back to bare overall when no baseline counts available', () => {
+  const summary = summaryWith({ 0: { lines: { covered: 43, total: 51 } } })
+  summary._overall.stats.lines = 84.3
+  const baseline = legacySummary({}, 33.8)
+  const badge = buildBadgeJson(summary, baseline)
+  assert.equal(badge.message, '84.3%')
+})
+
+console.log(`\n${passed} passed, ${failed} failed`)
+process.exit(failed === 0 ? 0 : 1)


### PR DESCRIPTION
## Why

When a PR only runs tests for one app, the coverage aggregator's *Overall line coverage* delta was misleading. Concrete example from #146 (a desktop-only run):

> **Overall line coverage: 84.3% (+50.5) vs `main`**

That `+50.5` is comparing a desktop-only mean against main's whole-codebase mean. They have different denominators; the delta is meaningless. Same problem affects the coverage badge for the PR preview page.

## What

- Extend `computeStats` to also return raw `{covered, total}` counts per metric (not just percentages). Persist them in `summary.json` under each bucket as a new `counts` field.
- New `synthesiseOverall(summary, baseline)`: for each bucket, use this run's counts where measured, fall back to baseline's counts where not. Sum across buckets to get a fair "what would the codebase overall be if only the parts we measured changed" number.
- New `resolveOverall(summary, baseline)`: drives the three rendering cases — synthesis runs, synthesis runs and partial, or synthesis impossible (legacy baseline).
- Renderers (`buildMarkdownTable`, `buildHtmlSummarySection`, `buildBadgeJson`) all use the synthesised value when available.

## After/before in the rendered output

**Before** (partial run, the bug):

> Overall line coverage: 84.3% (+50.5) vs `main`

**After** (partial run + legacy baseline — the transitional state, see below):

> Overall line coverage: 84.3% _(partial run — delta unavailable until baseline includes per-bucket counts)_

**After** (partial run + new-schema baseline — the steady state):

> Overall line coverage: 45% (+3) vs `main` _(includes carried-over baseline for unmeasured packages)_

## Schema migration

The currently deployed baseline at niivue.github.io/niivue-vscode/coverage/main/summary.json predates this change and has no per-bucket counts. The first run of the new aggregator on main will publish a new-schema summary.json. PRs opened *before* that publish see the "delta unavailable" message; PRs opened *after* see the proper synthesis. Full runs (push to main, or PRs that touch every app) are unaffected throughout.

## Tests

- New `scripts/coverage/aggregate.test.mjs` (standalone `node:assert`, no Vitest dep) — 10 tests covering `synthesiseOverall`, `resolveOverall`, `buildBadgeJson` across the matrix of full/partial runs × new/legacy baselines, including the regression case where both this run AND the baseline are missing a bucket (e.g. when a new bucket was just added to BUCKETS in the same PR).
- Wired into the `lint-and-typecheck` CI job as `pnpm coverage:report:test` (<1s, runs on every PR).

## Files

- [scripts/coverage/aggregate.mjs](scripts/coverage/aggregate.mjs) — extended; CLI-only guard at bottom; exports added for testing.
- [scripts/coverage/aggregate.test.mjs](scripts/coverage/aggregate.test.mjs) — new.
- [.github/workflows/ci.yml](.github/workflows/ci.yml) — adds coverage aggregator test step.
- [package.json](package.json) — adds `coverage:report:test` script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)