### PR TITLE
refactor(desktop): rename desktop app to @niivue/tauri

### DIFF
--- a/.changeset/add-desktop-tauri-app.md
+++ b/.changeset/add-desktop-tauri-app.md
@@ -1,5 +1,5 @@
 ---
-"@niivue/desktop": minor
+"@niivue/tauri": minor
 ---
 
 Add Tauri-based standalone desktop application for NiiVue medical image viewing with native filesystem access, recent files management, and cross-platform release workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,7 @@ jobs:
           key: build-artifacts-${{ github.sha }}
 
       - name: Run Desktop vitest coverage
-        run: pnpm --filter=@niivue/desktop test:coverage
+        run: pnpm --filter=@niivue/tauri test:coverage
 
       - name: Upload Desktop vitest coverage artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -30,7 +30,7 @@ jobs:
   prerelease:
     name: Build and publish pre-releases
     runs-on: ubuntu-latest
-    # Exposed for the desktop job below: whether @niivue/desktop was bumped and
+    # Exposed for the desktop job below: whether @niivue/tauri was bumped and
     # the beta version to stamp into its cross-platform build.
     outputs:
       desktop: ${{ steps.encode.outputs.desktop }}
@@ -222,7 +222,7 @@ jobs:
   # ── Desktop (Tauri) ────────────────────────────────────────────────────────
   # The cross-platform Tauri installers (Linux/macOS/Windows) are built by the
   # reusable release_desktop.yml. It runs only when a changeset bumped
-  # @niivue/desktop, stamps the computed beta version into the manifests, and
+  # @niivue/tauri, stamps the computed beta version into the manifests, and
   # attaches the installers to the pre-release created above. Kept as a separate
   # job because the desktop build needs a platform matrix and Rust toolchains
   # the single-runner publish job above cannot provide.

--- a/.github/workflows/release-coordinator.yml
+++ b/.github/workflows/release-coordinator.yml
@@ -93,4 +93,4 @@ jobs:
           dispatch 'niivue'             release_vscode.yml
           dispatch '@niivue/jupyter'    release_jupyterlab.yml
           dispatch '@niivue/streamlit'  release_streamlit.yml
-          dispatch '@niivue/desktop'    release_desktop.yml
+          dispatch '@niivue/tauri'      release_desktop.yml

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -3,7 +3,7 @@ name: Release Desktop (Tauri)
 on:
   push:
     tags:
-      - '@niivue/desktop@*'
+      - '@niivue/tauri@*'
   workflow_dispatch:
   # Reusable entry point for the pre-release lane (prerelease.yml). When
   # `version` is set, the build stamps it into the manifests; when
@@ -95,7 +95,7 @@ jobs:
       # in the "Version Packages" PR; it never touches tauri.conf.json or
       # Cargo.toml, which `tauri build` reads for the bundle/installer version.
       # Derive the version from package.json and stamp all three so the built
-      # installer matches the @niivue/desktop@<version> tag this run was
+      # installer matches the @niivue/tauri@<version> tag this run was
       # dispatched for. Skipped on the pre-release lane (handled above). Uses
       # bash explicitly so the command substitution works on the Windows runner
       # too (its default shell is pwsh).
@@ -156,7 +156,7 @@ jobs:
       # Pre-release lane: attach the installers to the rolling pre-release
       # created by prerelease.yml (do NOT recreate it, so the release body
       # listing the other apps survives). Bundle filenames contain spaces
-      # ("NiiVue Desktop_..."), so collect them null-delimited. Only the
+      # ("NiiVue Tauri_..."), so collect them null-delimited. Only the
       # distributable installers are uploaded — the raw macOS `.app` bundle
       # directory is skipped.
       - name: Attach bundles to existing pre-release

--- a/Release.md
+++ b/Release.md
@@ -55,7 +55,7 @@ The Release Coordinator then:
 
    The per-app workflows also accept a matching tag push and `workflow_dispatch`, so a maintainer can manually trigger a re-release or hotfix without going through Release Coordinator.
 
