### PR TITLE
ci(prerelease): skip daily beta when main is unchanged

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,10 +11,13 @@ name: Pre-release
 #   - PyPI:    <next-stable>.dev<run>          (PEP 440 development release)
 #
 # The job no-ops when there are no pending changesets (e.g. after a day of
-# doc-only commits), and also skips publish for any individual app that
-# changesets did not bump. Use the workflow_dispatch trigger to force an
-# off-schedule beta. Stable releases stay on the Release Coordinator path
-# (merge the "Version Packages" PR).
+# doc-only commits), when main has not advanced since the previous beta (a
+# commit already pre-released is recognised by its `prerelease-<sha>` tag, so
+# an unchanged main does not republish on the timer), and skips publish for
+# any individual app that changesets did not bump. Use the workflow_dispatch
+# trigger to force an off-schedule beta (it bypasses the unchanged-main check).
+# Stable releases stay on the Release Coordinator path (merge the "Version
+# Packages" PR).
 
 on:
   schedule:
@@ -47,9 +50,25 @@ jobs:
       # that satisfy the "every PR touching packages/apps needs a changeset"
       # rule without bumping a version) are skipped here too — they have no
       # package bumps so the pre-release would publish nothing.
-      - name: Detect pending changesets
+      - name: Detect whether a pre-release is needed
         id: detect
         run: |
+          # Scheduled runs fire daily against the latest commit on main, and
+          # each run stamps a fresh beta version from the run number. Without a
+          # guard a new beta would publish every day even when main has not
+          # moved since the previous beta (the "new release every day" bug).
+          # Each pre-release is tagged `prerelease-<sha>`, so if origin already
+          # has that tag for HEAD this exact commit was already pre-released and
+          # there is nothing new to ship. Only the schedule trigger is guarded;
+          # workflow_dispatch still force-publishes a beta on the same commit.
+          if [ "${{ github.event_name }}" = "schedule" ] \
+             && git ls-remote --exit-code --tags origin \
+                  "refs/tags/prerelease-${{ github.sha }}" >/dev/null; then
+            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
+            echo "Commit ${{ github.sha }} was already pre-released; skipping."
+            exit 0
+          fi
+
           shopt -s nullglob
           count=0
           for f in .changeset/*.md; do


### PR DESCRIPTION
## Problem

A new VS Code Marketplace beta was published **every single day**, even when `main` had not changed.

## Root cause

`prerelease.yml` runs on `cron: '0 3 * * *'` and gated the whole publish on one question: *"are there pending non-empty changesets in `.changeset/`?"* But changesets accumulate in `.changeset/` for the entire window between stable releases, so that's true every day. Each run stamps the version from `github.run_number`, so every daily run minted a new version and published it, regardless of whether anything actually changed.

The release history shows the symptom: `Pre-release 51 -> 52 -> 55` on consecutive calendar days, each a different scheduled run against an unchanged tree.

(Only `prerelease.yml` publishes on a timer. `release_vscode.yml` fires solely on `niivue@*` tag pushes; `release-coordinator.yml` only acts when the "Version Packages" PR merges.)

## Fix

Each beta is already tagged `prerelease-<sha>`. The `detect` step now skips on the schedule trigger when origin already has that tag for `HEAD` - meaning this exact commit was already pre-released, so there is nothing new to ship:

```bash
if [ "$github.event_name" = "schedule" ] \
   && git ls-remote --exit-code --tags origin \
        "refs/tags/prerelease-<sha>" >/dev/null; then
  echo "has_changesets=false" >> "$GITHUB_OUTPUT"
  exit 0
fi
```

- `main` must actually advance before another beta publishes - no more timer-driven republishes.
- `workflow_dispatch` is **exempt**, so a maintainer can still force an off-schedule beta on the same commit.
- `git ls-remote` queries origin directly (independent of `fetch-depth`); stderr stays visible so transient git failures surface in the logs instead of being swallowed.

The workflow header comment is updated to document the new no-op condition.

## Notes

- The next scheduled run after merge will publish one beta (this commit is genuinely new and has pending changesets); from then on an unchanged `main` skips.
- CI-only change, so no changeset (consistent with prior `ci(...)` commits; there is no changeset-required gate in `ci.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
