### PR TITLE
feat(dicom): detect extension-less DICOM and open full series from one file

### DIFF
--- a/.changeset/detect-extensionless-dicom.md
+++ b/.changeset/detect-extensionless-dicom.md
@@ -1,0 +1,28 @@
+---
+'@niivue/react': minor
+'niivue': minor
+'@niivue/pwa': patch
+'@niivue/streamlit': patch
+'@niivue/jupyter': patch
+'@niivue/tauri': patch
+---
+
+Detect extension-less DICOM files and open a whole series from one click.
+
+DICOM exports often have no extension (IM_0001) or a bare UID as the file
+name (1.2.840.113619...). These are now detected by content (the DICOM
+Part 10 magic: a 128-byte preamble followed by "DICM") instead of relying
+on the extension, and a single clicked DICOM file loads its entire series.
+
+- New `isDicomData()` helper exported from `@niivue/react`.
+- `loadVolume` content-sniffs payloads whose name matches no known format
+  and routes matches through the DICOM loader. Multi-file input
+  (`uri: string[]`) is now handled directly; previously an array URI threw
+  before reaching the DICOM path, which also broke PWA folder drop.
+- When dcm2niix returns more than one series (a folder with multiple
+  acquisitions), each additional series opens on its own canvas.
+- The VS Code extension expands a single opened DICOM file (by extension or
+  by content, including extension-less files opened via "NiiVue: Open") to
+  every DICOM file in its folder, so the full series loads together. The
+  "Open DICOM Folder" path now sends a correct file array (it previously
+  passed a single URI string alongside the data array).

--- a/apps/pwa/tests/Dicom.spec.ts
+++ b/apps/pwa/tests/Dicom.spec.ts
@@ -46,6 +46,67 @@ test.describe('Loading DICOM images', () => {
     expect(bodyText).not.toContain('failed')
   })
 
+  test('loads an extension-less DICOM file via magic-byte detection', async ({ page }) => {
+    // Scanner exports often have no extension (IM_0001) or a bare UID as the
+    // name. The viewer must detect DICOM content from the "DICM" magic bytes
+    // and route the file through the DICOM loader.
+    await page.goto(BASE_URL)
+
+    const dicomPath = path.join(__dirname, '..', 'test', 'assets', 'enh.dcm')
+    const dicomBuffer = fs.readFileSync(dicomPath)
+
+    const message = {
+      type: 'addImage',
+      body: {
+        data: Array.from(new Uint8Array(dicomBuffer)),
+        uri: 'IM_0001',
+      },
+    }
+
+    await page.evaluate((m) => window.postMessage(m, '*'), message)
+    await waitForImageLoad(page)
+
+    const canvases = await page.$$('canvas')
+    expect(canvases.length).toBeGreaterThanOrEqual(1)
+
+    await page.waitForTimeout(2000)
+
+    const bodyText = await page.textContent('body')
+    expect(bodyText).not.toContain('error')
+    expect(bodyText).not.toContain('failed')
+  })
+
+  test('loads a DICOM series passed as an array of files', async ({ page }) => {
+    // Multi-file series arrive as `uri: string[]` + `data: ArrayBuffer[]`
+    // (VS Code series expansion, PWA folder drop). This path previously threw
+    // because loadVolume called string methods on the array uri. dcm2niix
+    // assembles the array into one volume per series.
+    await page.goto(BASE_URL)
+
+    const dicomPath = path.join(__dirname, '..', 'test', 'assets', 'enh.dcm')
+    const dicomBuffer = fs.readFileSync(dicomPath)
+
+    const message = {
+      type: 'addImage',
+      body: {
+        data: [Array.from(new Uint8Array(dicomBuffer))],
+        uri: ['enh.dcm'],
+      },
+    }
+
+    await page.evaluate((m) => window.postMessage(m, '*'), message)
+    await waitForImageLoad(page)
+
+    const canvases = await page.$$('canvas')
+    expect(canvases.length).toBeGreaterThanOrEqual(1)
+
+    await page.waitForTimeout(2000)
+
+    const bodyText = await page.textContent('body')
+    expect(bodyText).not.toContain('error')
+    expect(bodyText).not.toContain('failed')
+  })
+
   test('loads DICOM from URL', async ({ page }) => {
     await page.goto(BASE_URL)
 

--- a/apps/vscode/src/editorProvider.ts
+++ b/apps/vscode/src/editorProvider.ts
@@ -87,13 +87,7 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
         if (e.type === 'ready' && !isImageSent) {
           isImageSent = true
           this.postInitSettings(panel)
-
-          if (uri.path.toLowerCase().endsWith('.mhd')) {
-            await NiiVueEditorProvider.sendMhdMessage(uri, panel.webview)
-          } else {
-            const body = await NiiVueEditorProvider.uriToImageBody(uri, panel.webview)
-            panel.webview.postMessage({ type: 'addImage', body })
-          }
+          await NiiVueEditorProvider.sendInitialImage(uri, panel.webview)
         }
       })
     })