-4. **The desktop app** (`release_desktop.yml`) is dispatched the same way when a `@niivue/desktop@<version>` tag is created, but instead of publishing to a registry it builds native installers with Tauri and attaches them to a GitHub Release created from the tag. One wrinkle: Tauri reads the bundle/installer version from `src-tauri/tauri.conf.json` (which overrides `Cargo.toml`), while changesets only bumps `apps/desktop-tauri/package.json` and never touches the Tauri manifests. So before `tauri build`, the stable lane re-stamps all three (`package.json`, `tauri.conf.json`, `Cargo.toml`) from `package.json`'s version via `scripts/release/set-desktop-version.mjs`, so the installer is labeled with the tagged version rather than whatever was last committed to `tauri.conf.json`. (The pre-release lane stamps the same three manifests, but from the explicit beta version `prerelease.yml` passes in via the `version` input; see [Pre-releases](#-pre-releases).)
+4. **The desktop app** (`release_desktop.yml`) is dispatched the same way when a `@niivue/tauri@<version>` tag is created, but instead of publishing to a registry it builds native installers with Tauri and attaches them to a GitHub Release created from the tag. One wrinkle: Tauri reads the bundle/installer version from `src-tauri/tauri.conf.json` (which overrides `Cargo.toml`), while changesets only bumps `apps/desktop-tauri/package.json` and never touches the Tauri manifests. So before `tauri build`, the stable lane re-stamps all three (`package.json`, `tauri.conf.json`, `Cargo.toml`) from `package.json`'s version via `scripts/release/set-desktop-version.mjs`, so the installer is labeled with the tagged version rather than whatever was last committed to `tauri.conf.json`. (The pre-release lane stamps the same three manifests, but from the explicit beta version `prerelease.yml` passes in via the `version` input; see [Pre-releases](#-pre-releases).)
 
 *(Note: The **PWA** is deployed to GitHub Pages directly from `main`, outside the tag workflow.)*
 
@@ -72,7 +72,7 @@ Stable versions ship as-is — whatever changesets computed. No re-encoding is n
 
 `.github/workflows/prerelease.yml` runs on a daily schedule (03:00 UTC) and, if there are pending changeset files, publishes a pre-release across all four published apps (VS Code, JupyterLab, Streamlit, and the Tauri desktop app). Running on a timer rather than on every push caps pre-releases at **one per day**, regardless of how many times `main` is pushed (frequent dependabot merges previously produced a beta each). **No manual flag, no mode switch, no remembering to merge anything** — and you can trigger the workflow manually (`workflow_dispatch`) to force an off-schedule beta.
 
-The desktop app is the exception to the "one workflow does everything" rule: because its installers need a per-OS build matrix and Rust toolchains, `prerelease.yml` delegates to the reusable `release_desktop.yml` (`workflow_call`) when a changeset bumped `@niivue/desktop`. That job stamps the computed beta version into the desktop manifests, builds the Linux/macOS/Windows installers, and attaches them to the same GitHub pre-release. The bundles land a few minutes after the rest, once the cross-platform build finishes.
+The desktop app is the exception to the "one workflow does everything" rule: because its installers need a per-OS build matrix and Rust toolchains, `prerelease.yml` delegates to the reusable `release_desktop.yml` (`workflow_call`) when a changeset bumped `@niivue/tauri`. That job stamps the computed beta version into the desktop manifests, builds the Linux/macOS/Windows installers, and attaches them to the same GitHub pre-release. The bundles land a few minutes after the rest, once the cross-platform build finishes.
 
 ### How versions are computed
 
