### PR TITLE
test(pwa): deterministic e2e architecture (state waits + bounded WebGL lane)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,10 @@ jobs:
   e2e-tests:
     needs: [changes, build]
     if: needs.changes.outputs.pwa == 'true'
-    timeout-minutes: 10
+    # Headroom for the serial WebGL lane on software-WebGL CI. This is the only
+    # outer time bound now that globalTimeout is gone; bump the webgl lane to
+    # --workers=2 (see apps/pwa/tests/README.md) before lowering this.
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -410,8 +413,26 @@ jobs:
         run: pnpm exec playwright install --with-deps
         working-directory: ./apps/pwa
 
-      - name: Run Playwright tests
-        run: pnpm test:e2e
+      # The e2e build is self-contained from source (vite aliases the workspace
+      # packages to their src/) and uses --base / to override the GitHub Pages
+      # base. Building once here lets both lanes below share it — the webServer
+      # only runs `vite preview`, so the two separate Playwright invocations do
+      # not each rebuild.
+      - name: Build PWA for e2e
+        run: pnpm run test:e2e:build
+        working-directory: ./apps/pwa
+
+      # Fast lane: DOM-only specs tagged @dom, run in parallel.
+      - name: Run e2e — fast lane (DOM-only, parallel)
+        run: pnpm run test:e2e:fast
+        working-directory: ./apps/pwa
+
+      # WebGL lane: everything else, serial (--workers=1) so heavy software-WebGL
+      # renders never contend across workers. Pass/fail is already time-independent
+      # (state waits + generous failsafe timeouts); serializing bounds wall-clock
+      # variance so the failsafes are rarely even approached.
+      - name: Run e2e — WebGL lane (serial, --workers=1)
+        run: pnpm run test:e2e:webgl
         working-directory: ./apps/pwa
 
       - name: Upload test results

--- a/apps/pwa/package.json
+++ b/apps/pwa/package.json
@@ -44,7 +44,10 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "coverage": "pnpm run test:coverage",
-    "test:e2e": "playwright test",
+    "test:e2e:build": "vite build --base /",
+    "test:e2e:fast": "playwright test --grep @dom",
+    "test:e2e:webgl": "playwright test --grep-invert @dom --workers=1",
+    "test:e2e": "pnpm run test:e2e:build && pnpm run test:e2e:fast && pnpm run test:e2e:webgl",
     "test:e2e:ui": "playwright test --ui",
     "ci": "pnpm run lint && pnpm run type-check && pnpm run test:coverage && pnpm run test:e2e"
   },

--- a/apps/pwa/playwright.config.ts
+++ b/apps/pwa/playwright.config.ts
@@ -9,14 +9,24 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 1 : 0, // Reduced retries to save time
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 2 : undefined, // 2 workers for faster execution
-  /* Global timeout for all tests - 5 minutes total */
-  globalTimeout: 5 * 60 * 1000, // 5 minutes total for entire test suite
-  /* Timeout for each test - shorter default */
-  timeout: 30 * 1000, // 30 seconds per test - should be enough for most tests
+  /* Retry on CI only — a net, not a crutch. */
+  retries: process.env.CI ? 1 : 0,
+  /*
+   * Worker count is GLOBAL in Playwright (there is no per-project worker cap),
+   * so true serialization of the heavy WebGL lane is done by a separate
+   * `--workers=1` invocation (see package.json `test:e2e:webgl`), not here.
+   * This default applies to the parallel `@dom` fast lane and to ad-hoc runs.
+   */
+  workers: process.env.CI ? 2 : undefined,
+  /*
+   * No `globalTimeout`. A suite-wide wall-clock cap turns contention or a
+   * (deliberately serial) heavy lane into a nondeterministic failure of the
+   * whole run. The CI job's `timeout-minutes` is the real outer bound; per-test
+   * `timeout` below bounds individual hangs.
+   */
+  /* Per-test failsafe — generous so software-WebGL renders under CPU contention
+   * never make a correct test time out. Not a happy-path budget. */
+  timeout: 60 * 1000,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['html', { open: 'never' }], // Don't auto-open browser with report
@@ -52,10 +62,14 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     /* Record video on failure */
     video: 'retain-on-failure',
-    /* Action timeout - aggressive for CI */
-    actionTimeout: 5 * 1000, // 5 seconds for clicks, typing, etc.
-    /* Navigation timeout - aggressive for CI */
-    navigationTimeout: 10 * 1000, // 10 seconds for page.goto()
+    /*
+     * Generous failsafes, NOT correctness budgets. The old 5 s actionTimeout
+     * was the direct cause of the #238 flakiness: a click on a visible, correct
+     * button can exceed 5 s while a parallel worker pegs CPU on software WebGL.
+     * Waits key on app state (see tests/utils.ts); these only bound a genuine hang.
+     */
+    actionTimeout: 15 * 1000,
+    navigationTimeout: 30 * 1000,
   },
 
   /* Configure projects for major browsers */
