### PR TITLE
fix(viewer): support numpy int64/uint64 .npy/.npz volumes (#90)

### DIFF
--- a/.changeset/npy-npz-dtype-support.md
+++ b/.changeset/npy-npz-dtype-support.md
@@ -1,0 +1,29 @@
+---
+'@niivue/react': minor
+'@niivue/pwa': patch
+'niivue': patch
+'@niivue/tauri': patch
+'@niivue/streamlit': patch
+'@niivue/jupyter': patch
+---
+
+Fix NumPy `.npy`/`.npz` loading (issue #90).
+
+NiiVue's numpy reader only understands a fixed set of element types
+(`b1, i1, u1, i2, u2, i4, u4, f4, f8`). NumPy's *default* integer dtype is int64
+(`<i8`) - `np.save('x.npy', np.arange(...))`, label maps and masks all land here -
+which the reader cannot handle, so those volumes came through corrupt/all-black
+(silently mis-read on the old line) or simply failed to display.
+
+A small loader shim (`packages/niivue-react/src/npy.ts`) is now registered via
+`nv.useLoader` for `.npy`/`.npz`. It runs before NiiVue's reader and down-casts the
+element types it can't take to ones it can:
+
+- int64 -> int32 (or float64 if any value overflows the int32 range)
+- uint64 -> uint32 (or float64 if any value overflows the uint32 range)
+
+int32 is preferred over float64 so the data keeps integer semantics (label-map
+auto-detection, integer colour scales). Types NiiVue already supports pass through
+untouched, and genuinely undisplayable ones (complex, float16) now raise a clear,
+actionable error instead of rendering black. `.npz` archives are unzipped directly
+(both stored and deflate-compressed members) and their first array is converted.

--- a/packages/niivue-react/src/components/NiiVueCanvas.tsx
+++ b/packages/niivue-react/src/components/NiiVueCanvas.tsx
@@ -29,6 +29,7 @@ import { Signal } from '@preact/signals'
 import { useEffect, useRef } from 'preact/hooks'
 import { ExtendedNiivue, notifyImageLoaded } from '../events'
 import { isNiftiName, NIFTI_PEEK_BYTES, niftiTooLargeWarning } from '../nifti'
+import { convertNpy, convertNpz, isNpyName } from '../npy'
 import { NiiVueSettings } from '../settings'
 import { isDicomData, isImageType } from '../utility'
 import { AppProps } from './AppProps'
@@ -337,6 +338,16 @@ async function loadVolume(nv: ExtendedNiivue, item: any, settings: NiiVueSetting
         throw new Error(warning)
       }
     }
+  }
+  // NumPy .npy/.npz: register converters that down-cast element types NiiVue's
+  // reader cannot handle (notably int64/uint64, numpy's default integer types)
+  // so the volume displays instead of erroring or rendering black. See #90.
+  // Registered once per instance: the npy converter shares its from/to extension,
+  // so re-registering would nest it around the previous reader on every load.
+  if (isNpyName(item.uri) && !nv.npyLoadersRegistered) {
+    nv.useLoader(convertNpy, 'npy', 'npy')
+    nv.useLoader(convertNpz, 'npz', 'npy')
+    nv.npyLoadersRegistered = true
   }
   const isMincFile = (uri: string) => {
     const lowerUri = uri.toLowerCase()

--- a/packages/niivue-react/src/events.ts
+++ b/packages/niivue-react/src/events.ts
@@ -443,6 +443,7 @@ export class ExtendedNiivue extends NiiVue {
   key = NaN
   body = null
   documentData: File | null = null // pending .nvd import (CBOR bytes wrapped in a File), consumed by NiiVueCanvas
+  npyLoadersRegistered = false // guards one-time nv.useLoader registration for .npy/.npz (see NiiVueCanvas)
   onVolumeUpdated = () => { }
   onFrameUpdate = (frame: number) => { }
   // v1: cross-canvas pan/3D sync is handled natively by `nv.broadcastTo(targets)`

--- a/packages/niivue-react/src/npy.ts
+++ b/packages/niivue-react/src/npy.ts
@@ -1,0 +1,322 @@
+/**
+ * NumPy `.npy` / `.npz` support for the viewer (issue #90).
+ *
+ * NiiVue can read `.npy`/`.npz`, but its reader only understands a fixed set of
+ * element types: `b1, i1, u1, i2, u2, i4, u4, f4, f8`. NumPy's *default* integer
+ * dtype is int64 (`<i8`) - `np.save('x.npy', np.arange(...))`, label maps, masks
+ * and most integer arrays land here - which the reader cannot handle. On the
+ * released 0.68.x line that int64 was silently mis-read as 1-byte float32
+ * (garbage / all-black); on niivue v1 it throws "Unsupported NPY dtype". Either
+ * way the volume never displays. See https://github.com/niivue/niivue-vscode/issues/90.
+ *
+ * These converters are registered with `nv.useLoader(..., 'npy'|'npz', 'npy')`
+ * (the same hook used for the MINC loader). They run before NiiVue's reader and
+ * down-cast the element types it can't take to ones it can:
+ *   - int64  -> int32   (or float64 if any value overflows the int32 range)
+ *   - uint64 -> uint32  (or float64 if any value overflows the uint32 range)
+ * Int32 is preferred over float64 so the data keeps integer semantics (label-map
+ * auto-detection, integer colour scales). Element types NiiVue already supports
+ * are passed through untouched; genuinely undisplayable ones (complex, float16)
+ * raise a clear, actionable error instead of rendering black.
+ */
+
+/** Element-type suffixes (dtype string minus its byte-order prefix) NiiVue reads natively. */
+const NIIVUE_SUPPORTED_SUFFIXES = new Set([
+  'b1',
+  'i1',
+  'u1',
+  'i2',
+  'u2',
+  'i4',
+  'u4',
+  'f4',
+  'f8',
+])
+
+const INT32_MIN = -2147483648n
+const INT32_MAX = 2147483647n
+const UINT32_MAX = 4294967295n
+
+/** True for a NumPy filename (`.npy` or `.npz`). */
+export function isNpyName(name: string): boolean {
+  const lower = name.toLowerCase()
+  return lower.endsWith('.npy') || lower.endsWith('.npz')
+}
+
+interface NpyHeader {
+  /** Byte offset where the raw array data begins. */
+  dataOffset: number
+  /** Full dtype string, e.g. `<i8`. */
+  descr: string
+  /** Byte-order prefix: `<`, `>`, `=` or `|`. */
+  endian: string
+  /** dtype without the byte-order prefix, e.g. `i8`. */
+  suffix: string
+  /** Whether the values are little-endian in the file. */
+  littleEndian: boolean
+  /** `fortran_order` flag, preserved verbatim into a rewritten header. */
+  fortranOrder: boolean
+  /** Raw text inside the `shape` tuple, e.g. `10, 12, 14` (preserved verbatim). */
+  shapeInner: string
+  /** Total number of elements (product of the shape dims). */
+  numElements: number
+}
+
+const SYSTEM_LITTLE_ENDIAN = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1
+const NPY_MAGIC = [0x93, 0x4e, 0x55, 0x4d, 0x50, 0x59] // \x93NUMPY
+
+/** Copy a (possibly offset) view into a fresh, exactly-sized ArrayBuffer. */
+function toArrayBuffer(data: ArrayBuffer | Uint8Array): ArrayBuffer {
+  if (data instanceof ArrayBuffer) {
+    return data
+  }
+  return data.slice().buffer
+}
+
+/** Parse an `.npy` header (versions 1.0, 2.0 and 3.0). */
+function parseNpyHeader(buffer: ArrayBuffer): NpyHeader {
+  const bytes = new Uint8Array(buffer)
+  const dv = new DataView(buffer)
+  if (bytes.length < 10 || !NPY_MAGIC.every((b, i) => bytes[i] === b)) {
+    throw new Error('Not a valid .npy file (magic number mismatch).')
+  }
+  const major = bytes[6]
+  let headerLen: number
+  let headerTextOffset: number
+  let encoding: string
+  if (major === 1) {
+    headerLen = dv.getUint16(8, true)
+    headerTextOffset = 10
+    encoding = 'latin1'
+  } else if (major === 2 || major === 3) {
+    headerLen = dv.getUint32(8, true)
+    headerTextOffset = 12
+    encoding = major === 3 ? 'utf-8' : 'latin1'
+  } else {
+    throw new Error(`Unsupported .npy version ${major}.`)
+  }
+  const dataOffset = headerTextOffset + headerLen
+  if (dataOffset > buffer.byteLength) {
+    throw new Error('Corrupt .npy file (header length exceeds file size).')
+  }
+  const header = new TextDecoder(encoding).decode(bytes.subarray(headerTextOffset, dataOffset))
+
+  const descrMatch = header.match(/'descr'\s*:\s*'([^']+)'/)
+  if (!descrMatch) {
+    throw new Error('Corrupt .npy header (no dtype).')
+  }
+  const descr = descrMatch[1]
+  const endian = descr[0]
+  const suffix = descr.slice(1)
+
+  const shapeMatch = header.match(/'shape'\s*:\s*\(([^)]*)\)/)
+  if (!shapeMatch) {
+    throw new Error('Corrupt .npy header (no shape).')
+  }
+  const shapeInner = shapeMatch[1]
+  const dims = shapeInner
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s !== '')
+    .map(Number)
+  if (dims.some((d) => !Number.isInteger(d) || d < 0)) {
+    throw new Error(`Corrupt .npy header (invalid shape (${shapeInner})).`)
+  }
+  const numElements = dims.reduce((a, b) => a * b, 1)
+
+  const fortranOrder = /'fortran_order'\s*:\s*True/.test(header)
+
+  // For multi-byte types `=` means native order; single-byte `|` is irrelevant.
+  const littleEndian =
+    endian === '<' || endian === '|' || (endian === '=' && SYSTEM_LITTLE_ENDIAN)
+
+  return { dataOffset, descr, endian, suffix, littleEndian, fortranOrder, shapeInner, numElements }
+}
+
+/** Assemble a v1.0 `.npy` file from a dtype string, preserved header fields and raw data. */
+function buildNpy(
+  descr: string,
+  fortranOrder: boolean,
+  shapeInner: string,
+  data: Uint8Array,
+): ArrayBuffer {
+  let dict = `{'descr': '${descr}', 'fortran_order': ${
+    fortranOrder ? 'True' : 'False'
+  }, 'shape': (${shapeInner}), }`
+  // The 10-byte preamble + header text + trailing newline must be a multiple of
+  // 64 bytes (NumPy's alignment rule); pad the dict with spaces to suit.
+  const pad = (64 - ((10 + dict.length + 1) % 64)) % 64
+  dict = dict + ' '.repeat(pad) + '\n'
+  const headerBytes = new TextEncoder().encode(dict)
+
+  const out = new Uint8Array(10 + headerBytes.length + data.byteLength)
+  out.set(NPY_MAGIC, 0)
+  out[6] = 1 // major version
+  out[7] = 0 // minor version
+  new DataView(out.buffer).setUint16(8, headerBytes.length, true)
+  out.set(headerBytes, 10)
+  out.set(data, 10 + headerBytes.length)
+  return out.buffer
+}
+
+/** Down-cast an int64 array to int32 (or float64 if any value overflows int32). */
+function downcastInt64(dv: DataView, dataOffset: number, n: number, littleEndian: boolean) {
+  let fitsInt32 = true
+  for (let i = 0; i < n; i++) {
+    const v = dv.getBigInt64(dataOffset + i * 8, littleEndian)
+    if (v < INT32_MIN || v > INT32_MAX) {
+      fitsInt32 = false
+      break
+    }
+  }
+  if (fitsInt32) {
+    const out = new Uint8Array(n * 4)
+    const odv = new DataView(out.buffer)
+    for (let i = 0; i < n; i++) {
+      odv.setInt32(i * 4, Number(dv.getBigInt64(dataOffset + i * 8, littleEndian)), true)
+    }
+    return { descr: '<i4', data: out }
+  }
+  const out = new Uint8Array(n * 8)
+  const odv = new DataView(out.buffer)
+  for (let i = 0; i < n; i++) {
+    odv.setFloat64(i * 8, Number(dv.getBigInt64(dataOffset + i * 8, littleEndian)), true)
+  }
+  return { descr: '<f8', data: out }
+}
+
+/** Down-cast a uint64 array to uint32 (or float64 if any value overflows uint32). */
+function downcastUint64(dv: DataView, dataOffset: number, n: number, littleEndian: boolean) {
+  let fitsUint32 = true
+  for (let i = 0; i < n; i++) {
+    if (dv.getBigUint64(dataOffset + i * 8, littleEndian) > UINT32_MAX) {
+      fitsUint32 = false
+      break
+    }
+  }
+  if (fitsUint32) {
+    const out = new Uint8Array(n * 4)
+    const odv = new DataView(out.buffer)
+    for (let i = 0; i < n; i++) {
+      odv.setUint32(i * 4, Number(dv.getBigUint64(dataOffset + i * 8, littleEndian)), true)
+    }
+    return { descr: '<u4', data: out }
+  }
+  const out = new Uint8Array(n * 8)
+  const odv = new DataView(out.buffer)
+  for (let i = 0; i < n; i++) {
+    odv.setFloat64(i * 8, Number(dv.getBigUint64(dataOffset + i * 8, littleEndian)), true)
+  }
+  return { descr: '<f8', data: out }
+}
+
+/**
+ * Convert an `.npy` buffer into one NiiVue's reader can display. Buffers already
+ * using a supported element type are returned unchanged; int64/uint64 are
+ * down-cast; anything else (complex, float16, ...) throws an actionable error.
+ */
+export function convertNpy(buffer: ArrayBuffer): ArrayBuffer {
+  const header = parseNpyHeader(buffer)
+  if (NIIVUE_SUPPORTED_SUFFIXES.has(header.suffix)) {
+    return buffer
+  }
+
+  const dv = new DataView(buffer)
+  let converted: { descr: string; data: Uint8Array }
+  if (header.suffix === 'i8') {
+    converted = downcastInt64(dv, header.dataOffset, header.numElements, header.littleEndian)
+  } else if (header.suffix === 'u8') {
+    converted = downcastUint64(dv, header.dataOffset, header.numElements, header.littleEndian)
+  } else {
+    throw new Error(
+      `This .npy uses dtype "${header.descr}", which the viewer cannot display. ` +
+        `Re-save it as an 8/16/32-bit integer or 32/64-bit float array ` +
+        `(e.g. arr.astype('int32') or arr.astype('float32')) before loading.`,
+    )
+  }
+
+  return buildNpy(converted.descr, header.fortranOrder, header.shapeInner, converted.data)
+}
+
+/** Inflate a raw DEFLATE stream (ZIP method 8) via `DecompressionStream`. */
+async function inflateRaw(compressed: Uint8Array): Promise<Uint8Array> {
+  if (typeof DecompressionStream === 'undefined') {
+    throw new Error('This environment cannot decompress .npz files (no DecompressionStream).')
+  }
+  const ds = new DecompressionStream('deflate-raw')
+  const writer = ds.writable.getWriter()
+  // Hand the compressed bytes straight to the writer/reader rather than via
+  // Blob.stream(), which some test environments (jsdom) do not implement. Copy
+  // into a fresh ArrayBuffer-backed view so the BufferSource type is concrete.
+  writer.write(new Uint8Array(compressed)).catch(() => {})
+  writer.close().catch(() => {})
+  const reader = ds.readable.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) {
+      break
+    }
+    if (value) {
+      chunks.push(value)
+      total += value.byteLength
+    }
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return out
+}
+
+const ZIP_LOCAL_FILE_HEADER = 0x04034b50
+
+/**
+ * Convert an `.npz` buffer into a single displayable `.npy`. An `.npz` is a ZIP
+ * archive of one or more `.npy` members (`np.savez` stores them, `savez_compressed`
+ * deflates them); the first `.npy` member is extracted and run through
+ * {@link convertNpy}. ZIP local-file headers are walked directly - numpy writes
+ * the member sizes inline, so no central-directory pass is needed.
+ */
+export async function convertNpz(buffer: ArrayBuffer): Promise<ArrayBuffer> {
+  const bytes = new Uint8Array(buffer)
+  const dv = new DataView(buffer)
+  let offset = 0
+  while (offset + 30 <= bytes.length) {
+    if (dv.getUint32(offset, true) !== ZIP_LOCAL_FILE_HEADER) {
+      break // reached the central directory (or end of archive)
+    }
+    const flags = dv.getUint16(offset + 6, true)
+    const method = dv.getUint16(offset + 8, true)
+    const compressedSize = dv.getUint32(offset + 18, true)
+    const nameLen = dv.getUint16(offset + 26, true)
+    const extraLen = dv.getUint16(offset + 28, true)
+    const name = new TextDecoder().decode(bytes.subarray(offset + 30, offset + 30 + nameLen))
+    const dataStart = offset + 30 + nameLen + extraLen
+
+    if (flags & 0x08 && compressedSize === 0) {
+      // Streaming entry: the size lives in a trailing data descriptor, not the
+      // local header. numpy never writes these; bail with a clear message.
+      throw new Error('This .npz uses streaming ZIP entries the viewer cannot read; re-save with numpy.')
+    }
+
+    if (name.toLowerCase().endsWith('.npy')) {
+      const compressed = bytes.subarray(dataStart, dataStart + compressedSize)
+      let npy: Uint8Array
+      if (method === 0) {
+        npy = compressed
+      } else if (method === 8) {
+        npy = await inflateRaw(compressed)
+      } else {
+        throw new Error(`This .npz entry "${name}" uses unsupported ZIP compression method ${method}.`)
+      }
+      return convertNpy(toArrayBuffer(npy))
+    }
+
+    offset = dataStart + compressedSize
+  }
+  throw new Error('This .npz archive contains no .npy arrays.')
+}

