### PR TITLE
fix(prerelease): derive next-stable from release plan, not snapshot mode

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -93,11 +93,15 @@ jobs:
         if: steps.detect.outputs.has_changesets == 'true'
         run: python -m pip install "jupyterlab>=4.0.0,<5" build twine
 
-      # Compute "what would the next stable be?" via changeset's snapshot
-      # mode (does not delete changeset files), then rewrite per-target.
-      - name: Compute snapshot versions
+      # Compute "what would the next stable be?" via `changeset status
+      # --output`, which writes a ReleasePlan JSON ({name, oldVersion,
+      # newVersion, type} per bumped package) without mutating any files.
+      # Snapshot mode is unsuitable here: by default it uses 0.0.0 as the
+      # base (not the calculated next-stable), so reading the bumped
+      # version back can't recover the intended pre-release base.
+      - name: Compute release plan
         if: steps.detect.outputs.has_changesets == 'true'
-        run: pnpm changeset version --snapshot beta
+        run: pnpm changeset status --output=changeset-status.json
 
       - name: Encode pre-release versions per target
         if: steps.detect.outputs.has_changesets == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ _version.py
 
 # Pre-release encoder transient output
 prerelease-targets.json
+changeset-status.json
 
 # Test artifacts
 test-results/

--- a/Release.md
+++ b/Release.md
@@ -72,7 +72,10 @@ Stable versions ship as-is — whatever changesets computed. No re-encoding is n
 
 ### How versions are computed
 