@@ -85,17 +99,22 @@ export default defineConfig({
   ],
 
   /*
-   * Build the app and serve it via `vite preview` so source maps have full
+   * Serve the production build via `vite preview` so source maps have full
    * paths (e.g. `apps/pwa/src/Pwa.tsx`, `packages/niivue-react/src/...`).
    * `--base /` overrides the GitHub Pages base so tests can hit the root.
-   * For local iteration, run `pnpm dev` separately and playwright will
-   * reuseExistingServer.
+   *
+   * The build is intentionally NOT part of this command: the two e2e lanes
+   * (fast + serial webgl) are separate Playwright invocations that must share
+   * ONE build, so `vite build --base /` runs once up front (see package.json
+   * `test:e2e:build`; `test:e2e` and CI run it before the lanes). `vite preview`
+   * here is cheap to (re)start per invocation. For local iteration, `pnpm dev`
+   * on :4000 is reused via reuseExistingServer.
    */
   webServer: {
-    command: 'vite build --base / && vite preview --base / --port 4000',
+    command: 'vite preview --base / --port 4000',
     url: 'http://localhost:4000',
     reuseExistingServer: !process.env.CI,
-    timeout: 5 * 60 * 1000, // 5 minutes — production build can take a while
+    timeout: 2 * 60 * 1000,
   },
 
   /* Global setup and teardown */

--- a/apps/pwa/tests/4d-navigation.spec.ts
+++ b/apps/pwa/tests/4d-navigation.spec.ts
@@ -65,10 +65,9 @@ test.describe('4D Navigation', () => {
     await playButton.click()
     await expect(playButton).toHaveAttribute('aria-label', 'Pause')
 
-    // Wait for a few iterations (animation happens every 200ms)
-    await page.waitForTimeout(1000)
-
-    // Frame should have changed
+    // Cine playback advances the frame (~every 200ms). Wait on the frame
+    // leaving 0 rather than sleeping a fixed amount.
+    await expect(volumeIndicator).not.toHaveText('0')
     const currentFrame = await volumeIndicator.innerText()
     expect(parseInt(currentFrame)).toBeGreaterThan(0)
 
@@ -76,9 +75,11 @@ test.describe('4D Navigation', () => {
     await playButton.click()
     await expect(playButton).toHaveAttribute('aria-label', 'Play')
 
-    // Frame should stay the same
+    // Verifying the ABSENCE of further advance is the one thing a state wait
+    // can't express, so allow a bounded settle longer than the ~200ms cine
+    // period: if playback were still running, the frame would change.
     const frameAfterPause = await volumeIndicator.innerText()
-    await page.waitForTimeout(500)
+    await page.waitForTimeout(600)
     await expect(volumeIndicator).toHaveText(frameAfterPause)
   })
 })

--- a/apps/pwa/tests/4d-sync.spec.ts
+++ b/apps/pwa/tests/4d-sync.spec.ts
@@ -67,16 +67,14 @@ test.describe('4D Sync', () => {
 
     // Press Right arrow to increment frame
     await page.keyboard.press('ArrowRight')
-    await page.waitForTimeout(100) // Wait for sync to propagate
 
-    // Both should now be at frame 1
+    // Both should now be at frame 1 (toHaveText auto-retries until sync propagates)
     await expect(vol0Indicator).toHaveText('1')
     await expect(vol1Indicator).toHaveText('1')
 
     // Press Left arrow to decrement frame
     await canvas0.click() // Ensure focus is regained
     await page.keyboard.press('ArrowLeft')
-    await page.waitForTimeout(100) // Wait for sync to propagate
 
     // Both should now be back at frame 0
     await expect(vol0Indicator).toHaveText('0')

--- a/apps/pwa/tests/Dicom.spec.ts
+++ b/apps/pwa/tests/Dicom.spec.ts
@@ -7,6 +7,15 @@ import { BASE_URL, waitForImageLoad } from './utils'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
+// A successful load resolves `waitForImageLoad` (state wait on loadedCount), so
+// the only thing left to verify is that no failure overlay surfaced. Assert that
+// directly and deterministically instead of sleeping for an arbitrary "settle"
+// window and grepping body text. `Volume.tsx` renders "Failed to load image" on
+// error; its absence is the real signal.
+async function expectNoLoadError(page) {
+  await expect(page.getByText(/Failed to load image/i)).toHaveCount(0)
+}
+
 test.describe('Loading DICOM images', () => {
   test('loads DICOM file from local test assets', async ({ page }) => {
     await page.goto(BASE_URL)
@@ -29,7 +38,7 @@ test.describe('Loading DICOM images', () => {
     }
 
     await page.evaluate((m) => window.postMessage(m, '*'), message)
-    
+
     // Wait for canvas to appear - this verifies NiiVue successfully loaded the DICOM
     await waitForImageLoad(page)
 
@@ -37,13 +46,8 @@ test.describe('Loading DICOM images', () => {
     const canvases = await page.$$('canvas')
     expect(canvases.length).toBeGreaterThanOrEqual(1)
 
-    // Wait for NiiVue to fully process the DICOM
-    await page.waitForTimeout(2000)
-
-    // Verify no error messages appeared
-    const bodyText = await page.textContent('body')
-    expect(bodyText).not.toContain('error')
-    expect(bodyText).not.toContain('failed')
+    // Verify no error overlay appeared
+    await expectNoLoadError(page)
   })
 
   test('loads an extension-less DICOM file via magic-byte detection', async ({ page }) => {
@@ -69,11 +73,7 @@ test.describe('Loading DICOM images', () => {
     const canvases = await page.$$('canvas')
     expect(canvases.length).toBeGreaterThanOrEqual(1)
 
-    await page.waitForTimeout(2000)
-
-    const bodyText = await page.textContent('body')
-    expect(bodyText).not.toContain('error')
-    expect(bodyText).not.toContain('failed')
+    await expectNoLoadError(page)
   })
 
   test('loads a DICOM series passed as an array of files', async ({ page }) => {
@@ -100,18 +100,14 @@ test.describe('Loading DICOM images', () => {
     const canvases = await page.$$('canvas')
     expect(canvases.length).toBeGreaterThanOrEqual(1)
 
-    await page.waitForTimeout(2000)
-
-    const bodyText = await page.textContent('body')
-    expect(bodyText).not.toContain('error')
-    expect(bodyText).not.toContain('failed')
+    await expectNoLoadError(page)
   })
 
   test('loads DICOM from URL', async ({ page }) => {
     await page.goto(BASE_URL)
 
     const testLink = BASE_URL + 'enh.dcm' // Re-using enh.dcm as a "remote" url test
-    
+
     const message = {
       type: 'addImage',
       body: {
@@ -126,13 +122,9 @@ test.describe('Loading DICOM images', () => {
     // Verify canvas loaded
     const canvases = await page.$$('canvas')
     expect(canvases).toHaveLength(1)
-    
-    // Wait for processing
-    await page.waitForTimeout(1000)
 
-    // Verify volume loaded
-    const bodyText = await page.textContent('body')
-    expect(bodyText).toBeTruthy()
+    // Verify volume loaded without error
+    await expectNoLoadError(page)
   })
 
   test('handles multiple DICOM files', async ({ page }) => {
@@ -151,20 +143,24 @@ test.describe('Loading DICOM images', () => {
     await page.evaluate((m) => window.postMessage(m, '*'), message1)
     await waitForImageLoad(page)
 
-    // Load second DICOM (using enh.dcm as second one too)
+    // Load a second DICOM. NOTE: no `?v=2` query — a query string makes the URL
+    // miss the `.dcm` routing in loadVolume and fall through to the mesh loader,
+    // which fails. (The old test hid that by only sleeping then asserting ≥1
+    // canvas, so the second load was never actually verified.) A second addImage
+    // already spins up a fresh canvas, so the same URL is genuinely a second load.
     const message2 = {
       type: 'addImage',
       body: {
         data: '',
-        uri: testLink + '?v=2', // dummy param to make it "new"
+        uri: testLink,
       },
     }
 
     await page.evaluate((m) => window.postMessage(m, '*'), message2)
-    
-    // Should have 2 canvases now
-    await page.waitForTimeout(1000)
-    const canvases = await page.$$('canvas')
-    expect(canvases.length).toBeGreaterThanOrEqual(1) // At least one canvas (may share)
+
+    // Wait for the second load to complete (loadedCount increments to 2) rather
+    // than guessing with a fixed delay, then confirm both canvases are present.
+    await waitForImageLoad(page)
+    await expect(page.locator('canvas')).toHaveCount(2)
   })
 })

--- a/apps/pwa/tests/ErrorHandling.spec.ts
+++ b/apps/pwa/tests/ErrorHandling.spec.ts
@@ -17,7 +17,7 @@ test.describe('Error Handling', () => {
 
     // Verify error message appears
     await expect(page.locator('text=Failed to load image')).toBeVisible({ timeout: 15000 })
-    await page.waitForTimeout(1000)
+    // The detail line auto-retries via toBeVisible; no fixed settle needed.
     await expect(page.locator('div').filter({ hasText: /nonexistent|fetch/i }).first()).toBeVisible()
 
     // Close with the close button

--- a/apps/pwa/tests/Menu.spec.ts
+++ b/apps/pwa/tests/Menu.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from './fixtures'
 import { BASE_URL, loadTestImage, waitForImageLoad } from './utils'
 
 test.describe('Menu', () => {
-  test('displays home screen', async ({ page }) => {
+  test('displays home screen', { tag: '@dom' }, async ({ page }) => {
     await page.goto(BASE_URL)
 
     expect(await page.textContent('text=/Home/i')).toBeTruthy()

--- a/apps/pwa/tests/MenuOverflow.spec.ts
+++ b/apps/pwa/tests/MenuOverflow.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from './fixtures'
 import { BASE_URL, waitForImageLoad } from './utils'
 
 test.describe('Menu overflow', () => {
-  test('wide viewport keeps top-level menus inline (no More button)', async ({ page }) => {
+  test('wide viewport keeps top-level menus inline (no More button)', { tag: '@dom' }, async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 })
     await page.goto(BASE_URL)
 
@@ -10,7 +10,7 @@ test.describe('Menu overflow', () => {
     await expect(page.getByTestId('menu-overflow')).toHaveCount(0)
   })
 
-  test('narrow viewport collapses overflowing menus into the More menu', async ({ page }) => {
+  test('narrow viewport collapses overflowing menus into the More menu', { tag: '@dom' }, async ({ page }) => {
     await page.setViewportSize({ width: 360, height: 800 })
     await page.goto(BASE_URL)
 

--- a/apps/pwa/tests/README.md
+++ b/apps/pwa/tests/README.md
@@ -1,0 +1,133 @@
+# PWA end-to-end tests (Playwright)
+
+These specs are a **thin smoke layer** over wiring and DOM geometry. Exhaustive
+correctness (layout/tile math, utilities, reducers) lives in the package unit
+tests (`packages/niivue-react/src/test/**`, Vitest) — keep it there. An e2e test
+should assert that things are *wired up* (a load reaches a canvas, a setting
+drives a computed style, a shortcut flips a signal), never re-prove math and
+never read pixels.
+
+## What belongs in an e2e test (vs a unit test)
+
+**Default to a unit test. Reach for e2e only when the integration *is* the thing
+under test** — something a unit test cannot exercise without mocking away the very
+part that could break. e2e is the slowest, flakiest, most expensive layer (real
+browser, software WebGL, serial); spend it only where it earns its keep.
+
+Keep in **e2e** (real browser genuinely required):
+
+- A real image/DICOM/mesh load decodes and reaches a `<canvas>` (the load
+  pipeline + GL attach).
+- DOM geometry that depends on real layout/CSS — tiles fit their container, menus
+  overflow at a real viewport width.
+- Cross-component wiring through the real `postMessage` bus + signals — e.g. 4D
+  frame sync across two real niivue instances.
+
+Push to a **unit test** (`packages/niivue-react/src/test/**`):
+
+- Pure functions / math — layout sizing (already there), DICOM magic-byte
+  sniffing, filename classification, URL-param parsing.
+- A handler/reducer mapping an input to a state change — e.g. "key `v` advances
+  `sliceType`" is logic on the keydown handler, not something that needs a real
+  GPU load to verify.
+- Settings reducers, image reordering, document round-trip serialization.
+
+**Smell test:** if a spec loads a real image only to then assert a *pure-logic*
+outcome (a key flips a signal, a filename is classified, a count is computed), the
+logic belongs in a unit test — only the "a real load reaches a canvas" part, if
+any, stays in e2e. (Today `keyboard-shortcuts.spec.ts` is the clearest example: it
+pays for a real WebGL load per test to assert handler logic that a component test
+could cover far faster.)
+
+## Why the suite is built the way it is
+
+The suite used to fail on CI under load — on **timeouts, not assertions**. Two
+things caused that, and both are now designed out:
+
+1. **Time was the correctness signal.** A 5 s `actionTimeout` / 30 s test
+   timeout / 5 min suite-wide `globalTimeout` decided pass/fail. On CI the e2e
+   job runs on **software WebGL** (ANGLE/SwiftShader, CPU-bound, synchronous
+   `gl.finish()`); with two parallel workers, a heavy render in one worker
+   starves the other, and a *correct* test times out.
+2. **Fixed sleeps.** ~29 `page.waitForTimeout(...)` calls waited a guessed number
+   of ms and hoped state had settled.
+
+> **Myth, busted:** niivue does **not** run a continuous `requestAnimationFrame`
+> render loop. The installed `@niivue/niivue@0.68.2` bundle has exactly three
+> `requestAnimationFrame` calls — two coalesce resize events, one yields a frame
+> during volume-chunk streaming. Rendering is **on-demand** (`drawScene()` gated
+> by `isBusy`/`needsRefresh`); an **idle canvas burns ~0 CPU**. So there is no
+> idle loop to "quiet" under a test flag — don't add one. The cost is per
+> *render* (load, resize, settings change, interaction) on software WebGL, not a
+> background loop.
+
+## The two design rules
+
+### 1. Pass/fail must be time-independent
+
+- **Wait on app state, never on a clock.** Use web-first assertions
+  (`expect(locator).toHaveText(...)`, `.toBeVisible()`) and `expect.poll(...)`
+  for non-DOM state (e.g. reading a signal via `page.evaluate`). They retry until
+  true or until a *generous* failsafe fires.
+- **`waitForTimeout` is banned**, with one documented exception: verifying the
+  *absence* of a change in a timer-driven feature (4D cine "paused" — see
+  `4d-navigation.spec.ts`), which no state wait can express.
+- Timeouts in `playwright.config.ts` are **failsafes, set generously** (60 s
+  test, 15 s action, 30 s nav, no `globalTimeout`). They bound a genuine hang;
+  they are not happy-path budgets. Image loads wait on
+  `window.__niivue.loadedCount` via `waitForImageLoad` (`utils.ts`).
+- CSS transitions/animations are force-disabled and `prefers-reduced-motion` is
+  emulated in `fixtures.ts`, so visibility/layout assertions never race
+  animation timing.
+
+Because correctness no longer depends on timing, contention affects only
+*speed*, not pass/fail. (At extreme oversubscription on software WebGL — say
+`--workers=4` — a single real load can still exceed even a generous failsafe;
+that is a *throughput* limit, not a correctness one, and is exactly what the
+serial heavy lane below prevents on CI.)
+
+### 2. The heavy lane is bounded (defense in depth)
+
+Almost every spec loads WebGL content, so we route by **`@dom` default-deny**:
+
+- Tag a test `{ tag: '@dom' }` **only if it does no WebGL/image load** (pure DOM,
+  e.g. menu overflow geometry). Today that's three tests in `Menu.spec.ts` /
+  `MenuOverflow.spec.ts`.
+- **Everything else is WebGL by default.** A new or untagged spec is therefore
+  fail-safe: it runs in the serial lane, not the flaky parallel one. New heavy
+  specs (e.g. the layout smoke test from the tile-spacing PR) need no tag.
+
+Two lanes share **one** build:
+
+| Lane  | Command (`apps/pwa`)                                     | Concurrency |
+| ----- | ------------------------------------------------------- | ----------- |
+| fast  | `pnpm test:e2e:fast`  → `playwright test --grep @dom`    | parallel    |
+| webgl | `pnpm test:e2e:webgl` → `--grep-invert @dom --workers=1`| **serial**  |
+
+`--workers=1` is the only hard serialization knob in Playwright (worker count is
+global; `fullyParallel: false` only serializes *within* a file). The webServer
+runs `vite preview` only; `pnpm test:e2e:build` builds once with `--base /` so
+both invocations reuse it.
+
+## Running locally
+
+```bash
+cd apps/pwa
+pnpm test:e2e          # build once, then fast lane + serial webgl lane
+pnpm test:e2e:build    # vite build --base / (needed before the lanes below)
+pnpm test:e2e:fast     # @dom specs only
+pnpm test:e2e:webgl    # everything else, serial
+pnpm test:e2e:ui       # Playwright UI (reuses a running `pnpm dev` on :4000)
+```
+
+A run with no server first builds, then `vite preview` serves `build/`. If
+`pnpm dev` is already on :4000 it is reused (`reuseExistingServer`), so no build
+is needed for the UI runner.
+
+## Tuning
+
+If the serial webgl lane's wall-clock ever crowds the CI job's `timeout-minutes`,
+raise its concurrency — `playwright test --grep-invert @dom --workers=2`. This is
+**safe**: there is no idle render loop, so two on-demand software-WebGL contexts
+contend only while actually rendering, and the generous failsafes absorb it. Keep
+`--workers=1` as the default for maximum determinism.

--- a/apps/pwa/tests/fixtures.ts
+++ b/apps/pwa/tests/fixtures.ts
@@ -15,6 +15,30 @@ export const test = base.extend({
     await page.addInitScript(() => {
       ;(window as any).PLAYWRIGHT_TEST = true
     })
+
+    // Determinism: strip CSS transitions/animations so visibility and layout
+    // assertions never race animation timing under CPU-contended CI. We both
+    // emulate `prefers-reduced-motion` (which the app/menus may honor) and
+    // force-disable via an injected stylesheet, applied as early as possible
+    // and re-applied on DOMContentLoaded in case <head> wasn't ready yet.
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await page.addInitScript(() => {
+      const css =
+        '*,*::before,*::after{transition:none!important;animation:none!important;' +
+        'animation-duration:0s!important;animation-delay:0s!important;' +
+        'transition-duration:0s!important;transition-delay:0s!important;' +
+        'scroll-behavior:auto!important}'
+      const inject = () => {
+        if (document.getElementById('pw-no-animations')) return
+        const style = document.createElement('style')
+        style.id = 'pw-no-animations'
+        style.textContent = css
+        ;(document.head || document.documentElement).appendChild(style)
+      }
+      inject()
+      document.addEventListener('DOMContentLoaded', inject)
+    })
+
     await startCoverage(page)
     await use(page)
     await stopCoverage(page, testInfo)

--- a/apps/pwa/tests/global-setup.ts
+++ b/apps/pwa/tests/global-setup.ts
@@ -12,10 +12,11 @@ async function globalSetup(config: FullConfig) {
 
   const testAssetsDir = path.resolve(__dirname, '..', 'test', 'assets')
   const pwaRoot = path.resolve(__dirname, '..')
-  // public/ for vite dev server; build/ for vite preview. Playwright starts
-  // webServer (which runs vite build) before globalSetup, so by the time we
-  // run, build/ already exists — we just have to drop the test images into
-  // it so vite preview can serve them.
+  // public/ for vite dev server; build/ for vite preview. The build runs as a
+  // separate step (`test:e2e:build`) before Playwright so the two e2e lanes can
+  // share one build; the webServer only runs `vite preview`. By the time this
+  // setup runs, build/ already exists — we just drop the test images into it so
+  // vite preview can serve them.
   const targets = ['public', 'build']
 
   try {

--- a/apps/pwa/tests/keyboard-shortcuts.spec.ts
+++ b/apps/pwa/tests/keyboard-shortcuts.spec.ts
@@ -36,6 +36,13 @@ async function getDebugValue(page, request) {
   }, request);
 }
 
+// Each shortcut updates a Preact signal in the keydown handler. Rather than
+// sleep a fixed amount and hope the signal has propagated (flaky under CI CPU
+// contention), poll the same app-state read until it reflects the change.
+function poll(page, request) {
+  return expect.poll(() => getDebugValue(page, request));
+}
+
 test.describe('Keyboard Shortcuts', () => {
   test('should cycle view modes with "v"', async ({ page }) => {
     const canvas = page.locator('canvas').first();
@@ -43,12 +50,11 @@ test.describe('Keyboard Shortcuts', () => {
 
     const initialSliceType = await getDebugValue(page, 'getSliceType');
     await page.keyboard.press('v');
-    await page.waitForTimeout(200); // Wait for signal update
-    const newSliceType = await getDebugValue(page, 'getSliceType');
-
     // Slice type should change when cycling
-    expect(newSliceType).not.toBe(initialSliceType);
+    await poll(page, 'getSliceType').not.toBe(initialSliceType);
+
     // Cycle should wrap around eventually (0 to 4)
+    const newSliceType = await getDebugValue(page, 'getSliceType');
     expect(newSliceType).toBeGreaterThanOrEqual(0);
     expect(newSliceType).toBeLessThanOrEqual(4);
   });
@@ -57,13 +63,9 @@ test.describe('Keyboard Shortcuts', () => {
     const canvas = page.locator('canvas').first();
     await canvas.click();
 
-    await page.keyboard.press('2'); // First switch to Sagittal
-    await page.waitForTimeout(100);
-
+    await page.keyboard.press('2'); // First switch away from Axial
     await page.keyboard.press('1');
-    await page.waitForTimeout(100);
-    const sliceType = await getDebugValue(page, 'getSliceType');
-    expect(sliceType).toBe(0); // Axial
+    await poll(page, 'getSliceType').toBe(0); // Axial
   });
 
   test('should change view to Coronal with "3"', async ({ page }) => {
@@ -71,9 +73,7 @@ test.describe('Keyboard Shortcuts', () => {
     await canvas.click();
 
     await page.keyboard.press('3');
-    await page.waitForTimeout(100);
-    const sliceType = await getDebugValue(page, 'getSliceType');
-    expect(sliceType).toBe(1); // Coronal
+    await poll(page, 'getSliceType').toBe(1); // Coronal
   });
 
   test('should change view to Render with "4"', async ({ page }) => {
@@ -81,9 +81,7 @@ test.describe('Keyboard Shortcuts', () => {
     await canvas.click();
 
     await page.keyboard.press('4');
-    await page.waitForTimeout(100);
-    const sliceType = await getDebugValue(page, 'getSliceType');
-    expect(sliceType).toBe(4); // Render (SLICE_TYPE.RENDER is 4)
+    await poll(page, 'getSliceType').toBe(4); // Render (SLICE_TYPE.RENDER is 4)
   });
 
   test('should change view to Multiplanar+Render with "5"', async ({ page }) => {
@@ -91,9 +89,7 @@ test.describe('Keyboard Shortcuts', () => {
     await canvas.click();
 
     await page.keyboard.press('5');
-    await page.waitForTimeout(100);
-    const sliceType = await getDebugValue(page, 'getSliceType');
-    expect(sliceType).toBe(3); // Multiplanar (SLICE_TYPE.MULTIPLANAR is 3)
+    await poll(page, 'getSliceType').toBe(3); // Multiplanar (SLICE_TYPE.MULTIPLANAR is 3)
   });
 
   test('should toggle interpolation with "i"', async ({ page }) => {
@@ -102,9 +98,7 @@ test.describe('Keyboard Shortcuts', () => {
 
     const initial = await getDebugValue(page, 'getInterpolation');
     await page.keyboard.press('i');
-    await page.waitForTimeout(200);
-    const newVal = await getDebugValue(page, 'getInterpolation');
-    expect(newVal).toBe(!initial);
+    await poll(page, 'getInterpolation').toBe(!initial);
   });
 
   test('should toggle colorbar with "b"', async ({ page }) => {
@@ -113,9 +107,7 @@ test.describe('Keyboard Shortcuts', () => {
 
     const initial = await getDebugValue(page, 'getColorbar');
     await page.keyboard.press('b');
-    await page.waitForTimeout(200);
-    const newVal = await getDebugValue(page, 'getColorbar');
-    expect(newVal).toBe(!initial);
+    await poll(page, 'getColorbar').toBe(!initial);
   });
 
   test('should toggle radiological convention with "x"', async ({ page }) => {
@@ -124,9 +116,7 @@ test.describe('Keyboard Shortcuts', () => {
 
     const initial = await getDebugValue(page, 'getRadiological');
     await page.keyboard.press('x');
-    await page.waitForTimeout(200);
-    const newVal = await getDebugValue(page, 'getRadiological');
-    expect(newVal).toBe(!initial);
+    await poll(page, 'getRadiological').toBe(!initial);
   });
 
   test('should toggle crosshairs with "m"', async ({ page }) => {
@@ -135,9 +125,7 @@ test.describe('Keyboard Shortcuts', () => {
 
     const initial = await getDebugValue(page, 'getCrosshair');
     await page.keyboard.press('m');
-    await page.waitForTimeout(200);
-    const newVal = await getDebugValue(page, 'getCrosshair');
-    expect(newVal).toBe(!initial);
+    await poll(page, 'getCrosshair').toBe(!initial);
   });
 
   test('should toggle zoom mode with "z"', async ({ page }) => {
@@ -146,9 +134,7 @@ test.describe('Keyboard Shortcuts', () => {
 
     const initial = await getDebugValue(page, 'getZoomMode');
     await page.keyboard.press('z');
-    await page.waitForTimeout(200);
-    const newVal = await getDebugValue(page, 'getZoomMode');
-    expect(newVal).toBe(!initial);
+    await poll(page, 'getZoomMode').toBe(!initial);
   });
 
   test('should toggle UI visibility with "u"', async ({ page }) => {
@@ -157,10 +143,8 @@ test.describe('Keyboard Shortcuts', () => {
 
     const initial = await getDebugValue(page, 'getHideUI');
     await page.keyboard.press('u');
-    await page.waitForTimeout(200);
-    const newVal = await getDebugValue(page, 'getHideUI');
     // hideUI cycles: 3 -> 2 -> 0 -> 3
-    expect(newVal).not.toBe(initial);
+    await poll(page, 'getHideUI').not.toBe(initial);
   });
 
   test('should reset view with "r"', async ({ page }) => {
@@ -169,9 +153,7 @@ test.describe('Keyboard Shortcuts', () => {
 
     // Press 'r' to reset pan/zoom
     await page.keyboard.press('r');
-    await page.waitForTimeout(200);
-    const pan = await getDebugValue(page, 'getPan');
-    expect(pan).toEqual([0, 0, 0, 1]); // Reset to default pan
+    await poll(page, 'getPan').toEqual([0, 0, 0, 1]); // Reset to default pan
   });
 
   test('should move crosshair with "h", "j", "k", "l"', async ({ page }) => {
@@ -181,24 +163,24 @@ test.describe('Keyboard Shortcuts', () => {
     const initialPos = await getDebugValue(page, 'getCrosshairPos');
 
     await page.keyboard.press('l'); // Right
-    await page.waitForTimeout(100);
-    let newPos = await getDebugValue(page, 'getCrosshairPos');
-    expect(newPos[0]).toBeGreaterThan(initialPos[0]);
+    await expect
+      .poll(async () => (await getDebugValue(page, 'getCrosshairPos'))[0])
+      .toBeGreaterThan(initialPos[0]);
 
     await page.keyboard.press('h'); // Left
-    await page.waitForTimeout(100);
-    newPos = await getDebugValue(page, 'getCrosshairPos');
-    expect(newPos[0]).toBeCloseTo(initialPos[0]);
+    await expect
+      .poll(async () => (await getDebugValue(page, 'getCrosshairPos'))[0])
+      .toBeCloseTo(initialPos[0]);
 
     await page.keyboard.press('j'); // Posterior (Y increases in NiiVue vox space for posterior? Actually depends on orientation, but it should change)
-    await page.waitForTimeout(100);
-    newPos = await getDebugValue(page, 'getCrosshairPos');
-    expect(newPos[1]).not.toBe(initialPos[1]);
+    await expect
+      .poll(async () => (await getDebugValue(page, 'getCrosshairPos'))[1])
+      .not.toBe(initialPos[1]);
 
     await page.keyboard.press('k'); // Anterior
-    await page.waitForTimeout(100);
-    newPos = await getDebugValue(page, 'getCrosshairPos');
-    expect(newPos[1]).toBeCloseTo(initialPos[1]);
+    await expect
+      .poll(async () => (await getDebugValue(page, 'getCrosshairPos'))[1])
+      .toBeCloseTo(initialPos[1]);
   });
 
   test('should move crosshair superior/inferior with "Shift+U" and "Shift+D"', async ({ page }) => {
@@ -208,14 +190,14 @@ test.describe('Keyboard Shortcuts', () => {
     const initialPos = await getDebugValue(page, 'getCrosshairPos');
 
     await page.keyboard.press('Shift+U');
-    await page.waitForTimeout(100);
-    let newPos = await getDebugValue(page, 'getCrosshairPos');
-    expect(newPos[2]).toBeGreaterThan(initialPos[2]);
+    await expect
+      .poll(async () => (await getDebugValue(page, 'getCrosshairPos'))[2])
+      .toBeGreaterThan(initialPos[2]);
 
     await page.keyboard.press('Shift+D');
-    await page.waitForTimeout(100);
-    newPos = await getDebugValue(page, 'getCrosshairPos');
-    expect(newPos[2]).toBeCloseTo(initialPos[2]);
+    await expect
+      .poll(async () => (await getDebugValue(page, 'getCrosshairPos'))[2])
+      .toBeCloseTo(initialPos[2]);
   });
 
   test('should NOT trigger shortcuts when typing in input fields', async ({ page }) => {
@@ -232,10 +214,12 @@ test.describe('Keyboard Shortcuts', () => {
 
     const initialSliceType = await getDebugValue(page, 'getSliceType');
     await page.keyboard.press('v');
-    await page.waitForTimeout(100);
-    const newSliceType = await getDebugValue(page, 'getSliceType');
-
-    expect(newSliceType).toBe(initialSliceType);
+    // Awaiting the input value (web-first, auto-retrying) proves the keypress
+    // was consumed by the input rather than dropped — without a fixed sleep.
+    // Once the input shows the char, the shortcut, if it were going to fire,
+    // already would have; the slice type must be unchanged.
     await expect(input).toHaveValue('v');
+    const newSliceType = await getDebugValue(page, 'getSliceType');
+    expect(newSliceType).toBe(initialSliceType);
   });
 });

--- a/apps/pwa/tests/utils.ts
+++ b/apps/pwa/tests/utils.ts
@@ -18,7 +18,12 @@ export async function stopCoverage(page: Page, testInfo: TestInfo) {
   await addCoverageReport([...js, ...css], testInfo)
 }
 
-export async function waitForImageLoad(page: Page, timeout = 10000) {
+// Default failsafe is generous (30 s): this is a STATE wait on
+// `window.__niivue.loadedCount`, so it resolves the instant a load completes.
+// The timeout only bounds a genuinely hung load on a CPU-contended CI runner —
+// it is never part of the happy path. Callers may pass a larger value for loads
+// that fetch over the network.
+export async function waitForImageLoad(page: Page, timeout = 30000) {
   // Snapshot the current loaded count before we start waiting.
   // NiiVueCanvas increments window.__niivue.loadedCount after each successful
   // volume load. This is more reliable than waiting for <canvas> to appear,


### PR DESCRIPTION
## Problem

The PWA Playwright suite failed on CI under load - on **timeouts, not assertions** (e.g. `MenuOverflow`'s image load exceeding 30s; the tile-spacing PR's clicks exceeding the 5s `actionTimeout`). `main` was green, so the suite sat just under a resource ceiling and any WebGL-heavy addition tipped it over nondeterministically.

## Root cause (corrected)

The original analysis blamed an idle niivue `requestAnimationFrame` render loop pegging CPU. **That is not what happens.** Verified against the installed `@niivue/niivue@0.68.2` bundle: there are exactly **3** `requestAnimationFrame` calls - two coalesce resize events, one yields a frame during volume-chunk streaming. Rendering is **on-demand** (`drawScene()` gated by `isBusy`/`needsRefresh`); an **idle canvas costs ~0 CPU**. There is no loop to "quiet", so the proposed test-only quiet-render mode is dropped.

The real cause is **time used as the correctness signal** while CPU is contended on **software WebGL** (ANGLE/SwiftShader on CI): a 5s `actionTimeout`, a 30s test timeout, a 5-min suite-wide `globalTimeout`, and 29 fixed `waitForTimeout` sleeps all decide pass/fail by wall-clock.

## What this PR does

### Tier 1 - make pass/fail time-independent (the primary fix)
- `playwright.config.ts`: remove the suite-wide `globalTimeout`; raise per-test 30s->60s, action 5s->15s, nav 10s->30s (generous failsafes, not happy-path budgets).
- `fixtures.ts`: force-disable CSS transitions/animations + emulate `prefers-reduced-motion`.
- `utils.ts`: raise `waitForImageLoad` default failsafe 10s->30s (state wait on `window.__niivue.loadedCount`).
- Convert **all 29** `waitForTimeout` sleeps to state waits (`expect.poll` / web-first assertions). One documented bounded wait remains - verifying the *absence* of advance after pausing 4D cine, which no state wait can express.

### Tier 2 - bound the heavy lane (defense in depth)
- Route by **`@dom` default-deny**: tag only the 3 pure-DOM tests; everything else runs in a **serial (`--workers=1`) WebGL lane**. Fail-safe - a new/untagged spec runs serial, not in the flaky parallel lane. (Inverts the original "tag every heavy spec `@webgl`" idea: ~6x less churn, and the merged tile-spacing layout spec needs no tag.)
- Split build from serve so both lanes share one `vite build --base /`; the webServer runs `vite preview` only.
- CI e2e job: build -> fast lane (parallel) -> serial WebGL lane; `timeout-minutes` 10->15 for headroom.

### Docs
- New `apps/pwa/tests/README.md`: the architecture, the on-demand-render correction, the `@dom` convention, and an explicit **unit-first test-placement policy** (default to unit tests; spend e2e only where the real-browser integration is the thing under test).

### Drive-by bug fix
`handles multiple DICOM files` used a `?v=2` query that made the loader miss `.dcm` routing and fall through to the mesh path (which fails); the old blind sleep + `>=1`-canvas assert hid it. It now genuinely loads a second DICOM and asserts two canvases.

## Verification

Run on SwiftShader (same backend as CI), the exact CI path:
- fast lane: **3/3** passed
- serial WebGL lane: **52/52** passed (~3.3m serial)

Lint + type-check (`turbo lint type-check`): 16/16 tasks green.

> Note on `--workers=4`: extreme oversubscription on software WebGL can still exceed even a 30s failsafe on a single load - a *throughput* limit, not a correctness one. That is precisely why the heavy lane runs serial on CI.

## Context / relationship to #238

#238 (tile-spacing) is already merged; this branch is rebased on it. The layout **math + unit tests** are on `main`; only the layout **e2e smoke spec** stayed parked. Re-adding that spec is a small follow-up - under this architecture it needs no tag (untagged -> serial lane automatically).

## Follow-ups (not in this PR)
- Migrate logic-only e2e to unit/component tests per the new placement policy, starting with `keyboard-shortcuts.spec.ts` (it pays for a real WebGL load per test to assert keydown-handler logic a component test could cover far faster). This shrinks the serial lane and is where most of the remaining e2e wall-clock lives.
- Re-add the parked layout e2e smoke test.

## Test plan
- [ ] CI `e2e-tests` job green (build + fast + serial webgl lanes)
- [ ] 5 consecutive CI runs green (determinism check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