@@ -203,18 +197,30 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
   }
 
   public static async openDcmFolder(folderUri: vscode.Uri, panel: vscode.WebviewPanel) {
+    const series = await NiiVueEditorProvider.collectDicomFolder(folderUri)
+    if (series.uris.length > 0) {
+      panel.webview.postMessage({
+        type: 'addImage',
+        body: { uri: series.uris, data: series.datas },
+      })
+      return
+    }
+    // Fallback: nothing sniffed as DICOM (e.g. files that lack the Part 10
+    // preamble). Send every file in the folder and let the loader decide.
     const files = await vscode.workspace.fs.readDirectory(folderUri)
-    const fileUris = files.map((file) => vscode.Uri.joinPath(folderUri, file[0]))
+    const fileUris = files
+      .filter(([, fileType]) => (fileType & vscode.FileType.File) !== 0)
+      .map(([name]) => vscode.Uri.joinPath(folderUri, name))
     const data = await Promise.all(
       fileUris.map((uri) =>
-        vscode.workspace.fs.readFile(uri).then((data) => NiiVueEditorProvider.toArrayBuffer(data)),
+        vscode.workspace.fs.readFile(uri).then((d) => NiiVueEditorProvider.toArrayBuffer(d)),
       ),
     )
     panel.webview.postMessage({
       type: 'addImage',
       body: {
-        data: data,
-        uri: fileUris[0].toString(),
+        data,
+        uri: fileUris.map((u) => u.toString()),
       },
     })
   }
@@ -244,19 +250,56 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
     webviewPanel.webview.onDidReceiveMessage(async (message) => {
       if (message.type === 'ready') {
         NiiVueEditorProvider.postInitSettings(webviewPanel)
-
-        if (document.uri.path.toLowerCase().endsWith('.mhd')) {
-          // MHD files have detached raw data; resolve the paired .raw file.
-          await NiiVueEditorProvider.sendMhdMessage(document.uri, webviewPanel.webview)
-        } else {
-          const body = await NiiVueEditorProvider.uriToImageBody(
-            document.uri,
-            webviewPanel.webview,
-          )
-          webviewPanel.webview.postMessage({ type: 'addImage', body })
-        }
+        await NiiVueEditorProvider.sendInitialImage(document.uri, webviewPanel.webview)
       }
     })
