### PR TITLE
fix(keyboard): stop the NiiVue tab from capturing keys and double-applying c/v (#223, #224)

### DIFF
--- a/.changeset/keyboard-shortcut-conflicts.md
+++ b/.changeset/keyboard-shortcut-conflicts.md
@@ -1,0 +1,13 @@
+---
+'@niivue/react': patch
+'niivue': patch
+'@niivue/pwa': patch
+'@niivue/streamlit': patch
+'@niivue/jupyter': patch
+'@niivue/tauri': patch
+---
+
+Fix two keyboard-handling conflicts.
+
+- The VS Code shortcut keybindings (1-5, r, i, b, x, etc.) now require keyboard focus to be in the viewer rather than only requiring the NiiVue tab to be active. They no longer swallow keystrokes meant for the Quick Open box or command palette (#223).
+- NiiVue's built-in `c` (clip plane) and `v` (view mode) hotkeys are disabled so the app's own handler is the single source of truth. The focused canvas is no longer acted on twice (#224). Note: the menu-less unstyled Streamlit embed has no app keyboard handler, so it loses NiiVue's built-in `c`/`v` hotkeys.

--- a/apps/pwa/tests/keyboard-shortcuts.spec.ts
+++ b/apps/pwa/tests/keyboard-shortcuts.spec.ts
@@ -28,6 +28,8 @@ async function getDebugValue(page, request) {
         return appProps.hideUI.value;
       case 'getCrosshairPos':
         return appProps.nvArray.value[0]?.scene?.crosshairPos;
+      case 'getClipPlaneIndex':
+        return appProps.nvArray.value[0]?.currentClipPlaneIndex;
       case 'getPan':
         return appProps.nvArray.value[0]?.scene?.pan2Dxyzmm;
       default:
@@ -57,6 +59,19 @@ test.describe('Keyboard Shortcuts', () => {
     const newSliceType = await getDebugValue(page, 'getSliceType');
     expect(newSliceType).toBeGreaterThanOrEqual(0);
     expect(newSliceType).toBeLessThanOrEqual(4);
+  });
+
+  test('should cycle the clip plane exactly once per "c" press', async ({ page }) => {
+    // Regression test for #224. The app's keyboard handler advances the clip
+    // plane for every selected canvas on keydown. NiiVue's own canvas handler
+    // used to advance it a second time for the focused canvas on keyup, so a
+    // single "c" landed on index 2 instead of 1. With NiiVue's clipPlaneHotKey
+    // disabled the app is the only handler, so one press == one step.
+    const canvas = page.locator('canvas').first();
+    await canvas.click();
+
+    await page.keyboard.press('c');
+    await poll(page, 'getClipPlaneIndex').toBe(1);
   });
 
   test('should change view to Axial with "1"', async ({ page }) => {

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -172,95 +172,95 @@
       {
         "command": "niivue.viewAxial",
         "key": "1",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.viewSagittal",
         "key": "2",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.viewCoronal",
         "key": "3",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.viewRender",
         "key": "4",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.viewMultiplanar",
         "key": "5",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.resetView",
         "key": "r",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.toggleInterpolation",
         "key": "i",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.toggleColorbar",
         "key": "b",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.toggleRadiological",
         "key": "x",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.toggleCrosshair",
         "key": "m",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.toggleZoomMode",
         "key": "z",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.addImage",
         "key": "ctrl+shift+o",
         "mac": "cmd+shift+o",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.addOverlay",
         "key": "ctrl+l",
         "mac": "cmd+l",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.colorscale",
         "key": "s",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.hideUI",
         "key": "u",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.showHeader",
         "key": "ctrl+h",
         "mac": "cmd+shift+h",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.crosshairSuperior",
         "key": "shift+u",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
         "command": "niivue.crosshairInferior",
         "key": "shift+d",
-        "when": "activeCustomEditorId == niiVue.default"
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       }
     ],
     "customEditors": [

--- a/apps/vscode/test/keybindings.test.ts
+++ b/apps/vscode/test/keybindings.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const dir = path.dirname(fileURLToPath(import.meta.url))
+const pkg = JSON.parse(readFileSync(path.resolve(dir, '../package.json'), 'utf8'))
+
+type Keybinding = { command: string; key: string; mac?: string; when?: string }
+const keybindings: Keybinding[] = pkg.contributes?.keybindings ?? []
+
+describe('contributed keybindings', () => {
+  it('contributes the niivue shortcut keybindings', () => {
+    expect(keybindings.length).toBeGreaterThan(0)
+    expect(keybindings.every((k) => k.command.startsWith('niivue.'))).toBe(true)
+  })
+
+  // Regression test for niivue/niivue-vscode#223: the niivue commands are
+  // no-ops (the webview's own keydown listener does the work), so a binding
+  // that stays active while a VS Code input box is focused merely *swallows*
+  // the key. Without `!inputFocus`, single-key bindings like "1" or "s" eat
+  // keystrokes meant for Quick Open / the command palette ("the top box").
+  it('gates every keybinding behind the editor having focus (not an input box)', () => {
+    for (const kb of keybindings) {
+      expect(kb.when, `keybinding for ${kb.command} must declare a when-clause`).toBeTruthy()
+      expect(
+        kb.when,
+        `keybinding for ${kb.command} ("${kb.key}") must require the niivue editor`,
+      ).toContain('activeCustomEditorId == niiVue.default')
+      expect(
+        kb.when,
+        `keybinding for ${kb.command} ("${kb.key}") must be disabled while a VS Code input is focused (#223)`,
+      ).toContain('!inputFocus')
+    }
+  })
+
+  // The bare printable keys are the ones that actually break typing in the
+  // top box, so guard them explicitly in case the list grows later.
+  it('guards the single printable-key shortcuts in particular', () => {
+    const printable = keybindings.filter((k) => /^[a-z0-9]$/i.test(k.key))
+    expect(printable.length).toBeGreaterThan(0)
+    expect(printable.every((k) => k.when?.includes('!inputFocus'))).toBe(true)
+  })
+})

--- a/packages/niivue-react/src/events.ts
+++ b/packages/niivue-react/src/events.ts
@@ -449,6 +449,14 @@ function growNvArrayBy(nvArray: Signal<Niivue[]>, n: number) {
       isResizeCanvas: true,
       dragMode: 1, // contrast
       dragAndDropEnabled: false, // handled by app (Volume component)
+      // 'c' (cycle clip plane) and 'v' (cycle view mode) are handled by the
+      // app's useKeyboardShortcuts hook, which broadcasts to every selected
+      // canvas. Disabling NiiVue's own canvas-level handlers for these keys
+      // (an empty hotkey never matches an event's KeyboardEvent.code) keeps the
+      // app as the single source of truth, so the focused canvas is no longer
+      // acted on a second time on key release. See niivue/niivue-vscode#224.
+      clipPlaneHotKey: '',
+      viewModeHotKey: '',
     })
     nv.key = Math.random()
     nvArray.value = [...nvArray.value, nv]


### PR DESCRIPTION
Fixes #223 and #224. Both are keyboard-handling conflicts between the VS Code/host layer and NiiVue's own canvas hotkeys.

## #223 — NiiVue tab captures keys meant for the "top box"

The extension contributes keybindings for `1`-`5`, `r`, `i`, `b`, `x`, `m`, `z`, `s`, `u`, `shift+u`, `shift+d`, etc., gated only by `when: activeCustomEditorId == niiVue.default`. Those commands are intentional **no-ops** (`extension.ts`) — the webview's own `keydown` listener does the real work; the VS Code commands exist only for command-palette discovery and keybinding customization.

The problem: `activeCustomEditorId` stays `niiVue.default` even when keyboard focus moves to Quick Open or the command palette. So when you open the "top box" over a NiiVue tab and type, the single-key bindings fire their no-op commands and **swallow** the keystrokes instead of letting them reach the input.

**Fix:** add `&& !inputFocus` to every contributed keybinding. `inputFocus` is true when a VS Code input widget (Quick Open, command palette, etc.) is focused and false when the webview itself is focused, so the shortcuts now only act when the viewer holds focus.

## #224 — `c`/`v` applied twice on the focused canvas

The app's `useKeyboardShortcuts` hook handles `c`/`v` on **keydown** and broadcasts the action to every selected canvas. NiiVue's own canvas handler *also* handles them on **keyup** (`clipPlaneHotKey`/`viewModeHotKey`), but only for the focused/in-bounds canvas. Result: the focused canvas is acted on twice per press — e.g. one `c` lands on clip-plane index 2 instead of 1.

**Fix:** construct each `ExtendedNiivue` with `clipPlaneHotKey: ''` and `viewModeHotKey: ''`. NiiVue matches hotkeys with a strict `KeyboardEvent.code === hotKey`, so an empty string never matches and its built-in `c`/`v` handlers are disabled. The app's broadcast handler becomes the single source of truth, so every selected canvas advances exactly once.

## Tests
- `apps/vscode/test/keybindings.test.ts` (new): asserts every contributed keybinding carries both `activeCustomEditorId == niiVue.default` and `!inputFocus`, with an extra guard over the bare printable keys.
- `apps/pwa/tests/keyboard-shortcuts.spec.ts`: new e2e case asserting a single `c` press lands on clip-plane index `1`.
- Unit suites pass (vscode 80/80, niivue-react 85/85); type-check + lint clean. The affected e2e specs pass locally in the WebGL lane (26/26).

## Note on arrow keys (investigated, intentionally not changed)
An earlier revision also tried to make the app the single source of truth for the ←/→ (4D frame) keys, on the assumption they double-applied like `c`/`v`. CI disproved that: the app's `volumeNext`/`volumePrev` pass a volume **object** to `nv.setFrame4D(id, frame)`, which expects a volume **id**, so they are silent no-ops — NiiVue's own handler is the *only* thing that advances the frame on arrow press. Suppressing it broke arrow navigation (and the pre-existing `4d-sync` keyboard test). That change has been reverted; NiiVue keeps owning the arrow keys, and there is no double-apply to fix. (The `volumeNext`/`volumePrev` no-op is a real but separate latent bug, worth a follow-up.)

## Reviewer notes
- The `events.ts` change lives in the shared `@niivue/react` package, so the #224 fix reaches the apps that mount the shared `Menu`/`useKeyboardShortcuts` handler: vscode, PWA, Jupyter, Tauri, and Streamlit's **styled** viewer.
- **Trade-off:** Streamlit's *unstyled* embed (`UnstyledCanvas` → `Container` only, no `Menu`) has no app keyboard handler, so disabling NiiVue's built-in `c`/`v` removes them there with no replacement. That mode has no shortcut UI, so this is considered acceptable; called out in the changeset.
- The `!inputFocus` change is VS Code-only (`apps/vscode/package.json`).

## Known residual / follow-ups (out of scope here)
- `volumeNext`/`volumePrev` keyboard handlers are no-ops (wrong arg to `setFrame4D`); NiiVue currently covers arrow navigation, so it is not user-visible, but the app-level broadcast for arrows never actually runs.
- `m` triggers two different actions when a canvas is focused (app: toggle crosshair; NiiVue: cycle drag mode) — same conflict root, but not a double-apply.
- Pre-existing `showHeader` keybinding mismatch (`ctrl+h` vs mac `cmd+shift+h`, while the webview handler expects `ctrl+shift+h`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
