### PR TITLE
fix(webgl): explain WebGL2-context failures with a troubleshooting hint

### DIFF
--- a/.changeset/webgl-context-error-hint.md
+++ b/.changeset/webgl-context-error-hint.md
@@ -1,0 +1,15 @@
+---
+'@niivue/react': patch
+'niivue': patch
+'@niivue/pwa': patch
+'@niivue/streamlit': patch
+'@niivue/jupyter': patch
+'@niivue/tauri': patch
+---
+
+Explain WebGL2-context failures in the on-canvas error instead of only showing the raw message.
+
+When a WebGL2 context cannot be created, niivue throws "unable to get WebGL context. Maybe the browser doesn't support WebGL2.", which already surfaces in the on-canvas error panel. On its own that message reads like a corrupt file, when it is actually an environment issue (no hardware acceleration, e.g. the VS Code snap build, missing GPU drivers, or recent Chromium dropping the automatic SwiftShader fallback).
+
+- The error panel now detects this specific message and appends a short note clarifying it is an environment/GPU issue, not the file, with a "How to fix" link to issue #236. Every app that mounts the shared viewer inherits this.
+- The VS Code extension README gains a Troubleshooting section with the recommended fix (restore hardware acceleration) and the temporary `enable-unsafe-swiftshader` workaround.

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -116,6 +116,31 @@ These shortcuts can be customized in VS Code's Keyboard Shortcuts editor (File â
 
 A standalone [web version](https://korbinian90.github.io/niivue-vscode) is also available that can be installed as a Progressive Web App with file associations (Chrome/Edge only).
 
+## Troubleshooting
+
+### "Failed to load image: unable to get WebGL context" (Linux)
+
+This viewer needs a WebGL2 context. If the editor cannot create one you will see "unable to get WebGL context. Maybe the browser doesn't support WebGL2." This is an environment / GPU issue, not a problem with the file, and it is most common on Linux.
+
+**Cause.** Recent Chromium versions (the engine inside VS Code; WebGL context creation starts failing from around Chromium 144) no longer fall back to software WebGL automatically. When the webview has no working hardware WebGL2 - common with the **snap** build of VS Code, missing or blocklisted GPU drivers, or some Wayland setups - WebGL2 becomes unavailable. The same extension version works on Windows because Windows has a separate software fallback (Direct3D WARP) that is not affected.
+
+**Recommended fix (restore hardware acceleration).**
+
+- If VS Code was installed as a snap, reinstall the official `.deb` / apt build; snap confinement often blocks GPU access.
+- Make sure GPU drivers are installed; on Wayland, trying an X11 session can also help.
+
+**Temporary workaround (software rendering).** Re-enable Chromium's software renderer. Open the Command Palette, run **Preferences: Configure Runtime Arguments**, add the following to `argv.json`, then fully restart VS Code:
+
+```json
+{
+  "enable-unsafe-swiftshader": true
+}
+```
+
+This renders in software: it works, but 3D is slower. Note that this Chromium flag is officially temporary and may be removed in a future release, so prefer the hardware-acceleration fix where possible.
+
+For details and to report your environment, see [issue #236](https://github.com/niivue/niivue-vscode/issues/236).
+
 ## Development
 
 This extension is part of the [niivue-vscode monorepo](https://github.com/niivue/niivue-vscode). Contributions are welcome!

--- a/packages/niivue-react/src/components/Volume.tsx
+++ b/packages/niivue-react/src/components/Volume.tsx
@@ -289,6 +289,20 @@ export const Volume = (props: AppProps & VolumeProps) => {
           <div className="text-xs text-gray-400 bg-black/30 p-2 rounded max-w-full overflow-y-auto max-h-24">
             {nv.loadError}
           </div>
+          {nv.loadError.includes('unable to get WebGL context') && (
+            <div className="text-xs text-gray-300 text-center max-w-full mt-3">
+              Your GPU or driver could not provide a WebGL2 context. This is an environment issue,
+              not a problem with the file.{' '}
+              <a
+                href="https://github.com/niivue/niivue-vscode/issues/236"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-400 underline"
+              >
+                How to fix
+              </a>
+            </div>
+          )}
         </div>
       ) : (
         <NiiVueCanvas {...props} render={props.render} />


### PR DESCRIPTION
## What

The on-canvas error panel now adds a short, targeted explanation and a "How to fix" link when WebGL2 context creation fails, instead of showing only niivue's raw message. Also adds a Troubleshooting section to the VS Code extension README.

Refs #236.

## Why

Reported on Linux in VS Code and reproduced on a second Debian machine: the same extension version that works on Windows fails with "Failed to load image: unable to get WebGL context. Maybe the browser doesn't support WebGL2."

The cause is environmental, not a bug in the extension. Recent Chromium (context creation starts failing around Chromium 144, which reached users via the VS Code Electron bump) removed the automatic fallback to software WebGL (SwiftShader). When the webview has no working hardware WebGL2 (common with the snap build of VS Code, missing or blocklisted GPU drivers, or some Wayland setups), `getContext('webgl2')` returns null. Windows is unaffected because its software fallback is Direct3D WARP, which Chromium does not gate.

niivue's message already surfaced in the error panel, but on its own it reads like a corrupt file. This change keeps that message and appends one line clarifying it is an environment/GPU issue, with a pointer to the fix.

## Changes

- `packages/niivue-react/src/components/Volume.tsx`: in the existing `nv.loadError` panel, when the message is exactly `unable to get WebGL context`, render a concise note plus a "How to fix" link to #236. Detection is a precise substring match. Every app mounts the shared `Container` -> `Volume`, so the PWA, Jupyter, Streamlit, and desktop apps inherit it too.
- `apps/vscode/README.md`: Troubleshooting section with the recommended fix (restore hardware acceleration; replace the snap with the official `.deb`) and the temporary `enable-unsafe-swiftshader` argv.json workaround, flagged as temporary since Chromium is removing it.
- Changeset (patch).

## Notes for reviewers

- Deliberately minimal: no capability probe, no separate component, no host detection, no new message protocol. The error is already displayed; this only augments it.
- `prettier --write` was intentionally not run on the touched existing files (repo source is not Prettier-conformant at baseline), so the diff is intent-only.
- Verified locally: typecheck (all packages), `@niivue/react` and `niivue` unit tests, and lint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)