### PR TITLE
docs(pwa): unit-first e2e test-placement policy + serial-lane CI headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,10 @@ jobs:
   e2e-tests:
     needs: [changes, build]
     if: needs.changes.outputs.pwa == 'true'
-    timeout-minutes: 10
+    # Headroom for the serial WebGL lane on software-WebGL CI. This is the only
+    # outer time bound now that globalTimeout is gone; bump the webgl lane to
+    # --workers=2 (see apps/pwa/tests/README.md) before lowering this.
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/apps/pwa/tests/README.md
+++ b/apps/pwa/tests/README.md
@@ -7,6 +7,38 @@ should assert that things are *wired up* (a load reaches a canvas, a setting
 drives a computed style, a shortcut flips a signal), never re-prove math and
 never read pixels.
 
+## What belongs in an e2e test (vs a unit test)
+
+**Default to a unit test. Reach for e2e only when the integration *is* the thing
+under test** — something a unit test cannot exercise without mocking away the very
+part that could break. e2e is the slowest, flakiest, most expensive layer (real
+browser, software WebGL, serial); spend it only where it earns its keep.
+
+Keep in **e2e** (real browser genuinely required):
+
+- A real image/DICOM/mesh load decodes and reaches a `<canvas>` (the load
+  pipeline + GL attach).
+- DOM geometry that depends on real layout/CSS — tiles fit their container, menus
+  overflow at a real viewport width.
+- Cross-component wiring through the real `postMessage` bus + signals — e.g. 4D
+  frame sync across two real niivue instances.
+
+Push to a **unit test** (`packages/niivue-react/src/test/**`):
+
+- Pure functions / math — layout sizing (already there), DICOM magic-byte
+  sniffing, filename classification, URL-param parsing.
+- A handler/reducer mapping an input to a state change — e.g. "key `v` advances
+  `sliceType`" is logic on the keydown handler, not something that needs a real
+  GPU load to verify.
+- Settings reducers, image reordering, document round-trip serialization.
+
+**Smell test:** if a spec loads a real image only to then assert a *pure-logic*
+outcome (a key flips a signal, a filename is classified, a count is computed), the
+logic belongs in a unit test — only the "a real load reaches a canvas" part, if
+any, stays in e2e. (Today `keyboard-shortcuts.spec.ts` is the clearest example: it
+pays for a real WebGL load per test to assert handler logic that a component test
+could cover far faster.)
+
 ## Why the suite is built the way it is
 
 The suite used to fail on CI under load — on **timeouts, not assertions**. Two
@@ -48,8 +80,11 @@ things caused that, and both are now designed out:
   emulated in `fixtures.ts`, so visibility/layout assertions never race
   animation timing.
 
-Because correctness no longer depends on timing, the suite passes at any worker
-count — including an over-subscribed `--workers=4` locally.
+Because correctness no longer depends on timing, contention affects only
+*speed*, not pass/fail. (At extreme oversubscription on software WebGL — say
+`--workers=4` — a single real load can still exceed even a generous failsafe;
+that is a *throughput* limit, not a correctness one, and is exactly what the
+serial heavy lane below prevents on CI.)
 
 ### 2. The heavy lane is bounded (defense in depth)
 

--- a/apps/pwa/tests/README.md
+++ b/apps/pwa/tests/README.md
@@ -2,7 +2,7 @@
 
 These specs are a **thin smoke layer** over wiring and DOM geometry. Exhaustive
 correctness (layout/tile math, utilities, reducers) lives in the package unit
-tests (`packages/niivue-react/src/test/**`, Vitest) — keep it there. An e2e test
+tests (`packages/niivue-react/src/test/**`, Vitest) - keep it there. An e2e test
 should assert that things are *wired up* (a load reaches a canvas, a setting
 drives a computed style, a shortcut flips a signal), never re-prove math and
 never read pixels.
@@ -10,7 +10,7 @@ never read pixels.
 ## What belongs in an e2e test (vs a unit test)
 
 **Default to a unit test. Reach for e2e only when the integration *is* the thing
-under test** — something a unit test cannot exercise without mocking away the very
+under test** - something a unit test cannot exercise without mocking away the very
 part that could break. e2e is the slowest, flakiest, most expensive layer (real
 browser, software WebGL, serial); spend it only where it earns its keep.
 
@@ -18,30 +18,30 @@ Keep in **e2e** (real browser genuinely required):
 
 - A real image/DICOM/mesh load decodes and reaches a `<canvas>` (the load
   pipeline + GL attach).
-- DOM geometry that depends on real layout/CSS — tiles fit their container, menus
+- DOM geometry that depends on real layout/CSS - tiles fit their container, menus
   overflow at a real viewport width.
-- Cross-component wiring through the real `postMessage` bus + signals — e.g. 4D
+- Cross-component wiring through the real `postMessage` bus + signals - e.g. 4D
   frame sync across two real niivue instances.
 
 Push to a **unit test** (`packages/niivue-react/src/test/**`):
 
-- Pure functions / math — layout sizing (already there), DICOM magic-byte
+- Pure functions / math - layout sizing (already there), DICOM magic-byte
   sniffing, filename classification, URL-param parsing.