-The workflow uses Changesets' `--snapshot` mode to compute "what would the next stable be if I merged the version-packages PR right now?", then re-encodes that base version for each target:
+The workflow asks Changesets for the pending release plan via `pnpm changeset status --output=changeset-status.json` — that file lists `{name, oldVersion, newVersion, type}` for every package that would be bumped if the Version Packages PR merged right now. The encoder reads that plan and rewrites each affected app's manifest to the per-target format:
+
+> **Why not `changeset version --snapshot`?** Changesets' snapshot mode discards the next-stable computation and always writes `0.0.0-<tag>-<datetime>` as the base (see [changesets docs](https://github.com/changesets/changesets/blob/main/docs/snapshot-releases.md)). Driving the pre-release encoder off that string yielded `0.1.<run>` for VS Code (the only `niivue` pre-release that ever shipped under the broken path was `0.1.46` from PR #107). The `status --output` flow recovers the real next-stable and is also non-mutating, so the changeset files survive for the eventual stable release.
+
 
 | Target | Format | Example (next stable = `2.10.0`, run #42) |
 | --- | --- | --- |

--- a/scripts/release/encode-prerelease-versions.mjs
+++ b/scripts/release/encode-prerelease-versions.mjs
@@ -2,25 +2,25 @@
 /**
  * scripts/release/encode-prerelease-versions.mjs
  *
- * Post-processor for `pnpm changeset version --snapshot beta`. For each
- * published app whose package.json was bumped by changesets (detected by the
- * "-beta-<id>" suffix changesets writes), strip the suffix to recover the
- * intended next-stable version, then re-encode it for its target's version
- * format using the CI run number as the unique build identifier.
+ * Reads the changeset release plan (`changeset-status.json`, produced by
+ * `pnpm changeset status --output=...` in the prerelease workflow) and, for
+ * each published app whose package was bumped, rewrites package.json (and
+ * pyproject.toml where relevant) with the per-target pre-release version
+ * derived from the plan's `newVersion`.
  *
- * Packages NOT bumped by changesets are skipped — re-encoding their current
- * version as `<stable>.dev<run>` would produce a PEP 440 release that sorts
- * BELOW the already-published stable, which pip would happily install
- * downgrade-style for users on `--pre`.
+ * Packages NOT in the release plan are skipped — re-encoding their current
+ * version would produce a release that ranks ambiguously (e.g. PyPI dev
+ * releases sort below the matching stable, so pip --pre would happily
+ * "downgrade" a user back to the dev cycle of an already-shipped stable).
  *
  * Conventions:
  *   - VS Code Marketplace requires bare `M.m.p`. Pre-releases live on an
- *     odd minor strictly greater than the next-stable minor:
+ *     odd minor strictly greater than the next-stable's minor:
  *       next-stable 2.10.0 → pre 2.11.<run>
  *       next-stable 2.9.0  → pre 2.11.<run>   (skip same-minor collision)
  *   - PyPI requires PEP 440. We use `.devN` (development release) so plain
  *     `pip install <pkg>` ignores it; only `pip install --pre` picks it up.
- *     Next-stable 0.3.0 → 0.3.0.dev<run>.
+ *     Next-stable 0.3.1 → 0.3.1.dev<run>.
  *   - package.json holds a semver-compatible mirror (`<base>-dev.<run>`) so
  *     pnpm/turbo/changesets keep parsing the manifest. The authoritative
  *     PyPI version is written to pyproject.toml.
@@ -46,10 +46,14 @@ if (!runNumber || !/^\d+$/.test(runNumber)) {
   process.exit(1)
 }
 
-const SNAPSHOT_RE = /-beta-/
-
-const readPkg = (relPath) =>
-  JSON.parse(readFileSync(path.join(repoRoot, relPath), 'utf8'))
+const planPath = path.join(repoRoot, 'changeset-status.json')
+const plan = JSON.parse(readFileSync(planPath, 'utf8'))
+if (!Array.isArray(plan.releases)) {
+  throw new Error(
+    `${planPath}: expected \`releases\` array (changesets ReleasePlan); got ${typeof plan.releases}`,
+  )
+}
+const releases = new Map(plan.releases.map((r) => [r.name, r]))
 
 const writePkgVersion = (relPath, newVersion) => {
   const abs = path.join(repoRoot, relPath)
@@ -58,12 +62,6 @@ const writePkgVersion = (relPath, newVersion) => {
   writeFileSync(abs, JSON.stringify(pkg, null, 2) + '\n')
   console.log(`  ${relPath}: ${newVersion}`)
 }
-
-// Did `changeset version --snapshot beta` actually bump this package?
-// changesets only bumps packages that have a changeset directly or transitively.
-const wasBumped = (relPath) => SNAPSHOT_RE.test(readPkg(relPath).version)
-
-const stripSnapshot = (version) => version.replace(/-beta-.*$/, '')
 
 // Next odd minor STRICTLY greater than the next-stable's minor.
 //   even minor n → n+1   (n=8 → 9)
@@ -105,36 +103,44 @@ const overridePyprojectVersion = (relPath, devVersion) => {
 }
 
 console.log(`Encoding pre-release versions (run #${runNumber}):`)
+if (releases.size === 0) {
+  console.log('  release plan is empty; nothing to encode')
+}
+
+const nextStable = (pkgName) => releases.get(pkgName)?.newVersion
 
 const targets = { vscode: false, jupyter: false, streamlit: false }
 
 // ── VS Code extension ───────────────────────────────────────────────────────
-if (wasBumped('apps/vscode/package.json')) {
-  const nextStable = stripSnapshot(readPkg('apps/vscode/package.json').version)
-  writePkgVersion('apps/vscode/package.json', toVscodePreRelease(nextStable))
+const vscodeNext = nextStable('niivue')
+if (vscodeNext) {
+  writePkgVersion('apps/vscode/package.json', toVscodePreRelease(vscodeNext))
   targets.vscode = true
 } else {
-  console.log('  apps/vscode: no changeset bump, skipping')
+  console.log('  apps/vscode: not in release plan, skipping')
 }
 
 // ── JupyterLab extension ────────────────────────────────────────────────────
-if (wasBumped('apps/jupyter/package.json')) {
-  const nextStable = stripSnapshot(readPkg('apps/jupyter/package.json').version)
-  writePkgVersion('apps/jupyter/package.json', toSemverDev(nextStable))
-  overridePyprojectVersion('apps/jupyter/pyproject.toml', toPep440Dev(nextStable))
+const jupyterNext = nextStable('@niivue/jupyter')
+if (jupyterNext) {
+  writePkgVersion('apps/jupyter/package.json', toSemverDev(jupyterNext))
+  overridePyprojectVersion('apps/jupyter/pyproject.toml', toPep440Dev(jupyterNext))
   targets.jupyter = true
 } else {
-  console.log('  apps/jupyter: no changeset bump, skipping')
+  console.log('  apps/jupyter: not in release plan, skipping')
 }
 
 // ── Streamlit component ─────────────────────────────────────────────────────
-if (wasBumped('apps/streamlit/package.json')) {
-  const nextStable = stripSnapshot(readPkg('apps/streamlit/package.json').version)
-  writePkgVersion('apps/streamlit/package.json', toSemverDev(nextStable))
-  overridePyprojectVersion('apps/streamlit/pyproject.toml', toPep440Dev(nextStable))
+const streamlitNext = nextStable('@niivue/streamlit')
+if (streamlitNext) {
+  writePkgVersion('apps/streamlit/package.json', toSemverDev(streamlitNext))
+  overridePyprojectVersion(
+    'apps/streamlit/pyproject.toml',
+    toPep440Dev(streamlitNext),
+  )
   targets.streamlit = true
 } else {
-  console.log('  apps/streamlit: no changeset bump, skipping')
+  console.log('  apps/streamlit: not in release plan, skipping')
 }
 
 writeFileSync(


### PR DESCRIPTION
## Summary

The pre-release workflow has been emitting wrong version numbers since it went live. Each pre-release published `0.1.<run>` for VS Code and `0.0.0.dev<run>` for the PyPI wheels, instead of the intended `<next-stable-encoded>.<run>`.

It only became visible today: pre-releases 14-45 happened to bump only `@niivue/streamlit` (so the VSCE publish step was correctly gated off), and PR #107 was the first `niivue` changeset under the new workflow. That run published [`KorbinianEckstein.niivue@0.1.46`](https://marketplace.visualstudio.com/items?itemName=KorbinianEckstein.niivue) to the Marketplace and Open VSX.

## Root cause

`scripts/release/encode-prerelease-versions.mjs` was driven off `pnpm changeset version --snapshot beta` and assumed the resulting bumped version would be `<next-stable>-beta-<ts>` per package. Per the [changesets snapshot docs](https://github.com/changesets/changesets/blob/main/docs/snapshot-releases.md), snapshot mode uses `0.0.0` as the base by default - so `stripSnapshot()` always recovered `"0.0.0"`, and `toVscodePreRelease("0.0.0", 46)` returned `0.1.46`.

## Fix

Swap snapshot mode for `pnpm changeset status --output=changeset-status.json`, which writes a `ReleasePlan` JSON (`{name, oldVersion, newVersion, type}` per bumped package) without mutating any files. The encoder reads that plan and passes the real `newVersion` into the unchanged target-encoding functions. Packages not in the plan are skipped.

Dry-run on the current pending changesets and against synthesized "all apps bumped" plans produced the expected versions:

| App | Pending state | Result |
| --- | --- | --- |
| `niivue` (VS Code) | not bumped | skipped |
| `@niivue/jupyter` | not bumped | skipped |
| `@niivue/streamlit` | patch (0.3.0 → 0.3.1) | publishes `0.3.1.dev<run>` |

And in a hypothetical run where all three are bumped (vscode patch, jupyter patch, streamlit minor): `2.11.<run>` / `0.2.8.dev<run>` / `0.4.0.dev<run>`.

The encode math (odd-minor-strictly-greater for VSCE, `.devN` for PyPI) is unchanged - only the input is corrected.

## Out-of-scope manual cleanup

These need maintainer action through the respective registry UIs and aren't part of this PR:
- VS Code Marketplace + Open VSX: unlist `KorbinianEckstein.niivue@0.1.46`
- PyPI: yank `jupyterlab_niivue==0.0.0.dev46` and `niivue-streamlit==0.0.0.dev{21..46}` (PyPI does not allow republishing, so the slots stay burned, but yanked dev releases won't surface to `pip --pre` users).

## Test plan

- [x] Dry-run the encode script against a synthesized streamlit-only plan and confirm only `targets.streamlit` flips to true with `0.3.1.dev46`.
- [x] Dry-run against a synthesized all-apps plan and confirm `2.11.46` / `0.2.8.dev46` / `0.4.0.dev46`.
- [x] Confirm the jupyter `pyproject.toml` transform still strips `version` from `dynamic = [...]` and inserts a static `version = "..."` line.
- [ ] CI: prerelease workflow on this branch is push-to-main triggered, so it won't run until merge. Verify on the first post-merge push that the encoded versions are `2.11.<run>` / `0.<next>.dev<run>` rather than `0.1.<run>` / `0.0.0.dev<run>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)