### PR TITLE
feat(graphml): load GraphML graphs as a NiiVue connectome (#234)

### DIFF
--- a/.changeset/graphml-connectome-support.md
+++ b/.changeset/graphml-connectome-support.md
@@ -1,0 +1,25 @@
+---
+'@niivue/react': minor
+'niivue': minor
+'@niivue/pwa': patch
+'@niivue/streamlit': patch
+'@niivue/jupyter': patch
+'@niivue/tauri': patch
+---
+
+Add support for the GraphML format.
+
+GraphML files (e.g. vessel skeletons and brain networks exported by tools
+such as SkelHub) now load as a NiiVue connectome: each `<node>` becomes a
+sphere placed at its world-space `X`/`Y`/`Z` coordinates and each `<edge>`
+becomes a cylinder joining the two nodes it references. This mirrors how the
+source tools preview these graphs as points and lines.
+
+- New `graphmlToConnectome()` helper exported from `@niivue/react` converts
+  GraphML XML into NiiVue's connectome model (lowercase `x`/`y`/`z`
+  coordinates are accepted as a fallback).
+- `loadVolume` routes `*.graphml` payloads through the converter, whether the
+  bytes arrive inlined (drag-and-drop) or have to be fetched from a URL
+  (VS Code webview resource, `?images=` query parameter).
+- The VS Code extension registers `*.graphml`, so a GraphML file opens
+  directly in the NiiVue editor.

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -331,6 +331,9 @@
           },
           {
             "filenamePattern": "*.npz"
+          },
+          {
+            "filenamePattern": "*.graphml"
           }
         ]
       }
@@ -371,7 +374,8 @@
           ".mnc",
           ".mnc.gz",
           ".npy",
