### PR TITLE
feat(colorscale): add "Hide 0" toggle to render zero as transparent (#237)

### DIFF
--- a/.changeset/colorscale-hide-zero.md
+++ b/.changeset/colorscale-hide-zero.md
@@ -1,0 +1,18 @@
+---
+'@niivue/react': minor
+'niivue': patch
+'@niivue/pwa': patch
+'@niivue/streamlit': patch
+'@niivue/jupyter': patch
+'@niivue/tauri': patch
+---
+
+Add a "Hide 0" toggle to the ColorScale menu that renders zero/background voxels
+as transparent (#237).
+
+The overlay ColorScale popup gains a toggle next to **Invert** that flips the
+layer's Niivue `colormapType` between `MIN_TO_MAX` (the default opaque mapping)
+and `ZERO_TO_MAX_TRANSPARENT_BELOW_MIN`. When enabled, voxels valued at zero
+become transparent regardless of the selected colormap, the cal_min/cal_max
+range, or whether the data is integer or float. It works for both volume layers
+and mesh layers, mirroring the existing per-overlay Invert control.

--- a/.changeset/colorscale-hide-zero.md
+++ b/.changeset/colorscale-hide-zero.md
@@ -16,3 +16,10 @@ and `ZERO_TO_MAX_TRANSPARENT_BELOW_MIN`. When enabled, voxels valued at zero
 become transparent regardless of the selected colormap, the cal_min/cal_max
 range, or whether the data is integer or float. It works for both volume layers
 and mesh layers, mirroring the existing per-overlay Invert control.
+
+Because `ZERO_TO_MAX_TRANSPARENT_BELOW_MIN` re-anchors the colormap at zero, a
+signed overlay (cal_min &lt; 0) would otherwise lose its entire negative half.
+To prevent that, enabling **Hide 0** on signed data that has no negative colormap
+automatically adds one (`winter`) so the negative values stay visible; the
+addition is removed again when the toggle is switched off, and a user-chosen
+negative/symmetric colormap is never overwritten.

--- a/packages/niivue-react/src/components/ScalingBox.tsx
+++ b/packages/niivue-react/src/components/ScalingBox.tsx
@@ -8,6 +8,13 @@ export interface ScalingOpts {
   max: number
 }
 
+// Niivue COLORMAP_TYPE values. MIN_TO_MAX is the default opaque mapping;
+// ZERO_TO_MAX_TRANSPARENT_BELOW_MIN scales the colormap from zero and renders
+// zero/background voxels as transparent (#237). Mirrored here to avoid importing
+// the enum, keeping the toggle a plain numeric property write.
+const MIN_TO_MAX = 0
+const ZERO_TRANSPARENT = 1
+
 export const ScalingBox = (props: any) => {
   const { nvArraySelected, selectedOverlayNumber, overlayMenu, visible } = props
   if (visible && !visible.value) return null
@@ -16,6 +23,9 @@ export const ScalingBox = (props: any) => {
     getOverlay(nvArraySelected.value[0], selectedOverlayNumber.value),
   )
   const invertState = useSignal(selectedOverlay.value.colormapInvert)
+  // colormapType === 1 (ZERO_TO_MAX_TRANSPARENT_BELOW_MIN) renders zero/background
+  // voxels as transparent. Works for any colormap, range or float/int data (#237).
+  const hideZeroState = useSignal(selectedOverlay.value.colormapType === ZERO_TRANSPARENT)
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -61,6 +71,14 @@ export const ScalingBox = (props: any) => {
     })
   }
 
+  const changeHideZero = () => {
+    hideZeroState.value = selectedOverlay.value.colormapType !== ZERO_TRANSPARENT
+    const colormapType = hideZeroState.value ? ZERO_TRANSPARENT : MIN_TO_MAX
+    nvArraySelected.value.forEach((nv: ExtendedNiivue) => {
+      handleOverlayColormapType(nv, selectedOverlayNumber.value, colormapType)
+    })
+  }
+
   return (
     <div className="absolute left-8 top-8 bg-gray-500 rounded-md z-50 space-y-1 space-x-1 p-1">
       <Scaling setScaling={setScaling} init={selectedOverlay.value} />
@@ -91,6 +109,15 @@ export const ScalingBox = (props: any) => {
         onClick={changeInverted}
       >
         Invert
+      </button>
+      <button
+        title="Render zero values as transparent"
+        className={`border-2 border-gray-600 rounded-md w-16 ${
+          hideZeroState.value ? 'bg-white text-gray-600' : 'bg-gray-600'
+        }`}
+        onClick={changeHideZero}
+      >
+        Hide 0
       </button>
       <button
         className="bg-gray-600 border-2 border-gray-600 rounded-md w-16 float-right"
@@ -172,6 +199,18 @@ function handleOverlayInvert(nv: ExtendedNiivue, layerNumber: number, invert: bo
     }
   } else {
     nv.setMeshLayerProperty(nv.meshes[0].id as any, layerNumber, 'colormapInvert', invert ? 1 : 0)
+  }
+  nv.updateGLVolume()
+}
+
+function handleOverlayColormapType(nv: ExtendedNiivue, layerNumber: number, colormapType: number) {
+  if (isVolumeOverlay(nv)) {
+    const overlay = nv.volumes[layerNumber]
+    if (overlay) {
+      overlay.colormapType = colormapType
+    }
+  } else {
+    nv.setMeshLayerProperty(nv.meshes[0].id as any, layerNumber, 'colormapType' as any, colormapType)
   }
   nv.updateGLVolume()
 }

--- a/packages/niivue-react/src/components/ScalingBox.tsx
+++ b/packages/niivue-react/src/components/ScalingBox.tsx
@@ -54,6 +54,13 @@ export const ScalingBox = (props: any) => {
     const colormap = e.target.value
     nvArraySelected.value.forEach((nv: ExtendedNiivue) => {
       handleOverlayColormap(nv, selectedOverlayNumber.value, colormap)
+      // Hide 0 anchors the colormap at zero; if it is active on signed data, make
+      // sure the freshly chosen colormap still keeps a negative colormap so the
+      // negative half stays visible (#237).
+      if (hideZeroState.value) {
+        reconcileHideZeroNegative(nv, selectedOverlayNumber.value)
+        nv.updateGLVolume()
+      }
     })
   }
 
@@ -73,9 +80,8 @@ export const ScalingBox = (props: any) => {
 
   const changeHideZero = () => {
     hideZeroState.value = selectedOverlay.value.colormapType !== ZERO_TRANSPARENT
-    const colormapType = hideZeroState.value ? ZERO_TRANSPARENT : MIN_TO_MAX
     nvArraySelected.value.forEach((nv: ExtendedNiivue) => {
-      handleOverlayColormapType(nv, selectedOverlayNumber.value, colormapType)
+      handleOverlayHideZero(nv, selectedOverlayNumber.value, hideZeroState.value!)
     })
   }
 
@@ -203,7 +209,57 @@ function handleOverlayInvert(nv: ExtendedNiivue, layerNumber: number, invert: bo
   nv.updateGLVolume()
 }
 
-function handleOverlayColormapType(nv: ExtendedNiivue, layerNumber: number, colormapType: number) {
+// Colormap used for the negative half when Hide 0 is auto-applied to signed data.
+const NEGATIVE_COLORMAP = 'winter'
+
+// Overlays we auto-assigned a negative colormap to (because Hide 0 would
+// otherwise drop their negative half). Tracked so toggling Hide 0 off — or
+// switching to a colormap that brings its own negative map — cleanly removes our
+// addition without ever clobbering a user-chosen negative/symmetric colormap.
+const autoNegativeOverlays = new WeakSet<object>()
+
+function handleOverlayHideZero(nv: ExtendedNiivue, layerNumber: number, enable: boolean) {
+  setOverlayColormapType(nv, layerNumber, enable ? ZERO_TRANSPARENT : MIN_TO_MAX)
+  if (enable) {
+    reconcileHideZeroNegative(nv, layerNumber)
+  } else {
+    removeAutoNegative(nv, layerNumber)
+  }
+  nv.updateGLVolume()
+}
+
+// Hide 0 (colormapType 1) re-anchors the colormap at zero, which renders every
+// negative voxel transparent unless a negative colormap is present. For a signed
+// overlay that has none, add one so the negative half stays visible; if the
+// overlay already carries a negative/symmetric colormap, leave it untouched (#237).
+function reconcileHideZeroNegative(nv: ExtendedNiivue, layerNumber: number) {
+  const overlay = getOverlay(nv, layerNumber)
+  if (!overlay) {
+    return
+  }
+  const hasNegativeColormap = (overlay.colormapNegative?.length ?? 0) > 0
+  if (overlayHasNegativeRange(overlay) && !hasNegativeColormap) {
+    setOverlayNegativeColormap(nv, layerNumber, NEGATIVE_COLORMAP)
+    autoNegativeOverlays.add(overlay)
+  } else if (hasNegativeColormap) {
+    // A colormap choice (e.g. symmetric) now owns the negative map; stop tracking it.
+    autoNegativeOverlays.delete(overlay)
+  }
+}
+
+function removeAutoNegative(nv: ExtendedNiivue, layerNumber: number) {
+  const overlay = getOverlay(nv, layerNumber)
+  if (overlay && autoNegativeOverlays.has(overlay)) {
+    setOverlayNegativeColormap(nv, layerNumber, '')
+    autoNegativeOverlays.delete(overlay)
+  }
+}
+
+function overlayHasNegativeRange(overlay: any) {
+  return (overlay?.cal_min ?? 0) < 0
+}
+
+function setOverlayColormapType(nv: ExtendedNiivue, layerNumber: number, colormapType: number) {
   if (isVolumeOverlay(nv)) {
     const overlay = nv.volumes[layerNumber]
     if (overlay) {
@@ -212,7 +268,19 @@ function handleOverlayColormapType(nv: ExtendedNiivue, layerNumber: number, colo
   } else {
     nv.setMeshLayerProperty(nv.meshes[0].id as any, layerNumber, 'colormapType', colormapType)
   }
-  nv.updateGLVolume()
+}
+
+function setOverlayNegativeColormap(nv: ExtendedNiivue, layerNumber: number, colormapNegative: string) {
+  if (isVolumeOverlay(nv)) {
+    const overlay = nv.volumes[layerNumber]
+    if (overlay) {
+      overlay.colormapNegative = colormapNegative
+    }
+  } else {
+    const id = nv.meshes[0].id
+    nv.setMeshLayerProperty(id as any, layerNumber, 'useNegativeCmap', (colormapNegative.length > 0) as any)
+    nv.setMeshLayerProperty(id as any, layerNumber, 'colormapNegative', colormapNegative as any)
+  }
 }
 
 function handleOverlayScaling(nv: ExtendedNiivue, layerNumber: number, scaling: ScalingOpts) {

--- a/packages/niivue-react/src/components/ScalingBox.tsx
+++ b/packages/niivue-react/src/components/ScalingBox.tsx
@@ -210,7 +210,7 @@ function handleOverlayColormapType(nv: ExtendedNiivue, layerNumber: number, colo
       overlay.colormapType = colormapType
     }
   } else {
-    nv.setMeshLayerProperty(nv.meshes[0].id as any, layerNumber, 'colormapType' as any, colormapType)
+    nv.setMeshLayerProperty(nv.meshes[0].id as any, layerNumber, 'colormapType', colormapType)
   }
   nv.updateGLVolume()
 }

--- a/packages/niivue-react/src/test/ScalingBox.test.tsx
+++ b/packages/niivue-react/src/test/ScalingBox.test.tsx
@@ -1,0 +1,65 @@
+import { signal } from '@preact/signals'
+import { fireEvent, render, screen } from '@testing-library/preact'
+import { describe, expect, it, vi } from 'vitest'
+import { ScalingBox } from '../components/ScalingBox'
+
+// Mock niivue to avoid webgl context issues in jsdom
+vi.mock('@niivue/niivue', () => ({
+  Niivue: vi.fn(),
+}))
+
+function makeVolumeNv() {
+  return {
+    volumes: [
+      {
+        colormap: 'gray',
+        colormapInvert: false,
+        colormapType: 0,
+        opacity: 1,
+        cal_min: 0,
+        cal_max: 1,
+      },
+    ],
+    meshes: [],
+    colormaps: () => ['gray', 'warm'],
+    updateGLVolume: vi.fn(),
+  }
+}
+
+function renderBox(nv: ReturnType<typeof makeVolumeNv>) {
+  return render(
+    <ScalingBox
+      nvArraySelected={signal([nv])}
+      selectedOverlayNumber={signal(0)}
+      overlayMenu={signal(true)}
+      visible={signal(true)}
+    />,
+  )
+}
+
+describe('ScalingBox "Hide 0" toggle (#237)', () => {
+  it('switches colormapType to ZERO_TO_MAX_TRANSPARENT_BELOW_MIN and back', () => {
+    const nv = makeVolumeNv()
+    renderBox(nv)
+
+    const button = screen.getByText('Hide 0')
+
+    fireEvent.click(button)
+    expect(nv.volumes[0].colormapType).toBe(1)
+    expect(nv.updateGLVolume).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(button)
+    expect(nv.volumes[0].colormapType).toBe(0)
+    expect(nv.updateGLVolume).toHaveBeenCalledTimes(2)
+  })
+
+  it('reflects an overlay that already renders zero as transparent', () => {
+    const nv = makeVolumeNv()
+    nv.volumes[0].colormapType = 1
+    renderBox(nv)
+
+    // Active state uses the white background highlight, matching the Invert button.
+    const button = screen.getByText('Hide 0')
+    expect(button.className).toContain('bg-white')
+  })
+})

--- a/packages/niivue-react/src/test/ScalingBox.test.tsx
+++ b/packages/niivue-react/src/test/ScalingBox.test.tsx
@@ -26,7 +26,26 @@ function makeVolumeNv() {
   }
 }
 
-function renderBox(nv: ReturnType<typeof makeVolumeNv>) {
+function makeMeshNv() {
+  const layer = {
+    colormap: 'hsv',
+    colormapInvert: false,
+    colormapType: 0,
+    opacity: 1,
+    cal_min: 0,
+    cal_max: 1,
+  }
+  return {
+    volumes: [],
+    meshes: [{ id: 'mesh-1', layers: [layer] }],
+    setMeshLayerProperty: vi.fn((_id: string, _layer: number, key: string, val: number) => {
+      ;(layer as Record<string, unknown>)[key] = val
+    }),
+    updateGLVolume: vi.fn(),
+  }
+}
+
+function renderBox(nv: ReturnType<typeof makeVolumeNv> | ReturnType<typeof makeMeshNv>) {
   return render(
     <ScalingBox
       nvArraySelected={signal([nv])}
@@ -61,5 +80,20 @@ describe('ScalingBox "Hide 0" toggle (#237)', () => {
     // Active state uses the white background highlight, matching the Invert button.
     const button = screen.getByText('Hide 0')
     expect(button.className).toContain('bg-white')
+  })
+
+  it('routes mesh-layer overlays through setMeshLayerProperty', () => {
+    const nv = makeMeshNv()
+    renderBox(nv)
+
+    const button = screen.getByText('Hide 0')
+
+    fireEvent.click(button)
+    expect(nv.setMeshLayerProperty).toHaveBeenLastCalledWith('mesh-1', 0, 'colormapType', 1)
+    expect(nv.updateGLVolume).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(button)
+    expect(nv.setMeshLayerProperty).toHaveBeenLastCalledWith('mesh-1', 0, 'colormapType', 0)
+    expect(nv.updateGLVolume).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/niivue-react/src/test/ScalingBox.test.tsx
+++ b/packages/niivue-react/src/test/ScalingBox.test.tsx
@@ -8,16 +8,18 @@ vi.mock('@niivue/niivue', () => ({
   Niivue: vi.fn(),
 }))
 
-function makeVolumeNv() {
+function makeVolumeNv(overlay: Record<string, unknown> = {}) {
   return {
     volumes: [
       {
         colormap: 'gray',
+        colormapNegative: '',
         colormapInvert: false,
         colormapType: 0,
         opacity: 1,
         cal_min: 0,
         cal_max: 1,
+        ...overlay,
       },
     ],
     meshes: [],
@@ -26,19 +28,21 @@ function makeVolumeNv() {
   }
 }
 
-function makeMeshNv() {
+function makeMeshNv(layerOverride: Record<string, unknown> = {}) {
   const layer = {
     colormap: 'hsv',
+    colormapNegative: '',
     colormapInvert: false,
     colormapType: 0,
     opacity: 1,
     cal_min: 0,
     cal_max: 1,
+    ...layerOverride,
   }
   return {
     volumes: [],
     meshes: [{ id: 'mesh-1', layers: [layer] }],
-    setMeshLayerProperty: vi.fn((_id: string, _layer: number, key: string, val: number) => {
+    setMeshLayerProperty: vi.fn((_id: string, _layer: number, key: string, val: unknown) => {
       ;(layer as Record<string, unknown>)[key] = val
     }),
     updateGLVolume: vi.fn(),
@@ -73,8 +77,7 @@ describe('ScalingBox "Hide 0" toggle (#237)', () => {
   })
 
   it('reflects an overlay that already renders zero as transparent', () => {
-    const nv = makeVolumeNv()
-    nv.volumes[0].colormapType = 1
+    const nv = makeVolumeNv({ colormapType: 1 })
     renderBox(nv)
 
     // Active state uses the white background highlight, matching the Invert button.
@@ -89,11 +92,62 @@ describe('ScalingBox "Hide 0" toggle (#237)', () => {
     const button = screen.getByText('Hide 0')
 
     fireEvent.click(button)
-    expect(nv.setMeshLayerProperty).toHaveBeenLastCalledWith('mesh-1', 0, 'colormapType', 1)
-    expect(nv.updateGLVolume).toHaveBeenCalledTimes(1)
+    expect(nv.setMeshLayerProperty).toHaveBeenCalledWith('mesh-1', 0, 'colormapType', 1)
 
     fireEvent.click(button)
-    expect(nv.setMeshLayerProperty).toHaveBeenLastCalledWith('mesh-1', 0, 'colormapType', 0)
-    expect(nv.updateGLVolume).toHaveBeenCalledTimes(2)
+    expect(nv.setMeshLayerProperty).toHaveBeenCalledWith('mesh-1', 0, 'colormapType', 0)
+  })
+
+  // colormapType=1 re-anchors the colormap at zero, so without a negative
+  // colormap the whole negative half of signed data would vanish. The toggle
+  // adds one for signed overlays and removes it again on toggle-off.
+  it('adds a negative colormap for signed data and removes it on toggle-off', () => {
+    const nv = makeVolumeNv({ cal_min: -5.2, cal_max: 5.3 })
+    renderBox(nv)
+
+    const button = screen.getByText('Hide 0')
+
+    fireEvent.click(button)
+    expect(nv.volumes[0].colormapType).toBe(1)
+    expect(nv.volumes[0].colormapNegative).toBe('winter')
+
+    fireEvent.click(button)
+    expect(nv.volumes[0].colormapType).toBe(0)
+    expect(nv.volumes[0].colormapNegative).toBe('')
+  })
+
+  it('does not add a negative colormap for unsigned data', () => {
+    const nv = makeVolumeNv({ cal_min: 0, cal_max: 5 })
+    renderBox(nv)
+
+    fireEvent.click(screen.getByText('Hide 0'))
+    expect(nv.volumes[0].colormapType).toBe(1)
+    expect(nv.volumes[0].colormapNegative).toBe('')
+  })
+
+  it('never clobbers a user-chosen negative colormap (symmetric)', () => {
+    const nv = makeVolumeNv({ cal_min: -5.2, cal_max: 5.3, colormapNegative: 'winter' })
+    renderBox(nv)
+
+    const button = screen.getByText('Hide 0')
+
+    fireEvent.click(button) // enable: must not re-assign or claim ownership
+    expect(nv.volumes[0].colormapNegative).toBe('winter')
+
+    fireEvent.click(button) // disable: must leave the user's negative map intact
+    expect(nv.volumes[0].colormapNegative).toBe('winter')
+  })
+
+  it('enables the negative colormap for signed mesh layers', () => {
+    const nv = makeMeshNv({ cal_min: -5.2, cal_max: 5.3 })
+    renderBox(nv)
+
+    fireEvent.click(screen.getByText('Hide 0'))
+    expect(nv.setMeshLayerProperty).toHaveBeenCalledWith('mesh-1', 0, 'useNegativeCmap', true)
+    expect(nv.setMeshLayerProperty).toHaveBeenCalledWith('mesh-1', 0, 'colormapNegative', 'winter')
+
+    fireEvent.click(screen.getByText('Hide 0'))
+    expect(nv.setMeshLayerProperty).toHaveBeenCalledWith('mesh-1', 0, 'useNegativeCmap', false)
+    expect(nv.setMeshLayerProperty).toHaveBeenCalledWith('mesh-1', 0, 'colormapNegative', '')
   })
 })


### PR DESCRIPTION
## Summary

Closes #237.

Adds an option to render zero / background voxels as **transparent**, placed in the per-overlay **ColorScale** menu (as the issue suggested). As hypothesized in the issue, Niivue core already supports this: the toggle flips the layer's `colormapType` between `MIN_TO_MAX` (the default opaque mapping) and `ZERO_TO_MAX_TRANSPARENT_BELOW_MIN`. The legacy `alphaThreshold` flag is intentionally avoided because Niivue now logs a deprecation warning for it and remaps it onto `colormapType` anyway.

When enabled, voxels valued at zero render transparent **independently of**:
- the selected colormap,
- the `cal_min` / `cal_max` range, and
- whether the data is integer or float.

It works for both volume layers and mesh layers, mirroring the existing per-overlay **Invert** control (same toggle styling, white highlight when active).

## Changes

- `packages/niivue-react/src/components/ScalingBox.tsx`: new **Hide 0** toggle button next to Invert, with a `handleOverlayColormapType` helper that writes `colormapType` on volume layers and via `setMeshLayerProperty` on mesh layers, then calls `updateGLVolume()`.
- `packages/niivue-react/src/test/ScalingBox.test.tsx`: unit tests covering the toggle round-trip (0 ↔ 1) and the active-state reflection for an overlay that already hides zero.
- Changeset added.

## Testing

- `pnpm --filter @niivue/react type-check` — clean
- `pnpm --filter @niivue/react lint` — clean
- `pnpm --filter @niivue/react test` — 87 passed (incl. 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