-- A handler/reducer mapping an input to a state change — e.g. "key `v` advances
+- A handler/reducer mapping an input to a state change - e.g. "key `v` advances
   `sliceType`" is logic on the keydown handler, not something that needs a real
   GPU load to verify.
 - Settings reducers, image reordering, document round-trip serialization.
 
 **Smell test:** if a spec loads a real image only to then assert a *pure-logic*
 outcome (a key flips a signal, a filename is classified, a count is computed), the
-logic belongs in a unit test — only the "a real load reaches a canvas" part, if
+logic belongs in a unit test - only the "a real load reaches a canvas" part, if
 any, stays in e2e. (Today `keyboard-shortcuts.spec.ts` is the clearest example: it
 pays for a real WebGL load per test to assert handler logic that a component test
 could cover far faster.)
 
 ## Why the suite is built the way it is
 
-The suite used to fail on CI under load — on **timeouts, not assertions**. Two
+The suite used to fail on CI under load - on **timeouts, not assertions**. Two
 things caused that, and both are now designed out:
 
 1. **Time was the correctness signal.** A 5 s `actionTimeout` / 30 s test
@@ -54,10 +54,10 @@ things caused that, and both are now designed out:
 
 > **Myth, busted:** niivue does **not** run a continuous `requestAnimationFrame`
 > render loop. The installed `@niivue/niivue@0.68.2` bundle has exactly three
-> `requestAnimationFrame` calls — two coalesce resize events, one yields a frame
+> `requestAnimationFrame` calls - two coalesce resize events, one yields a frame
 > during volume-chunk streaming. Rendering is **on-demand** (`drawScene()` gated
 > by `isBusy`/`needsRefresh`); an **idle canvas burns ~0 CPU**. So there is no
-> idle loop to "quiet" under a test flag — don't add one. The cost is per
+> idle loop to "quiet" under a test flag - don't add one. The cost is per
 > *render* (load, resize, settings change, interaction) on software WebGL, not a
 > background loop.
 
@@ -70,7 +70,7 @@ things caused that, and both are now designed out:
   for non-DOM state (e.g. reading a signal via `page.evaluate`). They retry until
   true or until a *generous* failsafe fires.
 - **`waitForTimeout` is banned**, with one documented exception: verifying the
-  *absence* of a change in a timer-driven feature (4D cine "paused" — see
+  *absence* of a change in a timer-driven feature (4D cine "paused" - see
   `4d-navigation.spec.ts`), which no state wait can express.
 - Timeouts in `playwright.config.ts` are **failsafes, set generously** (60 s
   test, 15 s action, 30 s nav, no `globalTimeout`). They bound a genuine hang;
@@ -81,8 +81,8 @@ things caused that, and both are now designed out:
   animation timing.
 
 Because correctness no longer depends on timing, contention affects only
-*speed*, not pass/fail. (At extreme oversubscription on software WebGL — say
-`--workers=4` — a single real load can still exceed even a generous failsafe;
+*speed*, not pass/fail. (At extreme oversubscription on software WebGL - say
+`--workers=4` - a single real load can still exceed even a generous failsafe;
 that is a *throughput* limit, not a correctness one, and is exactly what the
 serial heavy lane below prevents on CI.)
 
@@ -127,7 +127,7 @@ is needed for the UI runner.
 ## Tuning
 
 If the serial webgl lane's wall-clock ever crowds the CI job's `timeout-minutes`,
-raise its concurrency — `playwright test --grep-invert @dom --workers=2`. This is
+raise its concurrency - `playwright test --grep-invert @dom --workers=2`. This is
 **safe**: there is no idle render loop, so two on-demand software-WebGL contexts
 contend only while actually rendering, and the generous failsafes absorb it. Keep
 `--workers=1` as the default for maximum determinism.


### PR DESCRIPTION
Small follow-up to #241 (the deterministic e2e architecture, now merged). These two refinements landed just after #241 was cut.

## 1. Unit-first test-placement policy (`apps/pwa/tests/README.md`)

Adds an explicit decision guide so contributors know what belongs in e2e vs a unit test:

- **Default to a unit test.** Reach for e2e only when the real-browser integration *is* the thing under test (a real load reaching a canvas; DOM geometry from real layout; cross-component wiring through the real message bus).
- **Push to unit** anything pure or component-local: math, magic-byte sniffing, filename classification, a keydown handler mapping a key to a signal, settings reducers, document round-trip.
- **Smell test:** if a spec loads a real image only to assert a pure-logic outcome, the logic belongs in a unit test. (`keyboard-shortcuts.spec.ts` is the clearest current example.)

Also corrects an over-stated line in the merged README: "passes at any worker count including `--workers=4`". Extreme oversubscription on software WebGL can still exceed a generous failsafe on a single real load - a *throughput* limit, not a correctness one, and exactly why the heavy lane runs serial.

## 2. Serial-lane CI headroom (`.github/workflows/ci.yml`)

Raise the e2e job `timeout-minutes` 10 -> 15. The serial WebGL lane trades wall-clock for determinism; 15 gives margin on software-WebGL runners. The note points at the `--workers=2` tuning knob to try before lowering it again.

## Test plan
- [ ] Docs/CI-only change; e2e suite behavior unchanged. CI `e2e-tests` job green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