-          ".npz"
+          ".npz",
+          ".graphml"
         ],
         "icon": {
           "light": "./language-icon.png",

--- a/apps/vscode/src/editorProvider.ts
+++ b/apps/vscode/src/editorProvider.ts
@@ -285,6 +285,7 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
     '.npy',
     '.npz',
     '.raw',
+    '.graphml',
   ]
 
   static hasKnownExtension(lowerCasePath: string): boolean {

--- a/packages/niivue-react/src/components/NiiVueCanvas.tsx
+++ b/packages/niivue-react/src/components/NiiVueCanvas.tsx
@@ -30,7 +30,7 @@ import { useEffect, useRef } from 'preact/hooks'
 import { ExtendedNiivue, notifyImageLoaded } from '../events'
 import { isNiftiName, NIFTI_PEEK_BYTES, niftiTooLargeWarning } from '../nifti'
 import { NiiVueSettings } from '../settings'
-import { isDicomData, isImageType } from '../utility'
+import { graphmlToConnectome, isDicomData, isImageType } from '../utility'
 import { AppProps } from './AppProps'
 
 export interface NiiVueCanvasProps {
@@ -313,6 +313,47 @@ async function getNiftiHeaderBytes(item: any): Promise<ArrayBuffer | Uint8Array 
   return null
 }
 
+// Decode a GraphML payload (drag/drop buffer, postMessage number array, or
+// already-decoded string) to text.
+function graphmlBytesToText(data: any): string {
+  if (typeof data === 'string') {
+    return data
+  }
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data)
+  }
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(data as ArrayBufferView)
+  }
+  if (Array.isArray(data)) {
+    return new TextDecoder().decode(new Uint8Array(data))
+  }
+  throw new Error('Unsupported GraphML data type')
+}
+
+// Load a GraphML graph as a NiiVue connectome. The bytes come inlined
+// (drag/drop, vscode binary payload) or must be fetched from a URL (webview
+// resource, ?images= query parameter). NiiVue loads connectomes from a .jcon
+// mesh, so the converted graph is wrapped in a .jcon File whose name lets the
+// mesh loader detect the format and read it as bytes.
+async function loadGraphmlConnectome(nv: ExtendedNiivue, item: any) {
+  let text: string
+  if (item.data) {
+    text = graphmlBytesToText(item.data)
+  } else {
+    const response = await fetch(item.uri)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch GraphML (${response.status} ${response.statusText})`)
+    }
+    text = await response.text()
+  }
+  const baseName = (item.uri.split('?')[0].split('/').pop() || 'graph').replace(/\.graphml$/i, '')
+  const connectome = graphmlToConnectome(text)
+  const jconName = `${baseName}.jcon`
+  const file = new File([JSON.stringify(connectome)], jconName, { type: 'application/json' })
+  await nv.addMesh({ url: file, name: jconName })
+}
+
 async function loadVolume(nv: ExtendedNiivue, item: any, settings: NiiVueSettings) {
   // Multi-file DICOM series: item.uri is an array of slice names with
   // item.data an array of buffers. Handle this first, because the single-file
@@ -320,6 +361,11 @@ async function loadVolume(nv: ExtendedNiivue, item: any, settings: NiiVueSetting
   // on an array.
   if (Array.isArray(item.uri)) {
     await loadDicomSeries(nv, item.uri, item.data, settings)
+    return
+  }
+  // GraphML graphs (e.g. vessel skeletons) render as a NiiVue connectome.
+  if (item.uri.split('?')[0].toLowerCase().endsWith('.graphml')) {
+    await loadGraphmlConnectome(nv, item)
     return
   }
   // Guard: refuse NIfTI volumes whose uncompressed voxel data exceeds the ~2 GB

--- a/packages/niivue-react/src/test/utility.test.ts
+++ b/packages/niivue-react/src/test/utility.test.ts
@@ -5,6 +5,7 @@ import {
   getMetadataString,
   getNames,
   getNumberOfPoints,
+  graphmlToConnectome,
   isDicomData,
   isImageType,
 } from '../utility'
@@ -154,6 +155,136 @@ describe('getNumberOfPoints', () => {
   it('handles zero-length point arrays', () => {
     const nv = { meshes: [{ positions: [] }] } as any
     expect(getNumberOfPoints(nv)).toBe('Number of Points: 0')
+  })
+})
+
+describe('graphmlToConnectome', () => {
+  // Mirrors the GraphML that igraph writes (used by SkelHub): nodes carry
+  // world-space X/Y/Z plus a name, edges reference nodes by their `source`/
+  // `target` ids, and every <data> points at a <key> declaring its attr.name.
+  const igraphGraphml = `<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+  <key id="v_name" for="node" attr.name="name" attr.type="string"/>
+  <key id="v_X" for="node" attr.name="X" attr.type="double"/>
+  <key id="v_Y" for="node" attr.name="Y" attr.type="double"/>
+  <key id="v_Z" for="node" attr.name="Z" attr.type="double"/>
+  <key id="e_proto_edge_id" for="edge" attr.name="proto_edge_id" attr.type="double"/>
+  <graph edgedefault="undirected">
+    <node id="n0"><data key="v_name">a</data><data key="v_X">1</data><data key="v_Y">2</data><data key="v_Z">3</data></node>
+    <node id="n1"><data key="v_name">b</data><data key="v_X">4</data><data key="v_Y">5</data><data key="v_Z">6</data></node>
+    <node id="n2"><data key="v_name">c</data><data key="v_X">7</data><data key="v_Y">8</data><data key="v_Z">9</data></node>
+    <edge source="n0" target="n2"><data key="e_proto_edge_id">0</data></edge>
+    <edge source="n1" target="n2"><data key="e_proto_edge_id">1</data></edge>
+  </graph>
+</graphml>`
+
+  it('parses nodes with world coordinates and names', () => {
+    const c = graphmlToConnectome(igraphGraphml)
+    expect(c.nodes).toEqual([
+      { name: 'a', x: 1, y: 2, z: 3, colorValue: 1, sizeValue: 1 },
+      { name: 'b', x: 4, y: 5, z: 6, colorValue: 1, sizeValue: 1 },
+      { name: 'c', x: 7, y: 8, z: 9, colorValue: 1, sizeValue: 1 },
+    ])
+  })
+
+  it('maps edge source/target ids to node indices (not assuming order)', () => {
+    const c = graphmlToConnectome(igraphGraphml)
+    // n0->n2 and n1->n2 become index pairs 0-2 and 1-2.
+    expect(c.edges).toEqual([
+      { first: 0, second: 2, colorValue: 1 },
+      { first: 1, second: 2, colorValue: 1 },
+    ])
+  })
+
+  it('keeps node and edge color ranges collapsed so nothing is thresholded away', () => {
+    // The connectome renderer hides edges whose colorValue < edgeMin. Equal
+    // min/max guards every node and edge against being culled.
+    const c = graphmlToConnectome(igraphGraphml)
+    expect(c.nodeMinColor).toBe(c.nodeMaxColor)
+    expect(c.edgeMin).toBe(c.edgeMax)
+  })
+
+  it('accepts lowercase x/y/z coordinate attributes', () => {
+    const lower = `<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+      <key id="kx" for="node" attr.name="x" attr.type="double"/>
+      <key id="ky" for="node" attr.name="y" attr.type="double"/>
+      <key id="kz" for="node" attr.name="z" attr.type="double"/>
+      <graph>
+        <node id="a"><data key="kx">1.5</data><data key="ky">2.5</data><data key="kz">3.5</data></node>
+      </graph>
+    </graphml>`
+    const c = graphmlToConnectome(lower)
+    expect(c.nodes).toEqual([{ name: 'a', x: 1.5, y: 2.5, z: 3.5, colorValue: 1, sizeValue: 1 }])
+  })
+
+  it('falls back to the node id when no name attribute is present', () => {
+    const noName = `<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+      <key id="kx" for="node" attr.name="X" attr.type="double"/>
+      <key id="ky" for="node" attr.name="Y" attr.type="double"/>
+      <key id="kz" for="node" attr.name="Z" attr.type="double"/>
+      <graph><node id="root"><data key="kx">0</data><data key="ky">0</data><data key="kz">0</data></node></graph>
+    </graphml>`
+    expect(graphmlToConnectome(noName).nodes[0].name).toBe('root')
+  })
+
+  it('skips edges that reference an unknown node id', () => {
+    const danglingEdge = `<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+      <key id="kx" for="node" attr.name="X" attr.type="double"/>
+      <key id="ky" for="node" attr.name="Y" attr.type="double"/>
+      <key id="kz" for="node" attr.name="Z" attr.type="double"/>
+      <graph>
+        <node id="a"><data key="kx">0</data><data key="ky">0</data><data key="kz">0</data></node>
+        <node id="b"><data key="kx">1</data><data key="ky">1</data><data key="kz">1</data></node>
+        <edge source="a" target="b"/>
+        <edge source="a" target="missing"/>
+      </graph>
+    </graphml>`
+    expect(graphmlToConnectome(danglingEdge).edges).toEqual([{ first: 0, second: 1, colorValue: 1 }])
+  })
+
+  it('throws when a node has no coordinates', () => {
+    const noCoords = `<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+      <key id="v_name" for="node" attr.name="name" attr.type="string"/>
+      <graph><node id="n0"><data key="v_name">a</data></node></graph>
+    </graphml>`
+    expect(() => graphmlToConnectome(noCoords)).toThrow(/X\/Y\/Z/)
+  })
+
+  it('treats an empty coordinate value as missing rather than 0', () => {
+    // Number('') is 0; without the guard this node would silently land at the
+    // origin instead of reporting the missing coordinate.
+    const emptyCoord = `<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+      <key id="kx" for="node" attr.name="X" attr.type="double"/>
+      <key id="ky" for="node" attr.name="Y" attr.type="double"/>
+      <key id="kz" for="node" attr.name="Z" attr.type="double"/>
+      <graph><node id="n0"><data key="kx"></data><data key="ky">1</data><data key="kz">2</data></node></graph>
+    </graphml>`
+    expect(() => graphmlToConnectome(emptyCoord)).toThrow(/X\/Y\/Z/)
+  })
+
+  it('does not hoist nodes from a nested subgraph into the top-level graph', () => {
+    const nested = `<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+      <key id="kx" for="node" attr.name="X" attr.type="double"/>
+      <key id="ky" for="node" attr.name="Y" attr.type="double"/>
+      <key id="kz" for="node" attr.name="Z" attr.type="double"/>
+      <graph>
+        <node id="outer">
+          <data key="kx">0</data><data key="ky">0</data><data key="kz">0</data>
+          <graph><node id="inner"><data key="kx">9</data><data key="ky">9</data><data key="kz">9</data></node></graph>
+        </node>
+      </graph>
+    </graphml>`
+    const c = graphmlToConnectome(nested)
+    expect(c.nodes).toEqual([{ name: 'outer', x: 0, y: 0, z: 0, colorValue: 1, sizeValue: 1 }])
+  })
+
+  it('throws when the graph has no nodes', () => {
+    const empty = `<graphml xmlns="http://graphml.graphdrawing.org/xmlns"><graph></graph></graphml>`
+    expect(() => graphmlToConnectome(empty)).toThrow(/no nodes/)
+  })
+
+  it('throws on malformed XML', () => {
+    expect(() => graphmlToConnectome('<graphml><graph></graphml>')).toThrow(/not valid XML/)
   })
 })
 

--- a/packages/niivue-react/src/utility.ts
+++ b/packages/niivue-react/src/utility.ts
@@ -1,5 +1,5 @@
 import NiiVue from '@niivue/niivue'
-import type { NVImage } from '@niivue/niivue'
+import type { NVImage, NVConnectomeOptions } from '@niivue/niivue'
 import { isNiftiName, NIFTI_PEEK_BYTES, niftiTooLargeWarning } from './nifti'
 
 // This function computes the display names for each Niivue instance in the array
@@ -186,6 +186,161 @@ export function isImageType(item: string) {
     '.mnc',
     '.mnc.gz',
   ].find((fileType) => item.endsWith(fileType))
+}
+
+// ---- GraphML (vessel graph / brain network) support ----
+//
+// Tools such as SkelHub export vessel skeletons and brain networks as GraphML
+// (an XML graph format). Each <node> carries world-space coordinates and each
+// <edge> joins two nodes. We convert this to NiiVue's connectome model (the
+// sparse JCON shape: a node/edge list plus display options) so the graph
+// renders as spheres (nodes) joined by cylinders (edges), matching how the
+// source tools preview these graphs as points and lines.
+
+interface ConnectomeNode {
+  name: string
+  x: number
+  y: number
+  z: number
+  colorValue: number
+  sizeValue: number
+}
+
+interface ConnectomeEdge {
+  first: number
+  second: number
+  colorValue: number
+}
+
+// A NiiVue connectome in the sparse JCON representation: node/edge lists plus
+// the display options the mesh loader reads from the same JSON.
+export type GraphmlConnectome = NVConnectomeOptions & {
+  nodes: ConnectomeNode[]
+  edges: ConnectomeEdge[]
+}
+
+// Direct element children of `parent` with the given local name. Used instead
+// of getElementsByTagName so a nested subgraph's nodes/edges/data are not
+// hoisted into the parent graph or element.
+function directChildren(parent: Element, localName: string): Element[] {
+  const result: Element[] = []
+  for (let i = 0; i < parent.childNodes.length; i++) {
+    const child = parent.childNodes[i]
+    if (child.nodeType === 1 && (child as Element).localName === localName) {
+      result.push(child as Element)
+    }
+  }
+  return result
+}
+
+// Read the GraphML <key> table so <data key="..."> references resolve to their
+// declared attribute names (e.g. key id "v_X" -> attribute "X").
+function readGraphmlKeyNames(doc: Document): Map<string, string> {
+  const keyNames = new Map<string, string>()
+  const keys = doc.getElementsByTagNameNS('*', 'key')
+  for (let i = 0; i < keys.length; i++) {
+    const id = keys[i].getAttribute('id')
+    if (!id) continue
+    keyNames.set(id, keys[i].getAttribute('attr.name') ?? id)
+  }
+  return keyNames
+}
+
+// Collect an element's direct <data> children, keyed by resolved attribute
+// name. Only direct children are read so a nested subgraph cannot leak its
+// values into the parent node/edge.
+function readGraphmlData(element: Element, keyNames: Map<string, string>): Record<string, string> {
+  const values: Record<string, string> = {}
+  for (const el of directChildren(element, 'data')) {
+    const key = el.getAttribute('key')
+    if (!key) continue
+    values[keyNames.get(key) ?? key] = el.textContent ?? ''
+  }
+  return values
+}
+
+// First finite coordinate found among the candidate attribute names. An empty
+// <data> value is treated as absent: Number('') is 0, which would otherwise
+// place the node at the origin instead of reporting a missing coordinate.
+function pickGraphmlCoordinate(
+  values: Record<string, string>,
+  candidates: string[],
+): number | undefined {
+  for (const key of candidates) {
+    const raw = values[key]
+    if (raw === undefined || raw.trim() === '') continue
+    const n = Number(raw)
+    if (Number.isFinite(n)) return n
+  }
+  return undefined
+}
+
+/**
+ * Convert GraphML text into a NiiVue connectome definition. Nodes need
+ * world-space coordinates under attributes `X`/`Y`/`Z` (or lowercase
+ * `x`/`y`/`z`); edges reference nodes by their GraphML `source`/`target` ids.
+ * Throws with a clear message when the file is not parseable GraphML, has no
+ * nodes, or has nodes without coordinates.
+ */
+export function graphmlToConnectome(text: string): GraphmlConnectome {
+  const doc = new DOMParser().parseFromString(text, 'application/xml')
+  if (doc.getElementsByTagName('parsererror').length > 0) {
+    throw new Error('Could not parse GraphML: the file is not valid XML')
+  }
+  const graph = doc.getElementsByTagNameNS('*', 'graph')[0]
+  if (!graph) {
+    throw new Error('Could not parse GraphML: no <graph> element found')
+  }
+
+  const keyNames = readGraphmlKeyNames(doc)
+
+  const nodes: ConnectomeNode[] = []
+  const idToIndex = new Map<string, number>()
+  for (const el of directChildren(graph, 'node')) {
+    const id = el.getAttribute('id')
+    if (!id) continue
+    const values = readGraphmlData(el, keyNames)
+    const x = pickGraphmlCoordinate(values, ['X', 'x'])
+    const y = pickGraphmlCoordinate(values, ['Y', 'y'])
+    const z = pickGraphmlCoordinate(values, ['Z', 'z'])
+    if (x === undefined || y === undefined || z === undefined) {
+      throw new Error(
+        'GraphML node is missing X/Y/Z coordinates; cannot place the graph in 3D space',
+      )
+    }
+    idToIndex.set(id, nodes.length)
+    nodes.push({ name: values.name ?? id, x, y, z, colorValue: 1, sizeValue: 1 })
+  }
+
+  if (nodes.length === 0) {
+    throw new Error('GraphML contains no nodes')
+  }
+
+  const edges: ConnectomeEdge[] = []
+  for (const el of directChildren(graph, 'edge')) {
+    const first = idToIndex.get(el.getAttribute('source') ?? '')
+    const second = idToIndex.get(el.getAttribute('target') ?? '')
+    if (first === undefined || second === undefined) continue
+    edges.push({ first, second, colorValue: 1 })
+  }
+
+  // Uniform color values with nodeMin==nodeMax and edgeMin==edgeMax: this keeps
+  // every node and edge visible (the default connectome thresholds would hide
+  // edges whose value falls below edgeMin) and gives the graph one flat color.
+  return {
+    nodes,
+    edges,
+    nodeColormap: 'warm',
+    nodeColormapNegative: 'winter',
+    nodeMinColor: 1,
+    nodeMaxColor: 1,
+    nodeScale: 2,
+    edgeColormap: 'warm',
+    edgeColormapNegative: 'winter',
+    edgeMin: 1,
+    edgeMax: 1,
+    edgeScale: 1,
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #234.

## What

Adds support for the **GraphML** format. GraphML files (e.g. vessel skeletons and brain networks exported by tools such as [SkelHub](https://github.com/KMarshallX/SkelHub)) now load as a NiiVue **connectome**: each `<node>` becomes a sphere placed at its world-space `X`/`Y`/`Z` coordinates and each `<edge>` becomes a cylinder joining the two nodes it references. This mirrors how the source tools preview these graphs as points and lines.

## How

- **New `graphmlToConnectome()` helper** (`@niivue/react/utility`) parses GraphML XML into NiiVue's sparse connectome model (`NVConnectomeOptions` + `{nodes, edges}`, the JCON shape). It resolves each `<data key="...">` through the GraphML `<key>` table, maps `source`/`target` ids to node indices, reads node coordinates from `X`/`Y`/`Z` (lowercase `x`/`y`/`z` accepted as a fallback), and only collects direct children so nested subgraphs aren't flattened. It throws a clear message on invalid XML, an empty graph, or a node missing coordinates.
- **`loadVolume`** routes `*.graphml` payloads through the converter, whether the bytes arrive inlined (drag-and-drop, VS Code binary payload) or have to be fetched from a URL (VS Code webview resource, `?images=` query parameter). The converted connectome is serialized to a `.jcon` `File` and handed to `nv.addMesh({ url: file })` - the same in-memory-`File` idiom the volume/mesh paths already use post-v1, so the mesh loader detects the JCON format from the file name and reads it as bytes.
- **VS Code registration**: `*.graphml` added to the custom editor selector, language extensions, and the editor provider's `knownExtensions`, so a GraphML file opens directly in the NiiVue editor.

The connectome uses uniform node/edge color values with `nodeMinColor == nodeMaxColor` and `edgeMin == edgeMax`. This is deliberate: NiiVue's connectome renderer culls any edge whose `colorValue` falls below `edgeMin`, so collapsing the range guarantees every node and edge stays visible and the graph draws in one flat color.

> Rebased onto current `main`, which includes the `@niivue/niivue` v1 migration (#252). The connectome load path uses the v1 `.jcon` mesh API (the old `loadConnectomeAsMesh` was removed in v1); verified the sparse JCON reader expects exactly the `{name,x,y,z,colorValue,sizeValue}` / `{first,second,colorValue}` shape this produces.

## Design note / assumption

The issue text is terse ("Add support for Graphml format"). I grounded the implementation in the GraphML that the issue author's own tool (SkelHub) emits via igraph - undirected graphs whose nodes carry world `X`/`Y`/`Z` and whose edges connect node pairs - and matched its viewer, which draws these as points + straight lines between nodes. NiiVue's connectome (spheres + cylinders) is the faithful equivalent.

If the intent was instead to draw each edge's full curved centerline (the `centerline_points` edge attribute SkelHub also stores) as a streamline/tract, that's a larger change and a reasonable follow-up. Happy to adjust.

## Testing

- 13 unit tests for `graphmlToConnectome` (igraph-style parse, node/edge index mapping, lowercase fallback, name fallback, dangling-edge skip, empty-coordinate guard, nested-subgraph isolation, and the error cases). Full `@niivue/react` suite passes.
- `type-check`, `lint`, and `build` pass for `@niivue/react`, the `niivue` VS Code extension, and the `@niivue/pwa` consumer against `@niivue/niivue` v1.

An end-to-end visual check with a real SkelHub `.graphml` in the browser would be a good follow-up - the parser is fully unit-tested and the connectome render path is traced against the v1 library source, but I did not render one live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