+  }
+
+  /**
+   * Extensions the webview can route on its own (mirrors the customEditors
+   * selector in package.json plus formats handled by dedicated code paths).
+   * Files matching none of these get content-sniffed for DICOM, since DICOM
+   * exports often have no extension or a bare UID as the file name.
+   */
+  private static readonly knownExtensions = [
+    '.dcm',
+    '.ima',
+    '.nii',
+    '.nii.gz',
+    '.mih',
+    '.mif',
+    '.mif.gz',
+    '.nhdr',
+    '.nrrd',
+    '.mhd',
+    '.mha',
+    '.mgh',
+    '.mgz',
+    '.v',
+    '.v16',
+    '.vmr',
+    '.mz3',
+    '.gii',
+    '.mnc',
+    '.mnc.gz',
+    '.npy',
+    '.npz',
+    '.raw',
+  ]
+
+  static hasKnownExtension(lowerCasePath: string): boolean {
+    return NiiVueEditorProvider.knownExtensions.some((ext) => lowerCasePath.endsWith(ext))
+  }
+
+  /** DICOM Part 10 magic: a 128-byte preamble followed by "DICM". */
+  static isDicomData(data: Uint8Array): boolean {
+    return (
+      data.byteLength >= 132 &&
+      data[128] === 0x44 && // D
+      data[129] === 0x49 && // I
+      data[130] === 0x43 && // C
+      data[131] === 0x4d // M
+    )
   }
 
   /**
@@ -266,6 +309,10 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
    * proxy — i.e. remote workspaces where the file sits outside
    * `localResourceRoots`, or formats that NiiVue can only ingest as bytes
    * (`.dcm`, `.mnc`).
+   *
+   * Files without a recognized extension are read and sniffed for the DICOM
+   * magic bytes; matches are shipped as binary so the webview routes them
+   * through the DICOM loader.
    *
    * MHD files are handled separately by `sendMhdMessage` because they need
    * the paired `.raw` voxel file resolved alongside the header.
@@ -286,7 +333,136 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
         uri: uri.toString(),
       }
     }
+    if (!NiiVueEditorProvider.hasKnownExtension(lowerCasePath)) {
+      const data = await vscode.workspace.fs.readFile(uri)
+      if (NiiVueEditorProvider.isDicomData(data)) {
+        return {
+          data: NiiVueEditorProvider.toArrayBuffer(data),
+          uri: uri.toString(),
+        }
+      }
+    }
     return { uri: webview.asWebviewUri(uri).toString() }
+  }
+
+  /**
+   * Send the initial image(s) for a freshly opened panel.
+   *
+   * - MHD resolves its detached `.raw` voxel file.
+   * - A DICOM file (recognized by extension or by sniffing the file's
+   *   content) expands to every DICOM file in the same folder, so a single
+   *   clicked slice loads its whole series. dcm2niix groups the slices and
+   *   splits a multi-series folder into one volume per series.
+   * - Everything else loads as a single image.
+   */
+  static async sendInitialImage(uri: vscode.Uri, webview: vscode.Webview): Promise<void> {
+    if (uri.path.toLowerCase().endsWith('.mhd')) {
+      await NiiVueEditorProvider.sendMhdMessage(uri, webview)
+      return
+    }
+    const name = uri.path.split('/').pop() ?? ''
+    if (NiiVueEditorProvider.isDicomCandidateName(name)) {
+      try {
+        const series = await NiiVueEditorProvider.collectDicomFolderImages(uri)
+        if (series) {
+          webview.postMessage({
+            type: 'addImage',
+            body: { uri: series.uris, data: series.datas },
+          })
+          return
+        }
+      } catch {
+        // Fall through to a single-file load if directory scanning fails.
+      }
+    }
+    const body = await NiiVueEditorProvider.uriToImageBody(uri, webview)
+    webview.postMessage({ type: 'addImage', body })
+  }
+
+  /**
+   * Cheap name-based pre-filter for DICOM files, used to avoid reading every
+   * sibling in a directory. Matches `.dcm`/`.ima`, extension-less names
+   * (`IM_0001`), and DICOM UID-style names (digits and dots). Actual content
+   * is still verified with `isDicomData` before a file is treated as DICOM.
+   */
+  static isDicomCandidateName(name: string): boolean {
+    const base = (name.split('/').pop() ?? name).toLowerCase()
+    if (base.endsWith('.dcm') || base.endsWith('.ima')) {
+      return true
+    }
+    return !base.includes('.') || /^[\d.]+$/.test(base)
+  }
+
+  /** The parent directory of a file URI. */
+  private static parentDir(uri: vscode.Uri): vscode.Uri {
+    const slashIndex = uri.path.lastIndexOf('/')
+    const parentPath = slashIndex >= 0 ? uri.path.substring(0, slashIndex) : ''
+    return uri.with({ path: parentPath || '/' })
+  }
+
+  /**
+   * Read every DICOM file in a directory (name pre-filtered, content
+   * verified) and return their URIs and bytes, sorted by URI for a stable
+   * slice order.
+   */
+  static async collectDicomFolder(
+    dirUri: vscode.Uri,
+  ): Promise<{ uris: string[]; datas: ArrayBuffer[] }> {
+    let entries: [string, vscode.FileType][]
+    try {
+      entries = await vscode.workspace.fs.readDirectory(dirUri)
+    } catch {
+      return { uris: [], datas: [] }
+    }
+    const collected: { uri: string; data: ArrayBuffer }[] = []
+    for (const [name, fileType] of entries) {
+      if ((fileType & vscode.FileType.File) === 0) {
+        continue
+      }
+      if (!NiiVueEditorProvider.isDicomCandidateName(name)) {
+        continue
+      }
+      const fileUri = vscode.Uri.joinPath(dirUri, name)
+      let bytes: Uint8Array
+      try {
+        bytes = await vscode.workspace.fs.readFile(fileUri)
+      } catch {
+        continue
+      }
+      if (!NiiVueEditorProvider.isDicomData(bytes)) {
+        continue
+      }
+      collected.push({ uri: fileUri.toString(), data: NiiVueEditorProvider.toArrayBuffer(bytes) })
+    }
+    collected.sort((a, b) => (a.uri < b.uri ? -1 : a.uri > b.uri ? 1 : 0))
+    return { uris: collected.map((c) => c.uri), datas: collected.map((c) => c.data) }
+  }
+
+  /**
+   * If `fileUri` is a DICOM file, return every DICOM file in its directory so
+   * the whole series loads together. Returns null when the file is not DICOM,
+   * so the caller falls back to a single-file load.
+   */
+  static async collectDicomFolderImages(
+    fileUri: vscode.Uri,
+  ): Promise<{ uris: string[]; datas: ArrayBuffer[] } | null> {
+    let clicked: Uint8Array
+    try {
+      clicked = await vscode.workspace.fs.readFile(fileUri)
+    } catch {
+      return null
+    }
+    if (!NiiVueEditorProvider.isDicomData(clicked)) {
+      return null
+    }
+    const series = await NiiVueEditorProvider.collectDicomFolder(
+      NiiVueEditorProvider.parentDir(fileUri),
+    )
+    if (series.uris.length === 0) {
+      // Directory listing failed; load just the clicked file.
+      return { uris: [fileUri.toString()], datas: [NiiVueEditorProvider.toArrayBuffer(clicked)] }
+    }
+    return series
   }
 
   /**

--- a/apps/vscode/test/editorProvider.test.ts
+++ b/apps/vscode/test/editorProvider.test.ts
@@ -1,6 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NiiVueEditorProvider } from '../src/editorProvider'
-import { __resetMock, Uri, workspace } from './vscode-mock'
+import { __resetMock, FileType, Uri, workspace } from './vscode-mock'
+
+/** 140-byte buffer with the DICOM Part 10 magic ("DICM" at offset 128). */
+function dicomBytes(): Uint8Array {
+  const bytes = new Uint8Array(140)
+  bytes.set([0x44, 0x49, 0x43, 0x4d], 128)
+  return bytes
+}
+
+/** 140-byte buffer without the DICOM magic. */
+function nonDicomBytes(): Uint8Array {
+  return new Uint8Array(140)
+}
 
 /**
  * These tests pin down the URL-vs-binary decision made by
@@ -158,6 +170,62 @@ describe('NiiVueEditorProvider.uriToImageBody', () => {
     expect(webview.asWebviewUri).not.toHaveBeenCalled()
   })
 
+  it('ships binary for an extension-less file whose content is DICOM', async () => {
+    // Scanner exports often have no extension (IM_0001) or a bare UID as the
+    // name. The custom-editor selector can't match those, but "NiiVue: Open"
+    // can still target them; the provider must sniff the DICOM magic
+    // (128-byte preamble + "DICM") and ship bytes so the webview routes the
+    // file through the DICOM loader.
+    workspace.workspaceFolders = [{ uri: Uri.parse('file:///home/user/proj') }]
+    const payload = new Uint8Array(140)
+    payload.set([0x44, 0x49, 0x43, 0x4d], 128) // "DICM"
+    workspace.fs.readFile.mockResolvedValueOnce(payload)
+    const webview = makeWebview()
+    const uri = Uri.parse('file:///home/user/proj/IM_0001')
+
+    const body = await NiiVueEditorProvider.uriToImageBody(uri, webview as any)
+
+    expect(body.data).toBeInstanceOf(ArrayBuffer)
+    expect(body.uri).toBe('file:///home/user/proj/IM_0001')
+    expect(webview.asWebviewUri).not.toHaveBeenCalled()
+  })
+
+  it('ships binary for a UID-named DICOM file (dots but no real extension)', async () => {
+    workspace.workspaceFolders = [{ uri: Uri.parse('file:///home/user/proj') }]
+    const payload = new Uint8Array(140)
+    payload.set([0x44, 0x49, 0x43, 0x4d], 128)
+    workspace.fs.readFile.mockResolvedValueOnce(payload)
+    const uri = Uri.parse('file:///home/user/proj/1.2.840.113619.2.5.1762583153.101')
+
+    const body = await NiiVueEditorProvider.uriToImageBody(uri, makeWebview() as any)
+
+    expect(body.data).toBeInstanceOf(ArrayBuffer)
+  })
+
+  it('falls back to a webview URL for an extension-less file that is not DICOM', async () => {
+    workspace.workspaceFolders = [{ uri: Uri.parse('file:///home/user/proj') }]
+    workspace.fs.readFile.mockResolvedValueOnce(new Uint8Array(200)) // no magic
+    const webview = makeWebview()
+    const uri = Uri.parse('file:///home/user/proj/Makefile')
+
+    const body = await NiiVueEditorProvider.uriToImageBody(uri, webview as any)
+
+    expect(body.data).toBeUndefined()
+    expect(body.uri).toContain('vscode-cdn.net')
+    expect(webview.asWebviewUri).toHaveBeenCalledOnce()
+  })
+
+  it('does not sniff files with a recognized extension', async () => {
+    workspace.workspaceFolders = [{ uri: Uri.parse('file:///home/user/proj') }]
+    const webview = makeWebview()
+    const uri = Uri.parse('file:///home/user/proj/mesh.gii')
+
+    const body = await NiiVueEditorProvider.uriToImageBody(uri, webview as any)
+
+    expect(body.data).toBeUndefined()
+    expect(workspace.fs.readFile).not.toHaveBeenCalled()
+  })
+
   it('produces a fresh ArrayBuffer (not a view onto a pooled Node Buffer)', async () => {
     // VS Code returns Uint8Array views that on Node are backed by a shared
     // ArrayBuffer pool — handing that to postMessage would leak unrelated
@@ -174,5 +242,167 @@ describe('NiiVueEditorProvider.uriToImageBody', () => {
     expect(body.data!.byteLength).toBe(4)
     expect(body.data).not.toBe(shared)
     expect(new Uint8Array(body.data!)).toEqual(new Uint8Array([1, 2, 3, 4]))
+  })
+})
+
+describe('NiiVueEditorProvider.isDicomCandidateName', () => {
+  it.each([
+    ['scan.dcm', true],
+    ['SCAN.DCM', true],
+    ['image.ima', true],
+    ['IM_0001', true], // extension-less scanner export
+    ['1.2.840.113619.2.5.1762583153.101', true], // bare DICOM UID
+    ['scan.nii', false],
+    ['scan.nii.gz', false],
+    ['readme.md', false],
+    ['mesh.gii', false],
+  ])('given %s, returns %s', (name, expected) => {
+    expect(NiiVueEditorProvider.isDicomCandidateName(name)).toBe(expected)
+  })
+})
+
+describe('NiiVueEditorProvider.collectDicomFolder', () => {
+  // Mirror the way VS Code's fs returns per-URI bytes.
+  function readFileByName(map: Record<string, Uint8Array>) {
+    return async (uri: Uri) => {
+      const name = uri.path.split('/').pop() ?? ''
+      const bytes = map[name]
+      if (!bytes) throw new Error(`ENOENT ${name}`)
+      return bytes
+    }
+  }
+
+  it('collects only files that sniff as DICOM, sorted by URI', async () => {
+    workspace.fs.readDirectory.mockResolvedValue([
+      ['slice2.dcm', FileType.File],
+      ['slice1.dcm', FileType.File],
+      ['notes.txt', FileType.File], // skipped: not a DICOM candidate name
+      ['nested', FileType.Directory], // skipped: not a file
+    ])
+    workspace.fs.readFile.mockImplementation(
+      readFileByName({ 'slice1.dcm': dicomBytes(), 'slice2.dcm': dicomBytes() }),
+    )
+
+    const result = await NiiVueEditorProvider.collectDicomFolder(
+      Uri.parse('file:///proj/series'),
+    )
+
+    expect(result.uris).toEqual([
+      'file:///proj/series/slice1.dcm',
+      'file:///proj/series/slice2.dcm',
+    ])
+    expect(result.datas).toHaveLength(2)
+    // notes.txt is name-filtered before any read
+    expect(workspace.fs.readFile).not.toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/proj/series/notes.txt' }),
+    )
+  })
+
+  it('drops extension-less candidates whose content is not DICOM', async () => {
+    workspace.fs.readDirectory.mockResolvedValue([
+      ['IM_0001', FileType.File],
+      ['IM_0002', FileType.File],
+      ['Makefile', FileType.File], // candidate by name, but not DICOM content
+    ])
+    workspace.fs.readFile.mockImplementation(
+      readFileByName({
+        IM_0001: dicomBytes(),
+        IM_0002: dicomBytes(),
+        Makefile: nonDicomBytes(),
+      }),
+    )
+
+    const result = await NiiVueEditorProvider.collectDicomFolder(Uri.parse('file:///scan'))
+
+    expect(result.uris).toEqual(['file:///scan/IM_0001', 'file:///scan/IM_0002'])
+  })
+
+  it('returns empty when the directory cannot be read', async () => {
+    workspace.fs.readDirectory.mockRejectedValue(new Error('EACCES'))
+    const result = await NiiVueEditorProvider.collectDicomFolder(Uri.parse('file:///x'))
+    expect(result).toEqual({ uris: [], datas: [] })
+  })
+})
+
+describe('NiiVueEditorProvider.collectDicomFolderImages', () => {
+  it('expands a clicked DICOM file to every DICOM in its folder', async () => {
+    workspace.fs.readDirectory.mockResolvedValue([
+      ['001.dcm', FileType.File],
+      ['002.dcm', FileType.File],
+    ])
+    workspace.fs.readFile.mockResolvedValue(dicomBytes())
+
+    const series = await NiiVueEditorProvider.collectDicomFolderImages(
+      Uri.parse('file:///study/001.dcm'),
+    )
+
+    expect(series).not.toBeNull()
+    expect(series!.uris).toEqual(['file:///study/001.dcm', 'file:///study/002.dcm'])
+  })
+
+  it('returns null when the clicked file is not DICOM (caller loads it singly)', async () => {
+    workspace.fs.readFile.mockResolvedValueOnce(nonDicomBytes())
+    const series = await NiiVueEditorProvider.collectDicomFolderImages(
+      Uri.parse('file:///study/IM_0001'),
+    )
+    expect(series).toBeNull()
+  })
+})
+
+describe('NiiVueEditorProvider.sendInitialImage', () => {
+  function makeWebviewWithPost() {
+    return {
+      asWebviewUri: vi.fn((uri: Uri) => ({
+        toString: () => `https://cdn.vscode-cdn.net${uri.path}?scheme=${uri.scheme}`,
+      })),
+      postMessage: vi.fn(),
+    }
+  }
+
+  it('sends the whole DICOM series when a single DICOM file is opened', async () => {
+    workspace.fs.readDirectory.mockResolvedValue([
+      ['001.dcm', FileType.File],
+      ['002.dcm', FileType.File],
+      ['003.dcm', FileType.File],
+    ])
+    workspace.fs.readFile.mockResolvedValue(dicomBytes())
+    const webview = makeWebviewWithPost()
+
+    await NiiVueEditorProvider.sendInitialImage(Uri.parse('file:///study/001.dcm'), webview as any)
+
+    expect(webview.postMessage).toHaveBeenCalledTimes(1)
+    const message = webview.postMessage.mock.calls[0][0]
+    expect(message.type).toBe('addImage')
+    expect(Array.isArray(message.body.uri)).toBe(true)
+    expect(message.body.uri).toHaveLength(3)
+    expect(message.body.data).toHaveLength(3)
+  })
+
+  it('expands an extension-less DICOM file (right-click "NiiVue: Open")', async () => {
+    workspace.fs.readDirectory.mockResolvedValue([
+      ['IM_0001', FileType.File],
+      ['IM_0002', FileType.File],
+    ])
+    workspace.fs.readFile.mockResolvedValue(dicomBytes())
+    const webview = makeWebviewWithPost()
+
+    await NiiVueEditorProvider.sendInitialImage(Uri.parse('file:///scan/IM_0001'), webview as any)
+
+    const message = webview.postMessage.mock.calls[0][0]
+    expect(message.body.uri).toEqual(['file:///scan/IM_0001', 'file:///scan/IM_0002'])
+  })
+
+  it('loads a single image (not a series) for non-DICOM files', async () => {
+    workspace.workspaceFolders = [{ uri: Uri.parse('file:///proj') }]
+    const webview = makeWebviewWithPost()
+
+    await NiiVueEditorProvider.sendInitialImage(Uri.parse('file:///proj/brain.nii.gz'), webview as any)
+
+    const message = webview.postMessage.mock.calls[0][0]
+    expect(message.type).toBe('addImage')
+    expect(message.body.uri).toBe('https://cdn.vscode-cdn.net/proj/brain.nii.gz?scheme=file')
+    // .nii.gz is never read for DICOM sniffing
+    expect(workspace.fs.readDirectory).not.toHaveBeenCalled()
+    expect(workspace.fs.readFile).not.toHaveBeenCalled()
   })
 })

--- a/apps/vscode/test/vscode-mock.ts
+++ b/apps/vscode/test/vscode-mock.ts
@@ -101,6 +101,9 @@ export const window = {
 
 export const ViewColumn = { One: 1 }
 
+/** FileType: vscode.FileType bitmask used by readDirectory results. */
+export const FileType = { Unknown: 0, File: 1, Directory: 2, SymbolicLink: 64 }
+
 /**
  * Disposable: matches vscode.Disposable shape — just a `dispose()` method.
  * dispose.ts uses an array of these to register/release resources.

--- a/packages/niivue-react/src/components/NiiVueCanvas.tsx
+++ b/packages/niivue-react/src/components/NiiVueCanvas.tsx
@@ -30,7 +30,7 @@ import { Signal } from '@preact/signals'
 import { useEffect, useRef } from 'preact/hooks'
 import { ExtendedNiivue, notifyImageLoaded } from '../events'
 import { NiiVueSettings } from '../settings'
-import { isImageType } from '../utility'
+import { isDicomData, isImageType } from '../utility'
 import { AppProps } from './AppProps'
 
 export interface NiiVueCanvasProps {
@@ -163,7 +163,62 @@ const ensureArrayBuffer = (data: any) => {
   return data
 }
 
+// True for names without any extension ("IM_0001") or DICOM UID-style names
+// made of digits and dots ("1.2.840.113619...101"). Used to decide whether a
+// URL without data is worth fetching for a DICOM magic-byte sniff; mesh
+// names like "lh.pial" or "brain.obj" stay on the streaming URL path.
+const looksExtensionless = (uri: string) => {
+  const basename = uri.split('?')[0].split('/').pop() ?? ''
+  return !basename.includes('.') || /^[\d.]+$/.test(basename)
+}
+
+// Load one or more DICOM files as a single series. dcm2niix groups the
+// slices and returns one NIfTI per series; the first series fills this canvas
+// and any further series (a folder holding multiple acquisitions) are
+// re-emitted through the normal pipeline so each opens on its own canvas.
+async function loadDicomSeries(
+  nv: ExtendedNiivue,
+  uris: string[],
+  datas: any,
+  settings: NiiVueSettings,
+) {
+  const names = uris.map((u) => String(u).replace('.ima', '.dcm').replace('.IMA', '.dcm'))
+  const data = Array.isArray(datas) ? [...datas] : [datas]
+  // Fetch any missing buffers (e.g. plain URLs without inlined data).
+  for (let i = 0; i < names.length; i++) {
+    if (!data[i] && names[i].startsWith('http')) {
+      const response = await fetch(names[i])
+      data[i] = await response.arrayBuffer()
+    }
+  }
+  const dicomInput = names.map((name, i) => ({ data: ensureArrayBuffer(data[i]), name }))
+  const loadedFiles = await dicomLoader(dicomInput)
+  if (!loadedFiles || loadedFiles.length === 0) {
+    throw new Error('No DICOM volume could be decoded from the provided files')
+  }
+  const [first, ...rest] = loadedFiles
+  const volume = await NVImage.loadFromUrl({
+    url: first.data,
+    name: first.name,
+    colormap: settings.defaultVolumeColormap,
+  })
+  nv.addVolume(volume)
+  // Extra series are already-decoded NIfTI buffers; route them back through
+  // the image pipeline so each gets its own canvas.
+  for (const file of rest) {
+    window.postMessage({ type: 'addImage', body: { data: file.data, uri: file.name } })
+  }
+}
+
 async function loadVolume(nv: ExtendedNiivue, item: any, settings: NiiVueSettings) {
+  // Multi-file DICOM series: item.uri is an array of slice names with
+  // item.data an array of buffers. Handle this first, because the single-file
+  // string heuristics below call string methods on item.uri and would throw
+  // on an array.
+  if (Array.isArray(item.uri)) {
+    await loadDicomSeries(nv, item.uri, item.data, settings)
+    return
+  }
   const isMincFile = (uri: string) => {
     const lowerUri = uri.toLowerCase()
     return lowerUri.endsWith('.mnc') || lowerUri.endsWith('.mnc.gz')
@@ -194,38 +249,31 @@ async function loadVolume(nv: ExtendedNiivue, item: any, settings: NiiVueSetting
     return
   }
 
-  // Read .ima and .IMA as dicom files
-  if (Array.isArray(item.uri)) {
-    item.uri = item.uri.map((uri: any) => uri.replace('.ima', '.dcm').replace('.IMA', '.dcm'))
-  } else if (item.uri.endsWith('.ima') || item.uri.endsWith('.IMA')) {
+  // Read .ima and .IMA as dicom files (array form handled by loadDicomSeries)
+  if (item.uri.endsWith('.ima') || item.uri.endsWith('.IMA')) {
     item.uri = item.uri.replace('.ima', '.dcm').replace('.IMA', '.dcm')
   }
-  // Handle different file types
-  if (Array.isArray(item.uri) || item.uri.endsWith('.dcm')) {
-    if (!Array.isArray(item.uri)) {
-      item.uri = [item.uri]
-      item.data = [item.data]
-    }
-    
-    // Fetch data if missing for any DICOM URL
-    for (let i = 0; i < item.uri.length; i++) {
-      if (!item.data[i] && typeof item.uri[i] === 'string' && item.uri[i].startsWith('http')) {
-        const response = await fetch(item.uri[i])
-        item.data[i] = await response.arrayBuffer()
+  // DICOM files often have no extension (scanner exports may use bare
+  // numbers or UIDs as names). When the name matches no known image format,
+  // sniff the DICOM magic bytes and route matches through the DICOM loader.
+  if (!item.uri.endsWith('.dcm') && !isImageType(item.uri)) {
+    if (!item.data && item.uri.startsWith('http') && looksExtensionless(item.uri)) {
+      // No bytes to sniff (e.g. webview resource URL), so fetch them. The
+      // buffer is reused below; the file is not downloaded twice.
+      try {
+        const response = await fetch(item.uri)
+        item.data = await response.arrayBuffer()
+      } catch {
+        // leave item.data unset; the fallback paths report the failure
       }
     }
-
-    const dicomInput = item.uri.map((uri: any, i: number) => ({
-      data: ensureArrayBuffer(item.data[i]),
-      name: uri,
-    }))
-    const loadedFiles = await dicomLoader(dicomInput)
-    const volume = await NVImage.loadFromUrl({
-      url: loadedFiles[0].data,
-      name: loadedFiles[0].name,
-      colormap: settings.defaultVolumeColormap,
-    })
-    nv.addVolume(volume)
+    if (isDicomData(item.data)) {
+      item.uri += '.dcm'
+    }
+  }
+  // Handle different file types
+  if (item.uri.endsWith('.dcm')) {
+    await loadDicomSeries(nv, [item.uri], [item.data], settings)
   } else if (item.uri.endsWith('.raw')) {
     const header = await getMinimalHeaderMHA()
     if (!header) {

--- a/packages/niivue-react/src/test/utility.test.ts
+++ b/packages/niivue-react/src/test/utility.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getMetadataString, getNames, getNumberOfPoints, isImageType } from '../utility'
+import { getMetadataString, getNames, getNumberOfPoints, isDicomData, isImageType } from '../utility'
 
 describe('isImageType', () => {
   // The function returns the matched extension string when supported, or
@@ -41,6 +41,55 @@ describe('isImageType', () => {
   it('preserves preceding path components — only inspects the suffix', () => {
     expect(isImageType('/some/path/scan.nii.gz')).toBe('.nii.gz')
     expect(isImageType('http://host/img.nrrd')).toBe('.nrrd')
+  })
+})
+
+describe('isDicomData', () => {
+  // DICOM Part 10: 128-byte preamble, then the magic bytes "DICM". Files
+  // exported by scanners often have no extension, so this content sniff is
+  // what routes them to the DICOM loader.
+  function dicomBytes(extra = 8): Uint8Array {
+    const bytes = new Uint8Array(128 + 4 + extra)
+    bytes.set([0x44, 0x49, 0x43, 0x4d], 128) // "DICM"
+    return bytes
+  }
+
+  it('detects the DICM magic in an ArrayBuffer', () => {
+    expect(isDicomData(dicomBytes().buffer)).toBe(true)
+  })
+
+  it('detects the DICM magic in a Uint8Array view with a byte offset', () => {
+    const padded = new Uint8Array(16 + 140)
+    padded.set(dicomBytes(), 16)
+    const view = new Uint8Array(padded.buffer, 16, 140)
+    expect(isDicomData(view)).toBe(true)
+  })
+
+  it('detects the DICM magic in a plain number array (postMessage-serialized)', () => {
+    expect(isDicomData(Array.from(dicomBytes()))).toBe(true)
+  })
+
+  it('rejects buffers shorter than preamble + magic', () => {
+    expect(isDicomData(new ArrayBuffer(131))).toBe(false)
+    expect(isDicomData(new ArrayBuffer(0))).toBe(false)
+  })
+
+  it('rejects data with "DICM" at the wrong offset', () => {
+    const bytes = new Uint8Array(140)
+    bytes.set([0x44, 0x49, 0x43, 0x4d], 0)
+    expect(isDicomData(bytes.buffer)).toBe(false)
+  })
+
+  it('rejects non-DICOM binary data of sufficient length', () => {
+    const bytes = new Uint8Array(200).fill(0xff)
+    expect(isDicomData(bytes.buffer)).toBe(false)
+  })
+
+  it('rejects non-binary inputs', () => {
+    expect(isDicomData(undefined)).toBe(false)
+    expect(isDicomData(null)).toBe(false)
+    expect(isDicomData('DICM')).toBe(false)
+    expect(isDicomData([new ArrayBuffer(140)])).toBe(false) // array of buffers (folder payload)
   })
 })
 

--- a/packages/niivue-react/src/utility.ts
+++ b/packages/niivue-react/src/utility.ts
@@ -138,6 +138,32 @@ export function differenceInNames(names: string[], rec = true) {
   return diffNames
 }
 
+// DICOM Part 10 files start with a 128-byte preamble followed by the
+// magic bytes "DICM". Scanner exports often have no file extension (or a
+// bare UID as the name), so content sniffing is the only reliable check.
+const DICM_OFFSET = 128
+
+export function isDicomData(data: unknown): boolean {
+  let bytes: Uint8Array | number[]
+  if (data instanceof ArrayBuffer) {
+    bytes = new Uint8Array(data)
+  } else if (ArrayBuffer.isView(data)) {
+    bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+  } else if (Array.isArray(data) && typeof data[0] === 'number') {
+    // postMessage across some bridges serializes buffers to number arrays
+    bytes = data
+  } else {
+    return false
+  }
+  return (
+    bytes.length >= DICM_OFFSET + 4 &&
+    bytes[DICM_OFFSET] === 0x44 && // D
+    bytes[DICM_OFFSET + 1] === 0x49 && // I
+    bytes[DICM_OFFSET + 2] === 0x43 && // C
+    bytes[DICM_OFFSET + 3] === 0x4d // M
+  )
+}
+
 export function isImageType(item: string) {
   return [
     '.nii',


### PR DESCRIPTION
## What

Detect DICOM files by **content** rather than file extension, and load a **whole series** from a single clicked file.

DICOM exports frequently have no extension (`IM_0001`) or a bare UID as the file name (`1.2.840.113619...`). These were unrecognized and fell through to the mesh loader. They are now detected via the DICOM Part 10 magic (a 128-byte preamble followed by `DICM`), and opening one slice loads its entire series.

## Why

Reported against VS Code: opening a single DICOM slice only showed that slice (and extension-less scanner exports did not open at all). Users expect a clicked DICOM to render the full volume.

## Changes

- **`@niivue/react`**
  - New `isDicomData()` helper (content sniff).
  - `loadVolume` content-sniffs payloads whose name matches no known image format and routes matches through the DICOM loader.
  - Multi-file input (`uri: string[]`) is now handled directly via a new `loadDicomSeries` helper. Previously an array URI hit `item.uri.toLowerCase()` and threw before reaching the DICOM path — this also broke **PWA folder drop**.
  - When dcm2niix returns more than one series (a folder with multiple acquisitions), each additional series opens on its own canvas.
- **VS Code extension**
  - A single opened DICOM file (by extension or content, including extension-less files opened via right-click **NiiVue: Open**) expands to every DICOM file in its folder, so the full series loads together.
  - Fixed `openDcmFolder`, which sent a single URI string alongside the data array (latent bug now that the array path is exercised consistently).

## Tests

- VS Code: **77 unit tests pass** (17 new — series collection, candidate-name filter, `sendInitialImage` routing for `.dcm`, extension-less, and non-DICOM files).
- `@niivue/react`: 71 tests, type-check + lint clean (new `isDicomData` unit tests).
- PWA e2e: **5/5 DICOM tests pass**, including a new one exercising the multi-file array path end-to-end through real dcm2niix.
- Changeset included (`@niivue/react` + `niivue` minor; consuming apps patch).

## Reviewer notes

- VS Code cannot auto-associate a custom editor by file *content*, so an extension-less DICOM still won't open on **double-click** — the right-click **NiiVue: Open** command is the entry point. Double-click would require a user-side `workbench.editorAssociations` glob (e.g. `**/IM_*`).
- Multi-series folders load **every** series (one canvas each) rather than parsing `SeriesInstanceUID` to isolate just the clicked file's series. The common one-series-per-folder layout loads as a single volume. This was a deliberate scope choice.
- The clicked file is read once to sniff and again during folder collection (one extra read of one file), and a large series is held in the extension host before `postMessage` — same characteristics as the existing folder path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)