@@ -116,7 +116,7 @@ For the **desktop app**, download the installer for your platform (`.dmg`, `.msi
 
 The workflow exits without publishing when any of:
 - There are no pending `.changeset/*.md` files at the scheduled run (e.g. right after the Version Packages PR was merged, or a day of doc-only commits that added no changeset).
-- For a given app: no changeset directly or transitively bumped it. Each app is published independently — a PWA-only changeset will not produce a new VS Code / Jupyter / Streamlit / desktop pre-release. The desktop installers only build when `@niivue/desktop` itself was bumped.
+- For a given app: no changeset directly or transitively bumped it. Each app is published independently — a PWA-only changeset will not produce a new VS Code / Jupyter / Streamlit / desktop pre-release. The desktop installers only build when `@niivue/tauri` itself was bumped.
 
 ### Cost model
 
@@ -128,7 +128,7 @@ Each pre-release burns one version slot on PyPI per affected package (PyPI does 
 
 Users would then need `--index-url https://test.pypi.org/simple/` when installing pre-releases.
 
-Desktop pre-releases burn no registry slots (the installers are just GitHub release assets), but each one runs a full four-platform Tauri build, so they only run on days a `@niivue/desktop` changeset is pending — not on every scheduled run.
+Desktop pre-releases burn no registry slots (the installers are just GitHub release assets), but each one runs a full four-platform Tauri build, so they only run on days a `@niivue/tauri` changeset is pending — not on every scheduled run.
 
 ---
 

--- a/apps/desktop-tauri/README.md
+++ b/apps/desktop-tauri/README.md
@@ -1,4 +1,4 @@
-# NiiVue Desktop
+# NiiVue Tauri
 
 A standalone desktop application for viewing medical images (NIfTI, DICOM, and more), built with [Tauri](https://tauri.app/) and the shared `@niivue/react` component library.
 
@@ -26,13 +26,13 @@ A standalone desktop application for viewing medical images (NIfTI, DICOM, and m
 pnpm install
 
 # Run in development mode (Vite dev server + Tauri window)
-pnpm --filter @niivue/desktop dev
+pnpm --filter @niivue/tauri dev
 ```
 
 ## Building
 
 ```bash
-pnpm --filter @niivue/desktop build
+pnpm --filter @niivue/tauri build
 # Output: src-tauri/target/release/bundle/
 ```
 
@@ -40,7 +40,7 @@ pnpm --filter @niivue/desktop build
 
 ```bash
 # TypeScript unit tests
-pnpm --filter @niivue/desktop test
+pnpm --filter @niivue/tauri test
 
 # Rust unit tests
 cd apps/desktop-tauri/src-tauri && cargo test
@@ -83,7 +83,7 @@ apps/desktop-tauri/
 
 ## Known limitations / planned work
 
-- **OS file association / CLI args** are not yet wired. Double-clicking a `.nii` file in Finder/Explorer or running `niivue-desktop /path/to/scan.nii` does not currently open the file in this app. Needs `tauri-plugin-single-instance` + `tauri-plugin-cli` integration.
+- **OS file association / CLI args** are not yet wired. Double-clicking a `.nii` file in Finder/Explorer or running `niivue-tauri /path/to/scan.nii` does not currently open the file in this app. Needs `tauri-plugin-single-instance` + `tauri-plugin-cli` integration.
 - **Recent files** are persisted to disk but there is no UI surface to re-open them yet. The plumbing is in place; the home-screen list is a follow-up.
 
 Both items are tracked as follow-up issues.

--- a/apps/desktop-tauri/index.html
+++ b/apps/desktop-tauri/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="NiiVue Desktop - Medical image viewer" />
-    <title>NiiVue Desktop</title>
+    <meta name="description" content="NiiVue Tauri - Medical image viewer" />
+    <title>NiiVue Tauri</title>
   </head>
 
   <body class="text-white p-0">

--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@niivue/desktop",
+  "name": "@niivue/tauri",
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "NiiVue Desktop - Tauri-based standalone medical image viewer",
+  "description": "NiiVue Tauri - standalone medical image viewer built with Tauri",
   "license": "BSD-2-Clause",
   "author": {
     "name": "Korbinian Eckstein",

--- a/apps/desktop-tauri/src-tauri/Cargo.lock
+++ b/apps/desktop-tauri/src-tauri/Cargo.lock
@@ -1804,7 +1804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
-name = "niivue-desktop"
+name = "niivue-tauri"
 version = "0.1.0"
 dependencies = [
  "serde",

--- a/apps/desktop-tauri/src-tauri/Cargo.toml
+++ b/apps/desktop-tauri/src-tauri/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "niivue-desktop"
+name = "niivue-tauri"
 version = "0.1.0"
-description = "NiiVue Desktop - Medical image viewer"
+description = "NiiVue Tauri - Medical image viewer"
 authors = ["Korbinian Eckstein <korbinian90@gmail.com>"]
 license = "BSD-2-Clause"
 repository = "https://github.com/niivue/niivue-vscode"
 edition = "2021"
 
 [lib]
-name = "niivue_desktop_lib"
+name = "niivue_tauri_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]

--- a/apps/desktop-tauri/src-tauri/capabilities/default.json
+++ b/apps/desktop-tauri/src-tauri/capabilities/default.json
@@ -1,6 +1,6 @@
 {
   "identifier": "default",
-  "description": "Default capability for NiiVue Desktop",
+  "description": "Default capability for NiiVue Tauri",
   "windows": ["main"],
   "permissions": [
     "core:default",

--- a/apps/desktop-tauri/src-tauri/src/main.rs
+++ b/apps/desktop-tauri/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    niivue_desktop_lib::run()
+    niivue_tauri_lib::run()
 }

--- a/apps/desktop-tauri/src-tauri/tauri.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
-  "productName": "NiiVue Desktop",
+  "productName": "NiiVue Tauri",
   "version": "0.1.0",
-  "identifier": "org.niivue.desktop",
+  "identifier": "org.niivue.tauri",
   "build": {
     "frontendDist": "../build",
     "devUrl": "http://localhost:4001",
@@ -11,7 +11,7 @@
   "app": {
     "windows": [
       {
-        "title": "NiiVue Desktop",
+        "title": "NiiVue Tauri",
         "width": 1280,
         "height": 800,
         "minWidth": 800,
@@ -39,7 +39,7 @@
     ],
     "category": "Medical",
     "shortDescription": "Medical image viewer for NIfTI and DICOM files",
-    "longDescription": "NiiVue Desktop is a high-performance medical image viewer built with Tauri and WebGL2. It supports NIfTI, DICOM, and many other neuroimaging formats with direct filesystem access for fast loading of large datasets.",
+    "longDescription": "NiiVue Tauri is a high-performance medical image viewer built with Tauri and WebGL2. It supports NIfTI, DICOM, and many other neuroimaging formats with direct filesystem access for fast loading of large datasets.",
     "linux": {
       "deb": {
         "depends": ["libwebkit2gtk-4.1-0", "libgtk-3-0"]

--- a/apps/desktop-tauri/src/components/DesktopHomeScreen.tsx
+++ b/apps/desktop-tauri/src/components/DesktopHomeScreen.tsx
@@ -60,7 +60,7 @@ export const DesktopHomeScreen = () => {
   return (
     <>
       <h2 className="text-2xl sm:text-3xl font-bold text-gray-200 p-2 px-4">
-        NiiVue Desktop
+        NiiVue Tauri
       </h2>
       <p className="w-full sm:w-96 mb-4 text-m font-normal text-gray-300 px-4">
         Open medical images from your local filesystem. Drag and drop files

--- a/scripts/release/encode-prerelease-versions.mjs
+++ b/scripts/release/encode-prerelease-versions.mjs
@@ -169,7 +169,7 @@ if (streamlitNext) {
 // prerelease.yml) with its own checkout, so we only COMPUTE the version here
 // and pass it through prerelease-targets.json; that workflow stamps the
 // manifests via set-desktop-version.mjs before building.
-const desktopNext = nextStable('@niivue/desktop')
+const desktopNext = nextStable('@niivue/tauri')
 if (desktopNext) {
   targets.desktop = true
   targets.desktopVersion = toDesktopPreRelease(desktopNext)


### PR DESCRIPTION
## Why

The Tauri-based desktop app was named **"NiiVue Desktop"** (`@niivue/desktop`), which is easily confused with the separate [niivue/niivue](https://github.com/niivue/niivue) **Electron** desktop app. This renames it to the Tauri-scoped name so the two are unambiguous.

## What changed

| Dimension | Before | After |
| --- | --- | --- |
| npm package | `@niivue/desktop` | `@niivue/tauri` |
| Cargo crate | `niivue-desktop` | `niivue-tauri` |
| Cargo lib | `niivue_desktop_lib` | `niivue_tauri_lib` |
| Bundle identifier | `org.niivue.desktop` | `org.niivue.tauri` |
| Product name / window title / descriptions | `NiiVue Desktop` | `NiiVue Tauri` |

Updated to match the new package name:
- Pending changeset (`.changeset/add-desktop-tauri-app.md`)
- Release tag trigger and dispatch (`release_desktop.yml`, `release-coordinator.yml`)
- Pre-release encoder (`encode-prerelease-versions.mjs`) and `prerelease.yml` comments
- CI coverage filter (`ci.yml`)
- Docs (`Release.md`, app `README.md`, `index.html`, home screen heading)

## What was intentionally kept

- **Folder** `apps/desktop-tauri/`: it already carries "tauri", and renaming it would churn every CI path, `.gitignore` entry, eslint glob, and coverage matcher for no brand benefit.
- **Internal pipeline identifiers**: the `release_desktop.yml` / `set-desktop-version.mjs` filenames, the `desktop` target key in `prerelease-targets.json`, and CI artifact/job names (`test-desktop`, `coverage-unit-desktop`). These are not user-facing and stay consistent with the folder name.
- **React component symbols** (`DesktopApp`, `DesktopHomeScreen`): internal code, never shown to users.

> **Note on the bundle identifier:** changing `org.niivue.desktop` to `org.niivue.tauri` means existing installs treat the renamed app as a separate application (no in-place auto-update). This is fine at v0.1.0 with limited distribution, but worth flagging explicitly.

## Verification

- `pnpm install`: workspace resolves, `pnpm-lock.yaml` unchanged
- `pnpm --filter @niivue/tauri test`: 22/22 pass
- `pnpm --filter @niivue/tauri type-check`: clean
- `cargo verify-project`: ok; `cargo metadata --offline` confirms `Cargo.lock` is consistent with the renamed crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