--- a/packages/niivue-react/src/test/npy.test.ts
+++ b/packages/niivue-react/src/test/npy.test.ts
@@ -1,0 +1,186 @@
+import { deflateRawSync } from 'node:zlib'
+import { describe, expect, it } from 'vitest'
+import { convertNpy, convertNpz, isNpyName } from '../npy'
+
+// --- .npy builders / readers ----------------------------------------------
+// Build minimal but spec-correct v1.0 .npy buffers and read them back, so the
+// tests exercise the real header parser without depending on Python fixtures.
+
+const MAGIC = [0x93, 0x4e, 0x55, 0x4d, 0x50, 0x59]
+
+function makeNpy(descr: string, shapeInner: string, data: Uint8Array): ArrayBuffer {
+  let dict = `{'descr': '${descr}', 'fortran_order': False, 'shape': (${shapeInner}), }`
+  const pad = (64 - ((10 + dict.length + 1) % 64)) % 64
+  dict = dict + ' '.repeat(pad) + '\n'
+  const headerBytes = new TextEncoder().encode(dict)
+  const out = new Uint8Array(10 + headerBytes.length + data.byteLength)
+  out.set(MAGIC, 0)
+  out[6] = 1
+  out[7] = 0
+  new DataView(out.buffer).setUint16(8, headerBytes.length, true)
+  out.set(headerBytes, 10)
+  out.set(data, 10 + headerBytes.length)
+  return out.buffer
+}
+
+function readNpy(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer)
+  const dv = new DataView(buffer)
+  const headerLen = dv.getUint16(8, true)
+  const header = new TextDecoder('latin1').decode(bytes.subarray(10, 10 + headerLen))
+  const descr = header.match(/'descr'\s*:\s*'([^']+)'/)![1]
+  const shapeInner = header.match(/'shape'\s*:\s*\(([^)]*)\)/)![1]
+  const suffix = descr.slice(1)
+  const le = descr[0] !== '>'
+  const dataOffset = 10 + headerLen
+  const dims = shapeInner
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(Number)
+  const n = dims.reduce((a, b) => a * b, 1)
+  const values: number[] = []
+  for (let i = 0; i < n; i++) {
+    switch (suffix) {
+      case 'i4':
+        values.push(dv.getInt32(dataOffset + i * 4, le))
+        break
+      case 'u4':
+        values.push(dv.getUint32(dataOffset + i * 4, le))
+        break
+      case 'f8':
+        values.push(dv.getFloat64(dataOffset + i * 8, le))
+        break
+      case 'u1':
+        values.push(dv.getUint8(dataOffset + i))
+        break
+      default:
+        throw new Error(`test reader: unhandled dtype ${descr}`)
+    }
+  }
+  return { descr, shapeInner, values }
+}
+
+function bytesOf(arr: { buffer: ArrayBufferLike; byteOffset: number; byteLength: number }): Uint8Array {
+  return new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength)
+}
+
+// --- .npz (ZIP) builder ----------------------------------------------------
+// One local file header + member data is all convertNpz needs (it returns at
+// the first .npy member); a trailing central-directory signature terminates the
+// scan cleanly.
+
+function makeNpz(entryName: string, npy: Uint8Array, method: 0 | 8): ArrayBuffer {
+  const data = method === 8 ? new Uint8Array(deflateRawSync(npy)) : npy
+  const nameBytes = new TextEncoder().encode(entryName)
+  const header = new Uint8Array(30 + nameBytes.length)
+  const dv = new DataView(header.buffer)
+  dv.setUint32(0, 0x04034b50, true) // local file header signature
+  dv.setUint16(4, 20, true) // version needed
+  dv.setUint16(6, 0, true) // flags
+  dv.setUint16(8, method, true) // compression method
+  dv.setUint32(14, 0, true) // crc-32 (not validated by the reader)
+  dv.setUint32(18, data.length, true) // compressed size
+  dv.setUint32(22, npy.length, true) // uncompressed size
+  dv.setUint16(26, nameBytes.length, true)
+  dv.setUint16(28, 0, true) // extra length
+  header.set(nameBytes, 30)
+  const out = new Uint8Array(header.length + data.length + 4)
+  out.set(header, 0)
+  out.set(data, header.length)
+  out.set([0x50, 0x4b, 0x01, 0x02], header.length + data.length) // central-dir sentinel
+  return out.buffer
+}
+
+describe('isNpyName', () => {
+  it('matches .npy and .npz case-insensitively', () => {
+    expect(isNpyName('volume.npy')).toBe(true)
+    expect(isNpyName('VOLUME.NPZ')).toBe(true)
+    expect(isNpyName('brain.nii.gz')).toBe(false)
+  })
+})
+
+describe('convertNpy - supported dtypes pass through untouched', () => {
+  it('returns the same buffer for float64', () => {
+    const buf = makeNpy('<f8', '2, 3', bytesOf(new Float64Array([0, 1, 2, 3, 4, 5])))
+    expect(convertNpy(buf)).toBe(buf)
+  })
+
+  it('returns the same buffer for uint8 and int32', () => {
+    const u8 = makeNpy('|u1', '2, 2', new Uint8Array([1, 2, 3, 4]))
+    const i4 = makeNpy('<i4', '2, 2', bytesOf(new Int32Array([1, 2, 3, 4])))
+    expect(convertNpy(u8)).toBe(u8)
+    expect(convertNpy(i4)).toBe(i4)
+  })
+})
+
+describe('convertNpy - int64 (numpy default integer dtype)', () => {
+  it('down-casts int64 to int32 when values fit, preserving data and shape', () => {
+    const src = new BigInt64Array([0n, 1n, -7n, 1679n])
+    const out = convertNpy(makeNpy('<i8', '2, 2', bytesOf(src)))
+    const r = readNpy(out)
+    expect(r.descr).toBe('<i4')
+    expect(r.shapeInner).toBe('2, 2')
+    expect(r.values).toEqual([0, 1, -7, 1679])
+  })
+
+  it('falls back to float64 when a value overflows int32', () => {
+    const src = new BigInt64Array([0n, 3000000000n]) // > 2^31 - 1
+    const out = convertNpy(makeNpy('<i8', '1, 2', bytesOf(src)))
+    const r = readNpy(out)
+    expect(r.descr).toBe('<f8')
+    expect(r.values).toEqual([0, 3000000000])
+  })
+})
+
+describe('convertNpy - uint64', () => {
+  it('down-casts uint64 to uint32 when values fit', () => {
+    const src = new BigUint64Array([0n, 5n, 4294967295n])
+    const out = convertNpy(makeNpy('<u8', '1, 3', bytesOf(src)))
+    const r = readNpy(out)
+    expect(r.descr).toBe('<u4')
+    expect(r.values).toEqual([0, 5, 4294967295])
+  })
+
+  it('falls back to float64 when a value overflows uint32', () => {
+    const src = new BigUint64Array([0n, 5000000000n]) // > 2^32 - 1
+    const out = convertNpy(makeNpy('<u8', '1, 2', bytesOf(src)))
+    const r = readNpy(out)
+    expect(r.descr).toBe('<f8')
+    expect(r.values).toEqual([0, 5000000000])
+  })
+})
+
+describe('convertNpy - undisplayable dtypes', () => {
+  it('throws an actionable error for complex data', () => {
+    const buf = makeNpy('<c16', '2', new Uint8Array(32))
+    expect(() => convertNpy(buf)).toThrow(/cannot display/i)
+  })
+
+  it('throws on a non-npy buffer', () => {
+    expect(() => convertNpy(new Uint8Array([1, 2, 3, 4]).buffer)).toThrow(/not a valid \.npy/i)
+  })
+})
+
+describe('convertNpz', () => {
+  it('extracts and converts a stored (uncompressed) int64 member', async () => {
+    const npy = new Uint8Array(makeNpy('<i8', '2, 2', bytesOf(new BigInt64Array([1n, 2n, 3n, 4n]))))
+    const out = await convertNpz(makeNpz('arr_0.npy', npy, 0))
+    const r = readNpy(out)
+    expect(r.descr).toBe('<i4')
+    expect(r.values).toEqual([1, 2, 3, 4])
+  })
+
+  it('inflates and converts a deflate-compressed member', async () => {
+    const npy = new Uint8Array(makeNpy('<i8', '1, 3', bytesOf(new BigInt64Array([10n, 20n, 30n]))))
+    const out = await convertNpz(makeNpz('data.npy', npy, 8))
+    const r = readNpy(out)
+    expect(r.descr).toBe('<i4')
+    expect(r.values).toEqual([10, 20, 30])
+  })
+
+  it('throws when the archive has no .npy member', async () => {
+    const notNpy = new Uint8Array([1, 2, 3, 4])
+    await expect(convertNpz(makeNpz('readme.txt', notNpy, 0))).rejects.toThrow(/no \.npy/i)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #90. NumPy `.npy`/`.npz` volumes were advertised as supported but loaded **corrupt / all-black** (or, on the new v1 core, failed outright).

**Root cause** is in NiiVue's numpy reader, not this repo's load path: the reader only understands a fixed set of element types (`b1, i1, u1, i2, u2, i4, u4, f4, f8`). NumPy's **default integer dtype is int64** (`<i8`) - `np.save` of any integer array, label maps, masks and `np.arange(...)` all land here - which the reader can't take. On the released 0.68.x line it silently mis-read int64 as 1-byte float32 (garbage / black); on the v1 core it throws `Unsupported NPY dtype`. Float arrays default to `<f8` (supported), which is why floats mostly worked and ints didn't.

I verified this by running NiiVue's actual reader against real `np.save` output across every common dtype.

## What changed

A small loader shim, `packages/niivue-react/src/npy.ts`, registered via `nv.useLoader` for `npy`/`npz` (the same hook already used for the MINC loader). It runs **before** NiiVue's reader and down-casts the element types it can't take:

- `int64 -> int32` (or `float64` if any value overflows int32)
- `uint64 -> uint32` (or `float64` if any value overflows uint32)

`int32` is preferred over `float64` so the data keeps integer semantics (label-map auto-detection, integer colour scales). Element types NiiVue already supports pass through untouched; genuinely undisplayable ones (complex, float16) now raise a clear, actionable error instead of rendering black. `.npz` archives are unzipped directly - both `savez` (stored) and `savez_compressed` (deflate) members - and their first array is converted.

The loaders are registered **once per instance** (`ExtendedNiivue.npyLoadersRegistered` guard): the npy converter shares its from/to extension, so re-registering on every load would nest it around the previous reader.

## Files

- `packages/niivue-react/src/npy.ts` - new: `convertNpy` / `convertNpz` / `isNpyName`
- `packages/niivue-react/src/components/NiiVueCanvas.tsx` - register the loaders
- `packages/niivue-react/src/events.ts` - `npyLoadersRegistered` guard flag
- `packages/niivue-react/src/test/npy.test.ts` - new: 12 tests

## Testing

- 12 new unit tests (int64->int32, overflow->float64, uint64, supported-dtype passthrough, npz stored + deflate, error cases).
- Full `@niivue/react` suite green (191 tests); repo-wide `type-check` and lint clean.

## Reviewer notes

- The data-correctness path is fully covered, but the final WebGL **render** was not verified headless (the converter emits a standard supported-dtype `.npy`, and NiiVue's reader already handles int32/float32/uint8 correctly). A manual eyeball of an int64 `.npy` in the PWA would be a good final check.
- Longer term this could be fixed upstream in NiiVue by adding native `i8`/`u8` support to its numpy reader, after which this shim could be retired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)