### PR TITLE
feat(label-selection): add per-label visibility controls for segmenta…

### DIFF
--- a/.changeset/label-selection-229.md
+++ b/.changeset/label-selection-229.md
@@ -1,0 +1,27 @@
+---
+'@niivue/react': minor
+'niivue': patch
+'@niivue/pwa': patch
+'@niivue/streamlit': patch
+'@niivue/jupyter': patch
+---
+
+Add per-label visibility controls for segmentation and atlas images (#229).
+
+Integer label maps (base image or overlay) get a "labels" entry in the
+ColorScale colormap dropdown. Selecting it renders the image as color-coded
+labels and reveals a "Labels" button that opens a panel of per-label
+checkboxes; selecting any normal color scale switches back to continuous
+rendering. Highlights:
+
+- Offered only for integer NIfTI images; when the image has no color table,
+  one is built from the data's distinct values
+- Per-label checkboxes with color swatches, search and select all / none, and
+  incremental loading for large atlases (100+ labels)
+- Works across multiple open files: the color table is built from the union of
+  label values across the selected canvases, so atlases with different label
+  ranges each render correctly, and the panel lists every file's labels
+- Toggling rewrites the color-table alpha and applies to every selected canvas
+
+Labels are opt-in via the dropdown and are not auto-applied when the popup
+opens.

--- a/packages/niivue-react/src/components/LabelSelectionPanel.tsx
+++ b/packages/niivue-react/src/components/LabelSelectionPanel.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
+import { LabelInfo } from './labelSelection'
+
+interface LabelSelectionPanelProps {
+  labels: LabelInfo[]
+  onLabelToggle: (labelValue: number, visible: boolean) => void
+  onSelectAll: () => void
+  onDeselectAll: () => void
+  onClose: () => void
+}
+
+export const LabelSelectionPanel = (props: LabelSelectionPanelProps) => {
+  const { labels, onLabelToggle, onSelectAll, onDeselectAll, onClose } = props
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const filteredLabels = useMemo(() => {
+    if (!searchQuery.trim()) {
+      return labels
+    }
+    const query = searchQuery.toLowerCase()
+    return labels.filter(
+      (label) =>
+        label.name?.toLowerCase().includes(query) || label.value.toString().includes(query),
+    )
+  }, [labels, searchQuery])
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+
+  // Handle large label sets with incremental loading
+  const VISIBLE_LABELS_LIMIT = 100
+  const [visibleCount, setVisibleCount] = useState(VISIBLE_LABELS_LIMIT)
+
+  useEffect(() => {
+    setVisibleCount(VISIBLE_LABELS_LIMIT)
+  }, [filteredLabels.length])
+
+  const handleScroll = () => {
+    if (scrollContainerRef.current) {
+      const { scrollTop, scrollHeight, clientHeight } = scrollContainerRef.current
+      if (scrollHeight - scrollTop - clientHeight < 50) {
+        setVisibleCount((prev) => Math.min(prev + 50, filteredLabels.length))
+      }
+    }
+  }
+
+  const displayLabels = filteredLabels.slice(0, visibleCount)
+  const hasMoreLabels = filteredLabels.length > visibleCount
+
+  return (
+    <div className="absolute left-8 top-32 bg-gray-500 rounded-md z-50 p-3 min-w-[280px] max-w-[400px] max-h-[400px] flex flex-col">
+      {/* Header with search */}
+      <div className="flex justify-between items-center mb-3 pb-2 border-b border-gray-600">
+        <span className="text-white text-sm font-bold">Label Visibility ({labels.length})</span>
+        <div className="space-x-1">
+          <button
+            className="bg-gray-600 hover:bg-gray-500 text-white text-xs px-2 py-1 rounded transition-colors"
+            onClick={onSelectAll}
+            title="Show all labels"
+          >
+            All
+          </button>
+          <button
+            className="bg-gray-600 hover:bg-gray-500 text-white text-xs px-2 py-1 rounded transition-colors"
+            onClick={onDeselectAll}
+            title="Hide all labels"
+          >
+            None
+          </button>
+        </div>
+      </div>
+
+      {/* Search box for large label sets */}
+      {labels.length > 10 && (
+        <div className="mb-2">
+          <input
+            type="text"
+            placeholder="Search labels..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.currentTarget.value)}
+            className="w-full bg-gray-700 border border-gray-600 rounded px-2 py-1 text-white text-sm focus:outline-none focus:border-gray-400"
+          />
+        </div>
+      )}
+
+      {/* Scrollable label list */}
+      <div
+        ref={scrollContainerRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto space-y-1 pr-2 min-h-[100px] max-h-[250px]"
+      >
+        {displayLabels.map((label) => (
+          <div
+            key={label.value}
+            className="flex items-center space-x-2 hover:bg-gray-600 rounded px-2 py-1.5 transition-colors cursor-pointer"
+            onClick={(e) => {
+              if ((e.target as HTMLElement).tagName !== 'INPUT') {
+                onLabelToggle(label.value, !label.visible)
+              }
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={label.visible}
+              onChange={(e) => {
+                e.stopPropagation()
+                onLabelToggle(label.value, e.currentTarget.checked)
+              }}
+              onClick={(e) => e.stopPropagation()}
+              className="w-4 h-4 cursor-pointer accent-blue-500"
+              id={`label-${label.value}`}
+            />
+            <div
+              className="w-4 h-4 rounded-sm border border-gray-400 flex-shrink-0"
+              style={{
+                backgroundColor: `rgb(${label.color[0]}, ${label.color[1]}, ${label.color[2]})`,
+              }}
+              title={`Label ${label.value}: ${label.name || 'Unnamed'}`}
+            />
+            <label
+              htmlFor={`label-${label.value}`}
+              className="text-white text-sm cursor-pointer flex-1 truncate"
+              title={label.name || `Label ${label.value}`}
+            >
+              {label.name || `Label ${label.value}`}
+            </label>
+            <span className="text-gray-400 text-xs">#{label.value}</span>
+          </div>
+        ))}
+
+        {hasMoreLabels && (
+          <div className="text-center py-2 text-gray-400 text-xs">
+            Loading more labels... ({visibleCount}/{filteredLabels.length})
+          </div>
+        )}
+
+        {filteredLabels.length === 0 && (
+          <div className="text-center py-4 text-gray-400 text-sm">
+            {searchQuery ? 'No labels match your search' : 'No labels found'}
+          </div>
+        )}
+      </div>
+
+      {/* Footer with count and close */}
+      <div className="mt-3 pt-2 border-t border-gray-600 flex justify-between items-center">
+        <span className="text-gray-400 text-xs">
+          {labels.filter((l) => l.visible).length} of {labels.length} visible
+        </span>
+        <button
+          className="bg-gray-600 hover:bg-gray-500 text-white text-sm px-4 py-1.5 rounded transition-colors"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/packages/niivue-react/src/components/ScalingBox.tsx
+++ b/packages/niivue-react/src/components/ScalingBox.tsx
@@ -1,12 +1,27 @@
 import { computed, useSignal } from '@preact/signals'
 import { useEffect, useRef } from 'preact/hooks'
 import { ExtendedNiivue } from '../events'
+import { LabelSelectionPanel } from './LabelSelectionPanel'
+import {
+  applyLabelVisibility,
+  buildColormapLabel,
+  detectLabelValues,
+  detectLabelValuesAcross,
+  getOverlayLabels,
+  isLabelOverlay,
+  LabelInfo,
+  mergeLabelLists,
+} from './labelSelection'
 
 export interface ScalingOpts {
   isManual: boolean
   min: number
   max: number
 }
+
+// Sentinel value for the colormap dropdown meaning "render as labels" instead of
+// a continuous color scale. Picking any real colormap leaves label mode.
+const LABELS_COLORMAP = 'labels'
 
 export const ScalingBox = (props: any) => {
   const { nvArraySelected, selectedOverlayNumber, overlayMenu, visible } = props
@@ -16,10 +31,97 @@ export const ScalingBox = (props: any) => {
     getOverlay(nvArraySelected.value[0], selectedOverlayNumber.value),
   )
   const invertState = useSignal<boolean>(!!selectedOverlay.value.isColormapInverted)
+  const labelSelectionOpen = useSignal(false)
+  const labelVisibility = useSignal<Record<number, boolean>>({})
+  const labelsList = useSignal<LabelInfo[]>([])
+  // True when the selected layer is an integer image that can be turned into a
+  // label map - exposed via the "labels" colormap option.
+  const labelCapable = useSignal(false)
+
+  // The selected layer's overlay on each selected canvas, paired with its
+  // instance. Mesh-only canvases (no volumes) drop out. The per-label controls
+  // act across every selected canvas, matching the rest of this component.
+  const selectedOverlays = () =>
+    nvArraySelected.value
+      .map((nv: ExtendedNiivue) => ({
+        nv,
+        overlay: isVolumeOverlay(nv) ? nv.volumes[selectedOverlayNumber.value] : undefined,
+      }))
+      .filter((entry: { overlay?: unknown }) => entry.overlay)
+
+  // True when any selected canvas's layer is an integer label map.
+  const anyLabelCapable = () =>
+    selectedOverlays().some(({ overlay }: any) => !!detectLabelValues(overlay)?.length)
+
+  // Build one color table from the union of label values across every selected
+  // label-map canvas, then apply it to each of them. Building from the union -
+  // rather than just the first canvas - is what lets labels render correctly
+  // when several files with different label ranges are open at once. Non-label
+  // canvases (e.g. a continuous anatomical image) are left untouched.
+  const enableLabels = () => {
+    const overlays = selectedOverlays()
+    const values = detectLabelValuesAcross(overlays.map(({ overlay }: any) => overlay))
+    if (values.length === 0) {
+      return
+    }
+    const built = buildColormapLabel(values)
+    overlays.forEach(({ nv, overlay }: any) => {
+      if (detectLabelValues(overlay)?.length) {
+        overlay.colormapLabel = { lut: new Uint8ClampedArray(built.lut) }
+        nv.updateGLVolume()
+      }
+    })
+    labelVisibility.value = {}
+    labelsList.value = getOverlayLabels(built)
+    labelCapable.value = false
+  }
+
+  // Clear the label color table on every selected canvas so the layer renders
+  // with its normal colormap again (the "go back to a color scale" path), then
+  // re-offer the "labels" option since the image is still an integer label map.
+  const disableLabels = () => {
+    selectedOverlays().forEach(({ nv, overlay }: any) => {
+      overlay.colormapLabel = null
+      nv.updateGLVolume()
+    })
+    labelsList.value = []
+    labelVisibility.value = {}
+    labelSelectionOpen.value = false
+    labelCapable.value = anyLabelCapable()
+  }
+
+  // Detect what label controls apply across the selected canvases. Per-label
+  // controls are only offered for INTEGER label maps:
+  //   - any canvas already has a color table -> list those labels (unioned)
+  //   - integer data otherwise               -> offer the "labels" option to opt in
+  // Labels are never auto-applied on open; the user opts in via the dropdown.
+  useEffect(() => {
+    labelCapable.value = false
+    const overlays = selectedOverlays()
+    if (overlays.length === 0) {
+      labelsList.value = []
+      labelSelectionOpen.value = false
+      return
+    }
+    const labelled = overlays.filter(({ overlay }: any) => isLabelOverlay(overlay))
+    if (labelled.length > 0) {
+      labelVisibility.value = {}
+      labelsList.value = mergeLabelLists(
+        labelled.map(({ overlay }: any) => getOverlayLabels(overlay.colormapLabel)),
+      )
+      return
+    }
+    labelsList.value = []
+    labelSelectionOpen.value = false
+    labelCapable.value = anyLabelCapable()
+  }, [selectedOverlayNumber.value])
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') overlayMenu.value = false
+      if (e.key === 'Escape') {
+        overlayMenu.value = false
+        labelSelectionOpen.value = false
+      }
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
@@ -33,16 +135,27 @@ export const ScalingBox = (props: any) => {
 
   const colormaps = computed(() => {
     const isVolume = nvArraySelected.value[0]?.volumes?.length > 0
-    if (isVolume) {
-      // v1: `colormaps` is a getter property (string[]), no longer a method.
-      return ['symmetric', ...nvArraySelected.value[0].colormaps]
-    } else {
-      return ['ge_color', 'gray', 'hsv', 'symmetric', 'warm']
-    }
+    // v1: `colormaps` is a getter property (string[]), no longer a method.
+    const scales = isVolume
+      ? ['symmetric', ...nvArraySelected.value[0].colormaps]
+      : ['ge_color', 'gray', 'hsv', 'symmetric', 'warm']
+    // Integer label maps render as labels; offer that as a colormap choice so
+    // picking any real color scale leaves label mode.
+    return labelCapable.value || labelsList.value.length > 0 ? [LABELS_COLORMAP, ...scales] : scales
   })
 
   const changeColormap = (e: any) => {
     const colormap = e.target.value
+    if (colormap === LABELS_COLORMAP) {
+      if (labelsList.value.length === 0) {
+        enableLabels()
+      }
+      return
+    }
+    // Selecting a real color scale leaves label mode (back to normal rendering).
+    if (labelsList.value.length > 0) {
+      disableLabels()
+    }
     nvArraySelected.value.forEach((nv: ExtendedNiivue) => {
       handleOverlayColormap(nv, selectedOverlayNumber.value, colormap)
     })
@@ -62,13 +175,48 @@ export const ScalingBox = (props: any) => {
     })
   }
 
+  const handleLabelSelectionClick = () => {
+    labelSelectionOpen.value = !labelSelectionOpen.value
+  }
+
+  // Apply the current visibility map to every selected canvas, matching the
+  // multi-canvas behaviour of the other overlay controls in this component.
+  const applyVisibility = (visibility: Record<number, boolean>) => {
+    nvArraySelected.value.forEach((nv: ExtendedNiivue) => {
+      updateLabelVisibility(nv, selectedOverlayNumber.value, visibility)
+    })
+  }
+
+  const handleLabelToggle = (labelValue: number, visible: boolean) => {
+    labelVisibility.value = { ...labelVisibility.value, [labelValue]: visible }
+    labelsList.value = labelsList.value.map((label) =>
+      label.value === labelValue ? { ...label, visible } : label,
+    )
+    applyVisibility(labelVisibility.value)
+  }
+
+  const setAllLabels = (visible: boolean) => {
+    const newVisibility: Record<number, boolean> = {}
+    labelsList.value.forEach((label) => {
+      newVisibility[label.value] = visible
+    })
+    labelVisibility.value = newVisibility
+    labelsList.value = labelsList.value.map((label) => ({ ...label, visible }))
+    applyVisibility(newVisibility)
+  }
+
+  const handleSelectAll = () => setAllLabels(true)
+  const handleDeselectAll = () => setAllLabels(false)
+
+  const hasLabels = labelsList.value.length > 0
+
   return (
     <div className="absolute left-8 top-8 bg-gray-500 rounded-md z-50 space-y-1 space-x-1 p-1">
       <Scaling setScaling={setScaling} init={selectedOverlay.value} />
       <select
         className="bg-gray-600 w-24 border-2 border-gray-600 rounded-md"
         onChange={changeColormap}
-        value={selectedOverlay.value.colormap}
+        value={labelsList.value.length > 0 ? LABELS_COLORMAP : selectedOverlay.value.colormap}
       >
         {colormaps.value.map((c) => (
           <option key={c} value={c}>
@@ -93,12 +241,36 @@ export const ScalingBox = (props: any) => {
       >
         Invert
       </button>
+      {hasLabels && (
+        <button
+          className={`border-2 border-gray-600 rounded-md w-16 ${
+            labelSelectionOpen.value ? 'bg-white text-gray-600' : 'bg-gray-600'
+          }`}
+          onClick={handleLabelSelectionClick}
+          title="Toggle label visibility"
+        >
+          Labels
+        </button>
+      )}
       <button
         className="bg-gray-600 border-2 border-gray-600 rounded-md w-16 float-right"
-        onClick={() => (overlayMenu.value = false)}
+        onClick={() => {
+          overlayMenu.value = false
+          labelSelectionOpen.value = false
+        }}
       >
         Close
       </button>
+
+      {labelSelectionOpen.value && hasLabels && (
+        <LabelSelectionPanel
+          labels={labelsList.value}
+          onLabelToggle={handleLabelToggle}
+          onSelectAll={handleSelectAll}
+          onDeselectAll={handleDeselectAll}
+          onClose={() => (labelSelectionOpen.value = false)}
+        />
+      )}
     </div>
   )
 }
@@ -238,4 +410,28 @@ function setMeshColormap(nv: ExtendedNiivue, layerNumber: number, colormap: stri
 function getOverlay(nv: ExtendedNiivue, layerNumber: number) {
   const layers = isVolumeOverlay(nv) ? nv.volumes : nv.meshes[0].layers
   return layers[layerNumber]
+}
+
+/**
+ * Apply per-label visibility to a single canvas by rewriting the alpha bytes of
+ * the overlay's colour-table LUT and refreshing the GL volume. Mesh layers have
+ * no colormapLabel and are ignored.
+ */
+function updateLabelVisibility(
+  nv: ExtendedNiivue,
+  layerNumber: number,
+  labelVisibility: Record<number, boolean>,
+) {
+  if (!isVolumeOverlay(nv)) {
+    return
+  }
+  const overlay = nv.volumes[layerNumber]
+  if (!overlay?.colormapLabel?.lut) {
+    return
+  }
+  overlay.colormapLabel = {
+    ...overlay.colormapLabel,
+    lut: applyLabelVisibility(overlay.colormapLabel.lut, labelVisibility),
+  }
+  nv.updateGLVolume()
 }

--- a/packages/niivue-react/src/components/labelSelection.ts
+++ b/packages/niivue-react/src/components/labelSelection.ts
@@ -1,0 +1,268 @@
+// Structural mirror of @niivue/niivue's LUT (a color table): the package does
+// not re-export the LUT type from its root, and we only need these two fields.
+export interface ColorLUT {
+  lut: Uint8ClampedArray
+  labels?: string[]
+}
+
+// Minimal shape of the parts of an NVImage we inspect for label detection.
+interface LabelImage {
+  img?: ArrayLike<number> | null
+  colormapLabel?: ColorLUT | null
+  hdr?: { datatypeCode?: number; intent_code?: number } | null
+}
+
+export interface LabelInfo {
+  value: number
+  name?: string
+  color: [number, number, number]
+  visible: boolean
+}
+
+// NIfTI datatype codes for integer voxels. Segmentations/atlases are integer;
+// continuous anatomical/statistical images are float (16, 64, 1536) and are not
+// label maps, so the per-label controls never apply to them.
+const INTEGER_DATATYPE_CODES = new Set([2, 4, 8, 256, 512, 768, 1024, 1280])
+// NIFTI_INTENT_LABEL — a hard signal that the image *is* a label map.
+const NIFTI_INTENT_LABEL = 1002
+// Upper bounds that keep a stray continuous image from being treated as labels
+// (and keep the built LUT a sane size). Real atlases stay well under these.
+const MAX_DISTINCT_LABELS = 8192
+const MAX_LABEL_VALUE = 65535
+
+/**
+ * A label/segmentation overlay is one that already carries a colormapLabel (the
+ * LUT produced when a volume is loaded with a colour table). The per-label
+ * controls key off this.
+ */
+export function isLabelOverlay(overlay: { colormapLabel?: ColorLUT | null } | null | undefined): boolean {
+  return overlay?.colormapLabel !== null && overlay?.colormapLabel !== undefined
+}
+
+/** Integer voxel data — the precondition for offering label controls. */
+export function isIntegerVolume(overlay: LabelImage | null | undefined): boolean {
+  const code = overlay?.hdr?.datatypeCode
+  return typeof code === 'number' && INTEGER_DATATYPE_CODES.has(code)
+}
+
+/** NIFTI_INTENT_LABEL: the image declares itself a label map, so auto-enable. */
+export function isAutoLabelMap(overlay: LabelImage | null | undefined): boolean {
+  return overlay?.hdr?.intent_code === NIFTI_INTENT_LABEL
+}
+
+/**
+ * Scan voxel data for the distinct non-zero integer values (the labels). Returns
+ * them sorted, or null when the data does not look like a label map — too many
+ * distinct values (a continuous image) or values too large to index a LUT. The
+ * early-exit keeps continuous images cheap: they blow past the cap almost
+ * immediately, so the scan stops long before reading the whole volume.
+ */
+export function getUniqueLabelValues(
+  img: ArrayLike<number> | null | undefined,
+  maxDistinct = MAX_DISTINCT_LABELS,
+): number[] | null {
+  if (!img || typeof img.length !== 'number') {
+    return null
+  }
+  const values = new Set<number>()
+  for (let i = 0; i < img.length; i++) {
+    const rounded = Math.round(img[i])
+    if (rounded === 0 || rounded < 0) {
+      continue
+    }
+    if (!values.has(rounded)) {
+      if (rounded > MAX_LABEL_VALUE || values.size >= maxDistinct) {
+        return null
+      }
+      values.add(rounded)
+    }
+  }
+  return Array.from(values).sort((a, b) => a - b)
+}
+
+/**
+ * Deterministic, visually distinct colour for a label value, using the golden
+ * angle so adjacent label values land far apart on the hue wheel.
+ */
+export function generateLabelColor(value: number): [number, number, number] {
+  const hue = (value * 137.508) % 360
+  const saturation = 0.7
+  const lightness = 0.6
+  const c = (1 - Math.abs(2 * lightness - 1)) * saturation
+  const x = c * (1 - Math.abs(((hue / 60) % 2) - 1))
+  const m = lightness - c / 2
+  let r, g, b
+  if (hue < 60) {
+    r = c
+    g = x
+    b = 0
+  } else if (hue < 120) {
+    r = x
+    g = c
+    b = 0
+  } else if (hue < 180) {
+    r = 0
+    g = c
+    b = x
+  } else if (hue < 240) {
+    r = 0
+    g = x
+    b = c
+  } else if (hue < 300) {
+    r = x
+    g = 0
+    b = c
+  } else {
+    r = c
+    g = 0
+    b = x
+  }
+  return [Math.round((r + m) * 255), Math.round((g + m) * 255), Math.round((b + m) * 255)]
+}
+
+/**
+ * Build a colormapLabel (color table) for a set of label values that has no LUT
+ * of its own. The LUT is indexed by value: present labels get a generated colour
+ * at full alpha, every other slot stays transparent (so getOverlayLabels lists
+ * exactly the present labels and NiiVue renders only them).
+ */
+export function buildColormapLabel(values: number[]): ColorLUT {
+  const maxValue = values.length ? values[values.length - 1] : 0
+  const lut = new Uint8ClampedArray((maxValue + 1) * 4)
+  for (const value of values) {
+    if (value < 0) {
+      continue
+    }
+    const [r, g, b] = generateLabelColor(value)
+    const offset = value * 4
+    lut[offset] = r
+    lut[offset + 1] = g
+    lut[offset + 2] = b
+    lut[offset + 3] = 255
+  }
+  return { lut }
+}
+
+// Cache the (one-time) voxel scan per image so reopening the ColorScale does not
+// rescan. Keyed by the NVImage object, so it is dropped when the image is.
+const scanCache = new WeakMap<object, number[] | null>()
+
+/**
+ * Determine the label values for an integer overlay, scanning once and caching.
+ * Returns null for non-integer images or data that does not look like labels.
+ */
+export function detectLabelValues(overlay: LabelImage | null | undefined): number[] | null {
+  if (!overlay || !isIntegerVolume(overlay)) {
+    return null
+  }
+  if (scanCache.has(overlay as object)) {
+    return scanCache.get(overlay as object) ?? null
+  }
+  const values = getUniqueLabelValues(overlay.img)
+  scanCache.set(overlay as object, values)
+  return values
+}
+
+/**
+ * Union the label values of several overlays (one per selected canvas). Only
+ * overlays that look like integer label maps contribute; others are skipped.
+ * The single colour table built from this union renders correctly on every
+ * canvas, even when the open files use different label ranges - which is why
+ * building from the union (not just the first canvas) is what makes the
+ * per-label controls work for multiple files at once.
+ */
+export function detectLabelValuesAcross(
+  overlays: Array<LabelImage | null | undefined>,
+): number[] {
+  const union = new Set<number>()
+  for (const overlay of overlays) {
+    const values = detectLabelValues(overlay)
+    if (values) {
+      for (const value of values) {
+        union.add(value)
+      }
+    }
+  }
+  return Array.from(union).sort((a, b) => a - b)
+}
+
+/**
+ * Merge per-canvas label lists into one, keyed by value, so a value shared
+ * across files appears once and toggling it affects every canvas that contains
+ * it. The first occurrence of a value keeps its name and colour; a label counts
+ * as visible only when it is visible in every list that contains it.
+ */
+export function mergeLabelLists(lists: LabelInfo[][]): LabelInfo[] {
+  const byValue = new Map<number, LabelInfo>()
+  for (const list of lists) {
+    for (const label of list) {
+      const existing = byValue.get(label.value)
+      if (existing) {
+        existing.visible = existing.visible && label.visible
+      } else {
+        byValue.set(label.value, { ...label })
+      }
+    }
+  }
+  return Array.from(byValue.values()).sort((a, b) => a.value - b.value)
+}
+
+/**
+ * Build the label list from the overlay's LUT rather than scanning voxel data.
+ * The LUT already enumerates every defined label (colour + optional name), so
+ * this is both cheaper and complete - a voxel scan has to be capped for large
+ * volumes and then silently misses labels that only occur past the cap.
+ *
+ * Index 0 is the background and is intentionally omitted (hiding it is the job
+ * of the separate "Hide 0" control).
+ */
+export function getOverlayLabels(
+  colormapLabel: ColorLUT | null | undefined,
+  visibility: Record<number, boolean> = {},
+): LabelInfo[] {
+  const lut = colormapLabel?.lut
+  if (!lut) {
+    return []
+  }
+  const names = colormapLabel?.labels
+  const count = names?.length ?? Math.floor(lut.length / 4)
+  const labels: LabelInfo[] = []
+  for (let value = 1; value < count; value++) {
+    const offset = value * 4
+    if (offset + 3 >= lut.length) {
+      break
+    }
+    // Without a names table, a fully transparent slot is LUT padding rather
+    // than a real label, so skip it. Named entries are always kept.
+    if (!names && lut[offset + 3] === 0) {
+      continue
+    }
+    labels.push({
+      value,
+      name: names?.[value] || `Label ${value}`,
+      color: [lut[offset], lut[offset + 1], lut[offset + 2]],
+      visible: visibility[value] ?? true,
+    })
+  }
+  return labels
+}
+
+/**
+ * Return a copy of the LUT with the alpha byte of each listed label set to
+ * opaque (255) or transparent (0) according to `visibility`. Labels absent from
+ * the map are left untouched. Showing a label resets it to fully opaque, which
+ * matches the original colour-table behaviour for label overlays.
+ */
+export function applyLabelVisibility(
+  lut: Uint8ClampedArray,
+  visibility: Record<number, boolean>,
+): Uint8ClampedArray {
+  const next = new Uint8ClampedArray(lut)
+  for (const [key, visible] of Object.entries(visibility)) {
+    const alphaIndex = Number(key) * 4 + 3
+    if (alphaIndex >= 0 && alphaIndex < next.length) {
+      next[alphaIndex] = visible ? 255 : 0
+    }
+  }
+  return next
+}

--- a/packages/niivue-react/src/test/LabelSelectionPanel.test.tsx
+++ b/packages/niivue-react/src/test/LabelSelectionPanel.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { LabelSelectionPanel } from '../components/LabelSelectionPanel'
+import { LabelInfo } from '../components/labelSelection'
+
+afterEach(() => cleanup())
+
+function labels(): LabelInfo[] {
+  return [
+    { value: 1, name: 'Cube', color: [255, 0, 0], visible: true },
+    { value: 2, name: 'Sphere', color: [0, 255, 0], visible: true },
+    { value: 3, name: 'Slice', color: [0, 0, 255], visible: false },
+  ]
+}
+
+function renderPanel(over: Partial<Parameters<typeof LabelSelectionPanel>[0]> = {}) {
+  const props = {
+    labels: labels(),
+    onLabelToggle: vi.fn(),
+    onSelectAll: vi.fn(),
+    onDeselectAll: vi.fn(),
+    onClose: vi.fn(),
+    ...over,
+  }
+  render(<LabelSelectionPanel {...props} />)
+  return props
+}
+
+describe('LabelSelectionPanel', () => {
+  it('renders one row per label and the visible/total counts', () => {
+    renderPanel()
+    expect(screen.getByText('Cube')).toBeTruthy()
+    expect(screen.getByText('Sphere')).toBeTruthy()
+    expect(screen.getByText('Slice')).toBeTruthy()
+    expect(screen.getByText(/Label Visibility \(3\)/)).toBeTruthy()
+    expect(screen.getByText(/2 of 3 visible/)).toBeTruthy() // labels 1 and 2 visible
+  })
+
+  it('toggles a visible label off when its checkbox is clicked', () => {
+    const { onLabelToggle } = renderPanel()
+    fireEvent.click(document.getElementById('label-1') as HTMLInputElement)
+    expect(onLabelToggle).toHaveBeenCalledWith(1, false)
+  })
+
+  it('toggles a label via a row click (on a non-input part of the row)', () => {
+    const { onLabelToggle } = renderPanel()
+    fireEvent.click(screen.getByText('#3')) // label 3 is hidden -> turn on
+    expect(onLabelToggle).toHaveBeenCalledTimes(1)
+    expect(onLabelToggle).toHaveBeenCalledWith(3, true)
+  })
+
+  it('wires the All / None / Close actions', () => {
+    const { onSelectAll, onDeselectAll, onClose } = renderPanel()
+    fireEvent.click(screen.getByText('All'))
+    fireEvent.click(screen.getByText('None'))
+    fireEvent.click(screen.getByText('Close'))
+    expect(onSelectAll).toHaveBeenCalledTimes(1)
+    expect(onDeselectAll).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the search box only for large label sets and filters by name', () => {
+    renderPanel() // 3 labels -> no search box
+    expect(screen.queryByPlaceholderText('Search labels...')).toBeNull()
+    cleanup()
+
+    const many: LabelInfo[] = Array.from({ length: 12 }, (_, i) => ({
+      value: i + 1,
+      name: `Region ${i + 1}`,
+      color: [0, 0, 0],
+      visible: true,
+    }))
+    renderPanel({ labels: many })
+    const search = screen.getByPlaceholderText('Search labels...')
+    fireEvent.change(search, { target: { value: 'Region 2' } })
+    expect(screen.getByText('Region 2')).toBeTruthy()
+    expect(screen.queryByText('Region 1')).toBeNull()
+  })
+})

--- a/packages/niivue-react/src/test/labelSelection.test.ts
+++ b/packages/niivue-react/src/test/labelSelection.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyLabelVisibility,
+  buildColormapLabel,
+  detectLabelValues,
+  detectLabelValuesAcross,
+  generateLabelColor,
+  getOverlayLabels,
+  getUniqueLabelValues,
+  isAutoLabelMap,
+  isIntegerVolume,
+  isLabelOverlay,
+  mergeLabelLists,
+} from '../components/labelSelection'
+
+// Build a colour-table LUT from RGBA tuples. The voxel value N indexes the LUT
+// at byte offset N*4, so tuple 0 is the background (label 0).
+function makeLut(entries: [number, number, number, number][], labels?: string[]) {
+  const lut = new Uint8ClampedArray(entries.flatMap((e) => e))
+  return labels ? { lut, labels } : { lut }
+}
+
+describe('isLabelOverlay', () => {
+  it('is false when there is no overlay', () => {
+    expect(isLabelOverlay(null)).toBe(false)
+    expect(isLabelOverlay(undefined)).toBe(false)
+  })
+
+  it('is false when colormapLabel is absent or null', () => {
+    expect(isLabelOverlay({})).toBe(false)
+    expect(isLabelOverlay({ colormapLabel: null })).toBe(false)
+  })
+
+  it('is true when the overlay carries a colormapLabel', () => {
+    expect(isLabelOverlay({ colormapLabel: makeLut([[0, 0, 0, 0]]) })).toBe(true)
+  })
+})
+
+describe('getOverlayLabels', () => {
+  it('returns an empty list without a LUT', () => {
+    expect(getOverlayLabels(null)).toEqual([])
+    expect(getOverlayLabels(undefined)).toEqual([])
+  })
+
+  it('builds one entry per label, skipping the background (index 0)', () => {
+    const colormapLabel = makeLut(
+      [
+        [0, 0, 0, 0],
+        [255, 0, 0, 255],
+        [0, 255, 0, 255],
+        [0, 0, 255, 255],
+      ],
+      ['Background', 'Cube', 'Sphere', 'Slice'],
+    )
+    expect(getOverlayLabels(colormapLabel)).toEqual([
+      { value: 1, name: 'Cube', color: [255, 0, 0], visible: true },
+      { value: 2, name: 'Sphere', color: [0, 255, 0], visible: true },
+      { value: 3, name: 'Slice', color: [0, 0, 255], visible: true },
+    ])
+  })
+
+  it('falls back to "Label N" when a name is missing', () => {
+    const colormapLabel = makeLut(
+      [
+        [0, 0, 0, 0],
+        [10, 20, 30, 255],
+        [40, 50, 60, 255],
+      ],
+      ['Background', '', ''],
+    )
+    expect(getOverlayLabels(colormapLabel).map((l) => l.name)).toEqual(['Label 1', 'Label 2'])
+  })
+
+  it('marks all labels visible by default and respects a visibility map', () => {
+    const colormapLabel = makeLut([
+      [0, 0, 0, 0],
+      [1, 1, 1, 255],
+      [2, 2, 2, 255],
+    ])
+    const labels = getOverlayLabels(colormapLabel, { 2: false })
+    expect(labels.find((l) => l.value === 1)?.visible).toBe(true)
+    expect(labels.find((l) => l.value === 2)?.visible).toBe(false)
+  })
+
+  it('skips fully transparent padding slots when there is no name table', () => {
+    const colormapLabel = makeLut([
+      [0, 0, 0, 0], // 0 background (always skipped)
+      [255, 0, 0, 255], // 1 real label
+      [0, 0, 0, 0], // 2 transparent padding -> skipped
+      [0, 0, 255, 255], // 3 real label
+    ])
+    expect(getOverlayLabels(colormapLabel).map((l) => l.value)).toEqual([1, 3])
+  })
+})
+
+describe('applyLabelVisibility', () => {
+  const baseLut = () =>
+    new Uint8ClampedArray([
+      0, 0, 0, 0, 255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255,
+    ])
+
+  it('sets the alpha byte to 0 for hidden labels and 255 for shown labels', () => {
+    const next = applyLabelVisibility(baseLut(), { 1: false, 3: true })
+    expect(next[1 * 4 + 3]).toBe(0) // label 1 hidden
+    expect(next[3 * 4 + 3]).toBe(255) // label 3 shown
+    expect(next[2 * 4 + 3]).toBe(255) // label 2 untouched (not in map)
+  })
+
+  it('restores a dimmed label to fully opaque when shown', () => {
+    const lut = baseLut()
+    lut[1 * 4 + 3] = 100
+    const next = applyLabelVisibility(lut, { 1: true })
+    expect(next[1 * 4 + 3]).toBe(255)
+  })
+
+  it('does not mutate the input LUT', () => {
+    const lut = baseLut()
+    const snapshot = Uint8ClampedArray.from(lut)
+    applyLabelVisibility(lut, { 1: false })
+    expect(lut).toEqual(snapshot)
+  })
+
+  it('ignores indices outside the LUT', () => {
+    const next = applyLabelVisibility(baseLut(), { 99: false })
+    expect(next).toEqual(baseLut())
+  })
+})
+
+describe('isIntegerVolume', () => {
+  it('is true for integer NIfTI datatype codes', () => {
+    for (const code of [2, 4, 8, 256, 512, 768]) {
+      expect(isIntegerVolume({ hdr: { datatypeCode: code } })).toBe(true)
+    }
+  })
+
+  it('is false for float datatypes and when the header is missing', () => {
+    expect(isIntegerVolume({ hdr: { datatypeCode: 16 } })).toBe(false) // float32
+    expect(isIntegerVolume({ hdr: { datatypeCode: 64 } })).toBe(false) // float64
+    expect(isIntegerVolume({})).toBe(false)
+    expect(isIntegerVolume(null)).toBe(false)
+  })
+})
+
+describe('isAutoLabelMap', () => {
+  it('is true only for NIFTI_INTENT_LABEL (1002)', () => {
+    expect(isAutoLabelMap({ hdr: { intent_code: 1002 } })).toBe(true)
+    expect(isAutoLabelMap({ hdr: { intent_code: 0 } })).toBe(false)
+    expect(isAutoLabelMap({})).toBe(false)
+  })
+})
+
+describe('getUniqueLabelValues', () => {
+  it('returns sorted distinct non-zero values, rounding floats', () => {
+    const img = new Float32Array([0, 3, 3, 1, 2.0, 1, 0, 2])
+    expect(getUniqueLabelValues(img)).toEqual([1, 2, 3])
+  })
+
+  it('returns an empty list for all-background data', () => {
+    expect(getUniqueLabelValues(new Uint8Array([0, 0, 0]))).toEqual([])
+  })
+
+  it('returns null when distinct values exceed the cap (continuous image)', () => {
+    const img = new Uint16Array(500)
+    for (let i = 0; i < img.length; i++) img[i] = i + 1
+    expect(getUniqueLabelValues(img, 100)).toBeNull()
+  })
+
+  it('returns null when a value is too large to index a LUT', () => {
+    expect(getUniqueLabelValues(new Int32Array([1, 70000]))).toBeNull()
+  })
+
+  it('returns null for missing data', () => {
+    expect(getUniqueLabelValues(null)).toBeNull()
+    expect(getUniqueLabelValues(undefined)).toBeNull()
+  })
+})
+
+describe('generateLabelColor', () => {
+  it('is deterministic and stays within the 0-255 range', () => {
+    const c = generateLabelColor(7)
+    expect(generateLabelColor(7)).toEqual(c)
+    expect(c).toHaveLength(3)
+    for (const channel of c) {
+      expect(channel).toBeGreaterThanOrEqual(0)
+      expect(channel).toBeLessThanOrEqual(255)
+    }
+  })
+
+  it('gives distinct values distinct colours', () => {
+    expect(generateLabelColor(1)).not.toEqual(generateLabelColor(2))
+  })
+})
+
+describe('buildColormapLabel', () => {
+  it('builds a LUT indexed by value: present labels opaque, gaps transparent', () => {
+    const { lut } = buildColormapLabel([1, 3])
+    expect(lut.length).toBe((3 + 1) * 4)
+    expect(lut[1 * 4 + 3]).toBe(255) // label 1 present
+    expect(lut[3 * 4 + 3]).toBe(255) // label 3 present
+    expect(lut[2 * 4 + 3]).toBe(0) // gap (label 2) transparent
+    expect(lut[0 * 4 + 3]).toBe(0) // background transparent
+  })
+
+  it('round-trips through getOverlayLabels to exactly the present values', () => {
+    const colormapLabel = buildColormapLabel([1, 2, 5])
+    expect(getOverlayLabels(colormapLabel).map((l) => l.value)).toEqual([1, 2, 5])
+  })
+})
+
+describe('detectLabelValues', () => {
+  it('scans an integer image for its label values', () => {
+    const overlay = { hdr: { datatypeCode: 2 }, img: new Uint8Array([0, 1, 2, 2, 4]) }
+    expect(detectLabelValues(overlay)).toEqual([1, 2, 4])
+  })
+
+  it('returns null for a float (non-label) image', () => {
+    const overlay = { hdr: { datatypeCode: 16 }, img: new Float32Array([0, 1.5, 2.5]) }
+    expect(detectLabelValues(overlay)).toBeNull()
+  })
+
+  it('returns null when there is no overlay', () => {
+    expect(detectLabelValues(null)).toBeNull()
+  })
+})
+
+describe('detectLabelValuesAcross', () => {
+  it('unions the label values of several integer overlays', () => {
+    const a = { hdr: { datatypeCode: 2 }, img: new Uint8Array([0, 1, 2]) }
+    const b = { hdr: { datatypeCode: 4 }, img: new Int16Array([0, 2, 200, 201]) }
+    expect(detectLabelValuesAcross([a, b])).toEqual([1, 2, 200, 201])
+  })
+
+  it('skips non-label (float) overlays and nullish entries', () => {
+    const labels = { hdr: { datatypeCode: 2 }, img: new Uint8Array([0, 5]) }
+    const continuous = { hdr: { datatypeCode: 16 }, img: new Float32Array([0, 1.5]) }
+    expect(detectLabelValuesAcross([labels, continuous, null, undefined])).toEqual([5])
+  })
+
+  it('returns an empty list when nothing looks like labels', () => {
+    expect(detectLabelValuesAcross([])).toEqual([])
+    expect(
+      detectLabelValuesAcross([{ hdr: { datatypeCode: 16 }, img: new Float32Array([1.1]) }]),
+    ).toEqual([])
+  })
+})
+
+describe('mergeLabelLists', () => {
+  it('merges by value so a shared label appears once, sorted', () => {
+    const a = getOverlayLabels(buildColormapLabel([1, 2]))
+    const b = getOverlayLabels(buildColormapLabel([2, 5]))
+    expect(mergeLabelLists([a, b]).map((l) => l.value)).toEqual([1, 2, 5])
+  })
+
+  it('keeps a label visible only when shown in every list that contains it', () => {
+    const shown = getOverlayLabels(buildColormapLabel([1]))
+    const hidden = shown.map((l) => ({ ...l, visible: false }))
+    expect(mergeLabelLists([shown, hidden])[0].visible).toBe(false)
+    expect(mergeLabelLists([shown, shown])[0].visible).toBe(true)
+  })
+
+  it('preserves the first name and colour for a shared value', () => {
+    const named = [{ value: 1, name: 'First', color: [10, 20, 30] as [number, number, number], visible: true }]
+    const other = [{ value: 1, name: 'Second', color: [40, 50, 60] as [number, number, number], visible: true }]
+    const merged = mergeLabelLists([named, other])
+    expect(merged[0].name).toBe('First')
+    expect(merged[0].color).toEqual([10, 20, 30])
+  })
+})


### PR DESCRIPTION
…tion overlays (#229)

- New LabelSelectionPanel component with checkbox toggles for each label
- Search functionality for large label sets (>10 labels)
- Select All / Deselect All quick actions
- Incremental loading for 100+ labels (performance optimization)
- Color swatches from LUT or auto-generated using HSV colormap
- Integration with ScalingBox via 'Labels' button
- LUT alpha channel modification for show/hide functionality
- Test segmentation file (6 labels) with color table
- Documentation for test assets and implementation status

Technical details:
- Detects label overlays via colormapLabel (LUT) property
- Generates distinct colors using golden angle hashing when no LUT
- Modifies LUT alpha channel (0=transparent, 255=opaque) per label
- Calls nv.updateGLVolume() to refresh rendering

Follows MRIcroGL's simple checkbox pattern for quick inspection workflows. Positions NiiVue between Papaya (no label control) and FSLeyes (full control).

Closes #229
Related to #232 (preset colors), #237/#246 (Hide 0 toggle)