### PR TITLE
feat(viewer): draw slices on the voxel grid by default, add a World Space toggle (#266)

### DIFF
--- a/.changeset/voxel-space-default.md
+++ b/.changeset/voxel-space-default.md
@@ -9,7 +9,9 @@
 
 Draw slices on the native voxel grid by default, with a **View > World Space** toggle (`W`) to switch back.
 
-niivue 0.x had `opts.isSliceMM`, whose default (`false`) drew 2D slices on the voxel grid; `true` drew them in scanner/world mm space, which rotates and resamples an obliquely acquired volume. The v1 core dropped the option and always renders in world space, so an oblique acquisition came up rotated with no way to see the rectangular grid it was measured on (#266).
+niivue 0.x had `opts.isSliceMM`, whose default (`false`) drew 2D slices on the voxel grid; `true` drew them in scanner/world mm space, which rotates and resamples an obliquely acquired volume. The v1 core always renders in world space, so an oblique acquisition came up rotated with no way to see the rectangular grid it was measured on (#266).
+
+The v1 option that looks like the replacement is not one: niivue/mono's migration table maps `isSliceMM` to `isPositionInMM`, but nothing in the render path reads that flag (upstream documents it as the *crosshair* coordinate space), and setting it on an oblique volume leaves `obliqueRAS`, `frac2mm` and the extents unchanged.
 
 - Voxel space is restored through niivue's public affine API: the volume affine is replaced by its nearest axis-aligned equivalent, which makes the core derive an identity `obliqueRAS` and lay the slices back on the voxel grid. Each voxel axis keeps its direction, sign and length, so the voxel data is neither permuted nor mirrored, and the world origin stays on the same voxel so the crosshair does not jump. `resetVolumeAffine` restores world space exactly.
 - The correction is derived from the background volume and applied to every volume of a canvas, so overlays stay registered to the background instead of each drifting onto its own grid. A volume that is already axis-aligned is left untouched, and an overlay loaded while voxel space is active is brought into line.

--- a/.changeset/voxel-space-default.md
+++ b/.changeset/voxel-space-default.md
@@ -1,0 +1,19 @@
+---
+'@niivue/react': minor
+'niivue': minor
+'@niivue/pwa': patch
+'@niivue/streamlit': patch
+'@niivue/jupyter': patch
+'@niivue/tauri': patch
+---
+
+Draw slices on the native voxel grid by default, with a **View > World Space** toggle (`W`) to switch back.
+
+niivue 0.x had `opts.isSliceMM`, whose default (`false`) drew 2D slices on the voxel grid; `true` drew them in scanner/world mm space, which rotates and resamples an obliquely acquired volume. The v1 core dropped the option and always renders in world space, so an oblique acquisition came up rotated with no way to see the rectangular grid it was measured on (#266).
+
+- Voxel space is restored through niivue's public affine API: the volume affine is replaced by its nearest axis-aligned equivalent, which makes the core derive an identity `obliqueRAS` and lay the slices back on the voxel grid. Each voxel axis keeps its direction, sign and length, so the voxel data is neither permuted nor mirrored, and the world origin stays on the same voxel so the crosshair does not jump. `resetVolumeAffine` restores world space exactly.
+- The correction is derived from the background volume and applied to every volume of a canvas, so overlays stay registered to the background instead of each drifting onto its own grid. A volume that is already axis-aligned is left untouched, and an overlay loaded while voxel space is active is brought into line.
+- New persisted `worldSpace` setting (default off), a `niivue.worldSpace` VS Code setting, and a `niivue.toggleWorldSpace` command bound to `W` so the shortcut is customizable in VS Code.
+- Meshes are not moved onto the voxel grid with the volumes, and the mm readout becomes voxel-grid mm rather than scanner mm. Both limitations were also present in niivue 0.x's voxel-space mode.
+
+The **Select** control moved out of its own slot at the far right of the top bar and is now a normal menu-bar item, trailing the others, so it reads as related to the menus it scopes. Like every other bar item it collapses into the overflow ("More") menu when the bar runs out of room.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ These shortcuts control the viewer interface and can be customized in VSCode set
 - **X**: Toggle radiological convention
 - **M**: Toggle crosshair
 - **Z**: Toggle zoom drag mode
+- **W**: Toggle world space (off by default: slices are drawn on the native voxel grid, so an oblique acquisition is shown unrotated)
 - **U**: Cycle UI visibility (Show All → Hide UI → Hide All)
 
 **Actions:**

--- a/apps/jupyter/src/viewer.ts
+++ b/apps/jupyter/src/viewer.ts
@@ -123,6 +123,7 @@ export class NiivueWidget extends Widget {
         colorbar: false,
         radiologicalConvention: false,
         zoomDragMode: false,
+        worldSpace: false,
         defaultVolumeColormap: 'gray',
         defaultOverlayColormap: 'redyell',
       }

--- a/apps/streamlit/niivue_component/frontend/src/hooks/useStreamlitNiivue.ts
+++ b/apps/streamlit/niivue_component/frontend/src/hooks/useStreamlitNiivue.ts
@@ -21,6 +21,7 @@ export const useStreamlitNiivue = (args: StreamlitArgs) => {
     interpolation: args.settings?.interpolation ?? true,
     defaultVolumeColormap: 'gray',
     zoomDragMode: false,
+    worldSpace: false,
     defaultOverlayColormap: 'red',
     defaultOverlayOpacity: 0.5,
     defaultMeshOverlayColormap: 'redyell',

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -94,6 +94,7 @@ These shortcuts can be customized in VS Code's Keyboard Shortcuts editor (File �
 - **X**: Toggle radiological convention
 - **M**: Toggle crosshair visibility
 - **Z**: Toggle zoom drag mode
+- **W**: Toggle world space (off by default: slices are drawn on the native voxel grid, so an oblique acquisition is shown unrotated)
 - **U**: Cycle UI visibility (Show All → Hide UI → Hide All)
 
 **Actions:**

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -141,6 +141,10 @@
         "title": "NiiVue: Toggle Zoom Mode"
       },
       {
+        "command": "niivue.toggleWorldSpace",
+        "title": "NiiVue: Toggle World Space"
+      },
+      {
         "command": "niivue.addImage",
         "title": "NiiVue: Add Image"
       },
@@ -223,6 +227,11 @@
       {
         "command": "niivue.toggleZoomMode",
         "key": "z",
+        "when": "activeCustomEditorId == niiVue.default && !inputFocus"
+      },
+      {
+        "command": "niivue.toggleWorldSpace",
+        "key": "w",
         "when": "activeCustomEditorId == niiVue.default && !inputFocus"
       },
       {
@@ -407,6 +416,11 @@
           "type": "boolean",
           "default": false,
           "description": "Enable zoom drag mode by default."
+        },
+        "niivue.worldSpace": {
+          "type": "boolean",
+          "default": false,
+          "description": "Render slices in scanner (world) mm space by default. When off, slices are drawn on the native voxel grid, so an oblique acquisition is shown unrotated and unresampled."
         },
         "niivue.defaultVolumeColormap": {
           "type": "string",

--- a/apps/vscode/src/editorProvider.ts
+++ b/apps/vscode/src/editorProvider.ts
@@ -57,6 +57,7 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
     const colorbar = config.get<boolean>('colorbar', false)
     const radiologicalConvention = config.get<boolean>('radiologicalConvention', false)
     const zoomDragMode = config.get<boolean>('zoomDragMode', false)
+    const worldSpace = config.get<boolean>('worldSpace', false)
     const defaultVolumeColormap = config.get<string>('defaultVolumeColormap', 'gray')
     const defaultOverlayColormap = config.get<string>('defaultOverlayColormap', 'redyell')
     const defaultOverlayOpacity = config.get<number>('defaultOverlayOpacity', 0.5)
@@ -70,6 +71,7 @@ export class NiiVueEditorProvider implements vscode.CustomReadonlyEditorProvider
         colorbar,
         radiologicalConvention,
         zoomDragMode,
+        worldSpace,
         defaultVolumeColormap,
         defaultOverlayColormap,
         defaultOverlayOpacity,

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -19,6 +19,7 @@ export function activate(context: vscode.ExtensionContext) {
     'niivue.toggleRadiological',
     'niivue.toggleCrosshair',
     'niivue.toggleZoomMode',
+    'niivue.toggleWorldSpace',
     'niivue.addImage',
     'niivue.addOverlay',
     'niivue.colorscale',

--- a/packages/niivue-react/src/components/Menu.css
+++ b/packages/niivue-react/src/components/Menu.css
@@ -10,7 +10,6 @@
   min-height: var(--topbar-h);
 }
 .nv-topbar-left { display: flex; align-items: center; gap: 20px; min-width: 0; flex: 1; }
-.nv-topbar-right { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
 
 /* Adaptive menu bar: a single non-wrapping row that overflows into a "More"
    menu instead of wrapping to a second line. */

--- a/packages/niivue-react/src/components/Menu.tsx
+++ b/packages/niivue-react/src/components/Menu.tsx
@@ -22,7 +22,6 @@ import { AppInfo, AppProps, SelectionMode } from './AppProps'
 import { HeaderBox } from './HeaderBox'
 import {
     HeaderDialog,
-    ImageSelect,
     MenuEntry,
     StepperEntry,
     ToggleEntry,
@@ -31,6 +30,7 @@ import {
 } from './MenuElements'
 import { BarItem, MenuBar } from './MenuBar'
 import { DEFAULT_TILE_SPACING } from '../settings'
+import { applySliceSpace } from '../sliceSpace'
 import { ScalingBox } from './ScalingBox'
 
 export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
@@ -48,6 +48,7 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
   const radiologicalConvention = useSignal(settings.value.radiologicalConvention)
   const colorbar = useSignal(settings.value.colorbar)
   const zoomDragMode = useSignal(settings.value.zoomDragMode)
+  const worldSpace = useSignal(settings.value.worldSpace)
   const tileSpacing = useSignal(settings.value.tileSpacing ?? DEFAULT_TILE_SPACING)
   const selectionActive = useSignal(false)
   const selectMultiple = useSignal(false)
@@ -92,6 +93,12 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
   effect(() => applyRadiologicalConvention(nvArray, radiologicalConvention))
   effect(() => applyColorbar(nvArray, colorbar))
   effect(() => applyDragMode(nvArray, zoomDragMode))
+  // Rewrites volume affines, so it is async; the effect only kicks it off.
+  effect(() => {
+    applySliceSpace(nvArray.value, worldSpace.value).catch((e) =>
+      console.warn('Failed to apply slice space', e),
+    )
+  })
 
   // Sync settings global value to local signals (e.g. for Streamlit)
   effect(() => {
@@ -100,6 +107,7 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
     radiologicalConvention.value = settings.value.radiologicalConvention
     colorbar.value = settings.value.colorbar
     zoomDragMode.value = settings.value.zoomDragMode
+    worldSpace.value = settings.value.worldSpace
     tileSpacing.value = settings.value.tileSpacing ?? DEFAULT_TILE_SPACING
   })
 
@@ -111,6 +119,7 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
       settings.value.radiologicalConvention !== radiologicalConvention.value ||
       settings.value.colorbar !== colorbar.value ||
       settings.value.zoomDragMode !== zoomDragMode.value ||
+      settings.value.worldSpace !== worldSpace.value ||
       settings.value.tileSpacing !== tileSpacing.value
     ) {
       settings.value = {
@@ -120,6 +129,7 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
         radiologicalConvention: radiologicalConvention.value,
         colorbar: colorbar.value,
         zoomDragMode: zoomDragMode.value,
+        worldSpace: worldSpace.value,
         tileSpacing: tileSpacing.value,
       }
     }
@@ -256,6 +266,7 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
       radiologicalConvention: radiologicalConvention.value,
       colorbar: colorbar.value,
       zoomDragMode: zoomDragMode.value,
+      worldSpace: worldSpace.value,
       tileSpacing: tileSpacing.value,
     }
     localStorage.setItem('userSettings', JSON.stringify(currentSettings))
@@ -449,6 +460,11 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
     settings.value = { ...settings.value, zoomDragMode: zoomDragMode.value }
   }
 
+  const toggleWorldSpace = () => {
+    worldSpace.value = !worldSpace.value
+    settings.value = { ...settings.value, worldSpace: worldSpace.value }
+  }
+
   const setTileSpacing = (value: number) => {
     tileSpacing.value = value
     settings.value = { ...settings.value, tileSpacing: value }
@@ -475,6 +491,7 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
     onToggleRadiological: toggleRadiological,
     onToggleCrosshair: toggleCrosshair,
     onToggleZoomMode: toggleZoomDragMode,
+    onToggleWorldSpace: toggleWorldSpace,
     onAddImage: addImagesEvent,
     onAddOverlay: overlayButtonOnClick,
     onColorscale: openColorScaleLastOverlay,
@@ -496,6 +513,7 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
     toggleRadiological,
     toggleCrosshair,
     toggleZoomDragMode,
+    toggleWorldSpace,
     addImagesEvent,
     overlayButtonOnClick,
     openColorScaleLastOverlay,
@@ -648,6 +666,13 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
             state={crosshair}
             shortcut={formatShortcut(UI_SHORTCUTS.TOGGLE_CROSSHAIR)}
           />
+          {/* Off (the default) draws slices on the native voxel grid; on shows
+              them in scanner mm space, which rotates an oblique acquisition. */}
+          <ToggleEntry
+            label="World Space"
+            state={worldSpace}
+            shortcut={formatShortcut(UI_SHORTCUTS.TOGGLE_WORLD_SPACE)}
+          />
           <hr />
           {!isVscode && <MenuEntry label="Save Settings" onClick={saveSettings} />}
         </>
@@ -770,6 +795,22 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
         </>
       ),
     },
+    {
+      // Scopes what the other menus act on. It used to be pinned to the far right
+      // of the top bar, which read as unrelated to the menus it governs; it is a
+      // normal bar item now, trailing them (#266).
+      key: 'select',
+      type: 'select',
+      label: 'Select',
+      visible: multipleVolumes.value,
+      state: selectionActive,
+      children: (
+        <>
+          <ToggleEntry label="Multiple" state={selectMultiple} />
+          <MenuEntry label="Select All" onClick={selectAll} />
+        </>
+      ),
+    },
   ]
 
   return (
@@ -783,12 +824,6 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
             onAbout={() => (aboutDialog.value = true)}
           />
           <MenuBar items={barItems} />
-        </div>
-        <div className="nv-topbar-right">
-          <ImageSelect label="Select" state={selectionActive} visible={multipleVolumes}>
-            <ToggleEntry label="Multiple" state={selectMultiple} />
-            <MenuEntry label="Select All" onClick={selectAll} />
-          </ImageSelect>
         </div>
       </div>
       <ScalingBox

--- a/packages/niivue-react/src/components/MenuBar.tsx
+++ b/packages/niivue-react/src/components/MenuBar.tsx
@@ -1,14 +1,24 @@
 import { ComponentChildren } from 'preact'
 import { Signal, computed, useSignal } from '@preact/signals'
 import { useLayoutEffect, useRef } from 'preact/hooks'
-import { MenuButton, MenuEntry, MenuItem, MenuToggle, ToggleEntry, activeMenu } from './MenuElements'
+import {
+    ImageSelect,
+    MenuButton,
+    MenuEntry,
+    MenuItem,
+    MenuToggle,
+    ToggleEntry,
+    activeMenu,
+} from './MenuElements'
 
 // One top-level entry of the menu bar. The same descriptor renders either as a
 // horizontal control in the bar (delegating to the existing menu primitives) or,
 // when it doesn't fit, as a row inside the "More" overflow popover.
+// `select` is a toggle that also carries a dropdown (the image-selection
+// control): clicking the label flips `state`, the caret opens `children`.
 export type BarItem = {
   key: string
-  type: 'button' | 'menu' | 'toggle'
+  type: 'button' | 'menu' | 'toggle' | 'select'
   label: string
   visible: boolean
   onClick?: () => void
@@ -120,6 +130,13 @@ const BarForm = ({ item }: { item: BarItem }) => {
   if (item.type === 'toggle') {
     return <MenuToggle label={item.label} state={item.state} shortcut={item.shortcut} />
   }
+  if (item.type === 'select') {
+    return (
+      <ImageSelect label={item.label} state={item.state}>
+        {item.children}
+      </ImageSelect>
+    )
+  }
   return (
     <MenuItem label={item.label} onClick={item.onClick} shortcut={item.shortcut}>
       {item.children}
@@ -131,7 +148,7 @@ const BarForm = ({ item }: { item: BarItem }) => {
 // BarForm (a menu is a label button + caret button; others a single button)
 // without flyouts, handlers or testids.
 const ProxyForm = ({ item }: { item: BarItem }) => {
-  if (item.type === 'menu') {
+  if (item.type === 'menu' || item.type === 'select') {
     return (
       <div className="relative" data-proxy>
         <button className="nv-topbtn" tabIndex={-1}>
@@ -198,6 +215,16 @@ const OverflowRow = ({ item, expanded }: { item: BarItem; expanded: Signal<strin
   }
   if (item.type === 'button') {
     return <MenuEntry label={item.label} onClick={item.onClick} shortcut={item.shortcut} />
+  }
+  // The split label/caret control has no room here, so the toggle becomes a row
+  // and its options sit permanently open underneath it.
+  if (item.type === 'select') {
+    return (
+      <div className="nv-more-group">
+        <ToggleEntry label={item.label} state={item.state} />
+        <div className="nv-more-sub">{item.children}</div>
+      </div>
+    )
   }
   const isExpanded = computed(() => expanded.value === item.key)
   return (

--- a/packages/niivue-react/src/constants/keyboardShortcuts.ts
+++ b/packages/niivue-react/src/constants/keyboardShortcuts.ts
@@ -124,6 +124,10 @@ export const UI_SHORTCUTS: Record<string, KeyboardShortcut> = {
     key: 'z',
     description: 'Toggle zoom drag mode',
   },
+  TOGGLE_WORLD_SPACE: {
+    key: 'w',
+    description: 'Toggle world space slice rendering (off = native voxel grid)',
+  },
   ADD_IMAGE: {
     key: 'o',
     ctrl: true,

--- a/packages/niivue-react/src/events.ts
+++ b/packages/niivue-react/src/events.ts
@@ -36,6 +36,10 @@ export async function handleMessage(message: any, appProps: AppProps) {
         const index = body.index >= 0 ? body.index : nvArray.value.length - 1
         if (index >= 0 && index < nvArray.value.length) {
           await addOverlay(nvArray.value[index], body, settings.value)
+          // Re-emit the array so the Menu effects see the new volume. Without
+          // this the overlay keeps its world-space affine while the background
+          // has already been moved onto the voxel grid, and the two misalign.
+          nvArray.value = [...nvArray.value]
           notifyImageLoaded()
         }
       }

--- a/packages/niivue-react/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/niivue-react/src/hooks/useKeyboardShortcuts.ts
@@ -18,6 +18,7 @@ export interface KeyboardShortcutHandlers {
   onToggleRadiological?: () => void
   onToggleCrosshair?: () => void
   onToggleZoomMode?: () => void
+  onToggleWorldSpace?: () => void
   onAddImage?: () => void
   onAddOverlay?: () => void
   onColorscale?: () => void
@@ -124,6 +125,12 @@ export function useKeyboardShortcuts(handlers: KeyboardShortcutHandlers, enabled
       ) {
         event.preventDefault()
         handlers.onToggleZoomMode()
+      } else if (
+        matchesShortcut(event, UI_SHORTCUTS.TOGGLE_WORLD_SPACE) &&
+        handlers.onToggleWorldSpace
+      ) {
+        event.preventDefault()
+        handlers.onToggleWorldSpace()
       } else if (matchesShortcut(event, UI_SHORTCUTS.ADD_IMAGE) && handlers.onAddImage) {
         event.preventDefault()
         handlers.onAddImage()

--- a/packages/niivue-react/src/index.ts
+++ b/packages/niivue-react/src/index.ts
@@ -18,6 +18,7 @@ export * from './events'
 export * from './nifti'
 export * from './hooks'
 export * from './settings'
+export * from './sliceSpace'
 export * from './utility'
 export { createViewerClient } from './viewer-client'
 // Re-export the Viewer-Host Protocol contract so apps depend only on

--- a/packages/niivue-react/src/settings.ts
+++ b/packages/niivue-react/src/settings.ts
@@ -19,6 +19,10 @@ export interface NiiVueSettings {
   colorbar: boolean
   radiologicalConvention: boolean
   zoomDragMode: boolean
+  /** Render 2D slices in scanner/world mm space instead of on the native voxel
+   *  grid. Off by default: an oblique acquisition is then shown as the
+   *  rectangular grid it was measured on, unrotated and unresampled. */
+  worldSpace: boolean
   defaultVolumeColormap: string
   defaultOverlayColormap: string
   defaultOverlayOpacity: number
@@ -39,6 +43,7 @@ export const defaultSettings: NiiVueSettings = {
   colorbar: false,
   radiologicalConvention: false,
   zoomDragMode: false,
+  worldSpace: false,
   defaultVolumeColormap: 'gray',
   defaultOverlayColormap: 'redyell',
   defaultOverlayOpacity: 0.5,

--- a/packages/niivue-react/src/sliceSpace.ts
+++ b/packages/niivue-react/src/sliceSpace.ts
@@ -1,0 +1,188 @@
+import type { NVImage } from '@niivue/niivue'
+import type { ExtendedNiivue } from './events'
+
+/**
+ * Voxel-space vs world-space slice rendering.
+ *
+ * niivue 0.x exposed `opts.isSliceMM`: `false` (its default) drew 2D slices on
+ * the native voxel grid, `true` drew them in scanner/world mm space, which
+ * rotates and resamples an obliquely acquired volume. @niivue/niivue 1.0 dropped
+ * the option and always renders in world space: its 2D model-view-projection is
+ * built from `volumes[0].obliqueRAS`, which is only the identity for an
+ * axis-aligned volume.
+ *
+ * Voxel space comes back through niivue's public affine API. Replacing a
+ * volume's affine with its nearest axis-aligned equivalent makes `calculateRAS`
+ * derive an identity `obliqueRAS`, so slices land on the voxel grid again. The
+ * orthogonalization keeps every voxel axis' dominant direction, sign and length,
+ * so niivue's RAS permutation (and the texture layout it drives) is unchanged;
+ * only the shear/rotation is dropped.
+ *
+ * Everything is derived from `volume.originalAffine`, the affine as loaded, which
+ * niivue stores once and never mutates. That makes the switch idempotent, and
+ * `resetVolumeAffine` restores world space exactly.
+ *
+ * Limitations, both shared with niivue 0.x's voxel-space mode: meshes are not
+ * moved onto the voxel grid with the volumes, and the mm readout becomes
+ * voxel-grid mm rather than scanner mm.
+ */
+
+/** Row-major 4x4 matrix, matching niivue's `AffineMatrix` shape. */
+export type Affine = number[][]
+
+/** Off-grid tolerance in mm per voxel; below this an affine counts as aligned. */
+const ALIGNED_TOLERANCE = 1e-4
+
+/** Row-major 4x4 multiply, `a * b`. */
+export function multiplyAffine(a: Affine, b: Affine): Affine {
+  const out: Affine = []
+  for (let r = 0; r < 4; r++) {
+    out.push([0, 1, 2, 3].map((c) => a[r][0] * b[0][c] + a[r][1] * b[1][c] + a[r][2] * b[2][c] + a[r][3] * b[3][c]))
+  }
+  return out
+}
+
+/** Inverse of a 4x4 affine (bottom row [0,0,0,1]); null when the 3x3 is singular. */
+export function invertAffine(m: Affine): Affine | null {
+  const [a, b, c] = m[0]
+  const [d, e, f] = m[1]
+  const [g, h, i] = m[2]
+  const det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g)
+  if (!Number.isFinite(det) || det === 0) {
+    return null
+  }
+  const inv3 = [
+    [(e * i - f * h) / det, (c * h - b * i) / det, (b * f - c * e) / det],
+    [(f * g - d * i) / det, (a * i - c * g) / det, (c * d - a * f) / det],
+    [(d * h - e * g) / det, (b * g - a * h) / det, (a * e - b * d) / det],
+  ]
+  const t = [m[0][3], m[1][3], m[2][3]]
+  const out: Affine = inv3.map((row) => [
+    ...row,
+    -(row[0] * t[0] + row[1] * t[1] + row[2] * t[2]),
+  ])
+  out.push([0, 0, 0, 1])
+  return out
+}
+
+/** True when two affines agree to within the off-grid tolerance. */
+export function isSameAffine(a: Affine, b: Affine, tolerance = ALIGNED_TOLERANCE): boolean {
+  for (let r = 0; r < 4; r++) {
+    for (let c = 0; c < 4; c++) {
+      if (Math.abs(a[r][c] - b[r][c]) > tolerance) {
+        return false
+      }
+    }
+  }
+  return true
+}
+
+/**
+ * Nearest axis-aligned affine: every voxel axis keeps the RAS direction, sign and
+ * length it had, the shear is dropped, and the world origin stays on the same
+ * voxel so the crosshair does not jump. Null for a degenerate affine.
+ */
+export function orthogonalizeAffine(affine: Affine): Affine | null {
+  const abs = (r: number, c: number) => Math.abs(affine[r][c])
+
+  // Which RAS row does each voxel column point along? This mirrors niivue's own
+  // dominant-axis pick in calculateRAS - strongest row for column 0, strongest
+  // of the two remaining rows for column 1, leftover row for column 2 - so the
+  // permRAS it derives from our affine matches the one it derived from the
+  // original, and the voxel data is not re-permuted or mirrored.
+  let r0 = 0
+  if (abs(1, 0) > abs(0, 0)) r0 = 1
+  if (abs(2, 0) > abs(0, 0) && abs(2, 0) > abs(1, 0)) r0 = 2
+  let r1: number
+  if (r0 === 0) r1 = abs(1, 1) > abs(2, 1) ? 1 : 2
+  else if (r0 === 1) r1 = abs(0, 1) > abs(2, 1) ? 0 : 2
+  else r1 = abs(0, 1) > abs(1, 1) ? 0 : 1
+  const rowForColumn = [r0, r1, 3 - r0 - r1]
+
+  const out: Affine = [
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+    [0, 0, 0, 1],
+  ]
+  for (let col = 0; col < 3; col++) {
+    const row = rowForColumn[col]
+    const length = Math.hypot(affine[0][col], affine[1][col], affine[2][col])
+    if (!(length > 0) || abs(row, col) === 0) {
+      return null
+    }
+    out[row][col] = affine[row][col] < 0 ? -length : length
+  }
+
+  // Keep the world origin on the voxel it already sits on: t = -A' * p, where p
+  // is the voxel index the original affine maps to (0,0,0) mm.
+  const inverse = invertAffine(affine)
+  if (!inverse) {
+    return null
+  }
+  const p = [inverse[0][3], inverse[1][3], inverse[2][3]]
+  for (let row = 0; row < 3; row++) {
+    out[row][3] = -(out[row][0] * p[0] + out[row][1] * p[1] + out[row][2] * p[2])
+  }
+  return out
+}
+
+/**
+ * The transform that moves a whole canvas from world space onto the background
+ * volume's voxel grid: `orthogonalize(A0) * inverse(A0)`. Applying the *same*
+ * correction to every volume keeps overlays registered to the background instead
+ * of letting each one drift onto its own grid.
+ *
+ * Null when the background is already axis-aligned (voxel space is then
+ * identical to world space, so the affines are left untouched) or degenerate.
+ */
+export function voxelSpaceCorrection(background: NVImage | undefined): Affine | null {
+  const original = background?.originalAffine
+  if (!original) {
+    return null
+  }
+  const ortho = orthogonalizeAffine(original)
+  if (!ortho || isSameAffine(ortho, original)) {
+    return null
+  }
+  const inverse = invertAffine(original)
+  return inverse ? multiplyAffine(ortho, inverse) : null
+}
+
+// Volumes currently switched to voxel space. Keyed on the volume object so the
+// bookkeeping survives reordering, and so a volume loaded while voxel space is
+// already active can be brought into line without re-applying the rest.
+const inVoxelSpace = new WeakSet<NVImage>()
+
+/**
+ * Bring every canvas to the requested slice space. Safe to call repeatedly: each
+ * volume is only touched when its space actually has to change.
+ */
+export async function applySliceSpace(
+  nvArray: ExtendedNiivue[],
+  worldSpace: boolean,
+): Promise<void> {
+  for (const nv of nvArray) {
+    const volumes: NVImage[] = nv?.volumes ?? []
+    if (volumes.length === 0) {
+      continue
+    }
+    const correction = worldSpace ? null : voxelSpaceCorrection(volumes[0])
+    for (let i = 0; i < volumes.length; i++) {
+      const volume = volumes[i]
+      try {
+        if (worldSpace) {
+          if (!inVoxelSpace.has(volume)) continue
+          await nv.resetVolumeAffine(i)
+          inVoxelSpace.delete(volume)
+        } else {
+          if (!correction || inVoxelSpace.has(volume) || !volume.originalAffine) continue
+          await nv.setVolumeAffine(i, multiplyAffine(correction, volume.originalAffine))
+          inVoxelSpace.add(volume)
+        }
+      } catch (e) {
+        console.warn(`Failed to switch volume ${i} to ${worldSpace ? 'world' : 'voxel'} space`, e)
+      }
+    }
+  }
+}

--- a/packages/niivue-react/src/sliceSpace.ts
+++ b/packages/niivue-react/src/sliceSpace.ts
@@ -6,10 +6,23 @@ import type { ExtendedNiivue } from './events'
  *
  * niivue 0.x exposed `opts.isSliceMM`: `false` (its default) drew 2D slices on
  * the native voxel grid, `true` drew them in scanner/world mm space, which
- * rotates and resamples an obliquely acquired volume. @niivue/niivue 1.0 dropped
- * the option and always renders in world space: its 2D model-view-projection is
- * built from `volumes[0].obliqueRAS`, which is only the identity for an
- * axis-aligned volume.
+ * rotates and resamples an obliquely acquired volume. @niivue/niivue 1.0 always
+ * renders in world space: its 2D model-view-projection is built from
+ * `volumes[0].obliqueRAS`, which is only the identity for an axis-aligned volume.
+ *
+ * There is a v1 option that looks like the successor. niivue/mono's own migration
+ * table (`packages/niivue/docs/convert.md`) maps `isSliceMM` to
+ * `ui.isPositionInMM`, and `documentLegacy.ts` applies that mapping when loading a
+ * 0.x document. It is a name-only successor: nothing in the render path reads
+ * `isPositionInMM` (in the mono source it appears only in its accessor, the
+ * defaults, type declarations, docs and the legacy-document mapping), and upstream
+ * `FEATURES.md` documents it as the *crosshair* coordinate space, not slice
+ * geometry. Setting it on an oblique volume in rc.9 leaves `obliqueRAS`, `frac2mm`,
+ * `tex2mm` and the extents bit-identical, so it cannot un-rotate the display.
+ * Likewise the matrices 0.x used for voxel space (`frac2mmOrtho`,
+ * `extentsMinOrtho`/`extentsMaxOrtho`, `mm2ortho`) are still computed by
+ * `calculateRAS` but consumed by nothing. Hence the affine route below; if
+ * upstream ever wires a real slice-space switch, this module can be deleted.
  *
  * Voxel space comes back through niivue's public affine API. Replacing a
  * volume's affine with its nearest axis-aligned equivalent makes `calculateRAS`

--- a/packages/niivue-react/src/test/Menu.test.tsx
+++ b/packages/niivue-react/src/test/Menu.test.tsx
@@ -1,9 +1,10 @@
 import { SLICE_TYPE } from '@niivue/niivue'
 import { signal } from '@preact/signals'
 import { cleanup, fireEvent, render, screen } from '@testing-library/preact'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AppProps, SelectionMode } from '../components/AppProps'
 import { Menu } from '../components/Menu'
+import { activeMenu } from '../components/MenuElements'
 
 // Mock canvas and niivue to avoid webgl context issues in jsdom.
 // v1 surface: the package's default export is the NiiVueGPU class (events.ts does
@@ -126,6 +127,7 @@ function makeKbProps(over: Record<string, unknown> = {}) {
       radiologicalConvention: false,
       colorbar: false,
       zoomDragMode: false,
+      worldSpace: false,
       menuItems: { view: true, navigation: true },
     }),
     ...over,
@@ -169,5 +171,46 @@ describe('Menu keyboard wiring (key -> view / UI value)', () => {
     expect(props.hideUI.value).toBe(0)
     pressKey('u')
     expect(props.hideUI.value).toBe(3)
+  })
+
+  it('"w" toggles world space, which defaults to off (voxel grid)', () => {
+    const props = makeKbProps()
+    render(<Menu {...(props as unknown as AppProps)} />)
+
+    expect(props.settings.value.worldSpace).toBe(false)
+    pressKey('w')
+    expect(props.settings.value.worldSpace).toBe(true)
+    pressKey('w')
+    expect(props.settings.value.worldSpace).toBe(false)
+  })
+})
+
+describe('Menu layout', () => {
+  // activeMenu is a module-level signal and `keepOpen` entries leave it set, so a
+  // menu can still be "open" from an earlier test. Start each test closed.
+  beforeEach(() => {
+    activeMenu.value = null
+  })
+
+  it('offers World Space in the View menu', async () => {
+    const props = makeKbProps()
+    render(<Menu {...(props as unknown as AppProps)} />)
+
+    fireEvent.click(screen.getByTestId('menu-item-dropdown-View'))
+    const entry = await screen.findByText('World Space')
+    fireEvent.click(entry)
+    expect(props.settings.value.worldSpace).toBe(true)
+  })
+
+  // The selection control used to be pinned to the far right of the top bar,
+  // detached from the menus it scopes (#266).
+  it('renders Select inside the menu bar, not in a separate right-hand slot', () => {
+    const props = makeKbProps({ nvArray: signal([makeKbNv(), makeKbNv()]) })
+    const { container } = render(<Menu {...(props as unknown as AppProps)} />)
+
+    expect(container.querySelector('.nv-topbar-right')).toBeNull()
+    // Two matches: the interactive row and the hidden width measurer.
+    const select = screen.getAllByText('Select')[0]
+    expect(select.closest('.nv-bar-row')).not.toBeNull()
   })
 })

--- a/packages/niivue-react/src/test/keyboardShortcuts.test.ts
+++ b/packages/niivue-react/src/test/keyboardShortcuts.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { KeyboardShortcut } from '../constants/keyboardShortcuts'
-import { formatShortcut, matchesShortcut, UI_SHORTCUTS } from '../constants/keyboardShortcuts'
+import {
+    formatShortcut,
+    matchesShortcut,
+    NIIVUE_CORE_SHORTCUTS,
+    UI_SHORTCUTS,
+} from '../constants/keyboardShortcuts'
 
 /** Build a KeyboardEvent-shaped object — only the four fields matchesShortcut inspects. */
 function evt(opts: { key: string; ctrl?: boolean; meta?: boolean; shift?: boolean; alt?: boolean }) {
@@ -75,6 +80,34 @@ describe('matchesShortcut', () => {
     expect(matchesShortcut(evt({ key: 'u', shift: true }), UI_SHORTCUTS.HIDE_UI)).toBe(false)
     expect(matchesShortcut(evt({ key: 'u', shift: true }), UI_SHORTCUTS.CROSSHAIR_SUPERIOR)).toBe(true)
     expect(matchesShortcut(evt({ key: 'u' }), UI_SHORTCUTS.CROSSHAIR_SUPERIOR)).toBe(false)
+  })
+})
+
+describe('the shortcut registry', () => {
+  // Both registries are dispatched from the same keydown handler (and niivue core
+  // watches its own keys), so a new entry that reuses a taken combination would
+  // silently shadow an existing action. ALL_SHORTCUTS is merged by name and hides
+  // that, hence walking the two registries directly.
+  it('assigns a unique key combination to every shortcut', () => {
+    const owners = new Map<string, string>()
+    const collisions: string[] = []
+    const registries = [
+      ['core', NIIVUE_CORE_SHORTCUTS],
+      ['ui', UI_SHORTCUTS],
+    ] as const
+    for (const [registry, shortcuts] of registries) {
+      for (const [name, shortcut] of Object.entries(shortcuts)) {
+        const combo = formatShortcut(shortcut)
+        const owner = `${registry}.${name}`
+        const previous = owners.get(combo)
+        if (previous) {
+          collisions.push(`${combo}: ${previous} vs ${owner}`)
+        } else {
+          owners.set(combo, owner)
+        }
+      }
+    }
+    expect(collisions).toEqual([])
   })
 })
 

--- a/packages/niivue-react/src/test/sliceSpace.test.ts
+++ b/packages/niivue-react/src/test/sliceSpace.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+    Affine,
+    applySliceSpace,
+    invertAffine,
+    isSameAffine,
+    multiplyAffine,
+    orthogonalizeAffine,
+    voxelSpaceCorrection,
+} from '../sliceSpace'
+
+const IDENTITY: Affine = [
+  [1, 0, 0, 0],
+  [0, 1, 0, 0],
+  [0, 0, 1, 0],
+  [0, 0, 0, 1],
+]
+
+// A plain axial 2mm volume: already on its voxel grid.
+const AXIAL: Affine = [
+  [2, 0, 0, -90],
+  [0, 2, 0, -126],
+  [0, 0, 2, -72],
+  [0, 0, 0, 1],
+]
+
+// 30 degrees of in-plane rotation about z, 1mm isotropic, origin at voxel 0.
+const COS30 = Math.cos(Math.PI / 6)
+const OBLIQUE: Affine = [
+  [COS30, -0.5, 0, 0],
+  [0.5, COS30, 0, 0],
+  [0, 0, 1, 0],
+  [0, 0, 0, 1],
+]
+
+function expectAffineClose(actual: Affine | null, expected: Affine, precision = 6) {
+  expect(actual).not.toBeNull()
+  for (let r = 0; r < 4; r++) {
+    for (let c = 0; c < 4; c++) {
+      expect(actual![r][c]).toBeCloseTo(expected[r][c], precision)
+    }
+  }
+}
+
+describe('affine helpers', () => {
+  it('multiplies row-major 4x4 matrices', () => {
+    expectAffineClose(multiplyAffine(AXIAL, IDENTITY), AXIAL)
+    // Translating by one voxel along x shifts the origin by the voxel size.
+    const shift: Affine = [
+      [1, 0, 0, 1],
+      [0, 1, 0, 0],
+      [0, 0, 1, 0],
+      [0, 0, 0, 1],
+    ]
+    expect(multiplyAffine(AXIAL, shift)[0][3]).toBeCloseTo(-88, 6)
+  })
+
+  it('inverts an affine and reports singular ones', () => {
+    expectAffineClose(multiplyAffine(OBLIQUE, invertAffine(OBLIQUE)!), IDENTITY)
+    expectAffineClose(multiplyAffine(AXIAL, invertAffine(AXIAL)!), IDENTITY)
+    const flat: Affine = [
+      [1, 0, 0, 0],
+      [0, 1, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 0, 1],
+    ]
+    expect(invertAffine(flat)).toBeNull()
+  })
+})
+
+describe('orthogonalizeAffine', () => {
+  it('leaves an axis-aligned affine alone', () => {
+    expectAffineClose(orthogonalizeAffine(AXIAL), AXIAL)
+  })
+
+  it('drops the rotation of an oblique affine', () => {
+    // Pure rotation of a 1mm isotropic volume about the origin voxel: the
+    // nearest axis-aligned affine is the identity.
+    expectAffineClose(orthogonalizeAffine(OBLIQUE), IDENTITY)
+  })
+
+  it('keeps voxel size and origin voxel when removing shear', () => {
+    // Shear applied to a 3mm slice direction, so the voxel size along z is not 3.
+    const sheared: Affine = [
+      [1, 0, 0.3, -90],
+      [0, 1, 0, -126],
+      [0, 0, 3, -60],
+      [0, 0, 0, 1],
+    ]
+    const ortho = orthogonalizeAffine(sheared)!
+    expect(ortho[0][2]).toBe(0)
+    expect(ortho[2][2]).toBeCloseTo(Math.hypot(0.3, 0, 3), 6)
+    // The world origin must stay on the same voxel, otherwise the crosshair jumps.
+    const before = invertAffine(sheared)!
+    const after = invertAffine(ortho)!
+    for (let r = 0; r < 3; r++) {
+      expect(after[r][3]).toBeCloseTo(before[r][3], 6)
+    }
+  })
+
+  it('keeps axis order and sign, so voxels are not permuted or mirrored', () => {
+    // LAS-style: x decreases with the column index.
+    const las: Affine = [
+      [-1, 0.1, 0, 90],
+      [0, 1, 0, -126],
+      [0, 0, 1, -72],
+      [0, 0, 0, 1],
+    ]
+    const ortho = orthogonalizeAffine(las)!
+    expect(ortho[0][0]).toBeLessThan(0)
+    expect(ortho[0][1]).toBe(0)
+    expect(ortho[1][0]).toBe(0)
+
+    // Sagittal acquisition: column 0 runs along RAS y, column 1 along -z,
+    // column 2 along x. Already axis-aligned, just permuted, so nothing changes.
+    const sagittal: Affine = [
+      [0, 0, 1, -70],
+      [1, 0, 0, -90],
+      [0, -1, 0, 90],
+      [0, 0, 0, 1],
+    ]
+    expectAffineClose(orthogonalizeAffine(sagittal), sagittal)
+  })
+
+  it('rejects a degenerate affine', () => {
+    const zeroColumn: Affine = [
+      [1, 0, 0, 0],
+      [0, 0, 0, 0],
+      [0, 0, 1, 0],
+      [0, 0, 0, 1],
+    ]
+    expect(orthogonalizeAffine(zeroColumn)).toBeNull()
+  })
+})
+
+describe('voxelSpaceCorrection', () => {
+  it('is null when the background is already axis-aligned', () => {
+    expect(voxelSpaceCorrection({ originalAffine: AXIAL } as any)).toBeNull()
+    expect(voxelSpaceCorrection(undefined)).toBeNull()
+    expect(voxelSpaceCorrection({} as any)).toBeNull()
+  })
+
+  it('maps the background onto its own voxel grid', () => {
+    const correction = voxelSpaceCorrection({ originalAffine: OBLIQUE } as any)!
+    expectAffineClose(multiplyAffine(correction, OBLIQUE), orthogonalizeAffine(OBLIQUE)!)
+  })
+})
+
+function makeNv(affines: Affine[]) {
+  return {
+    volumes: affines.map((originalAffine, i) => ({ originalAffine, id: `vol${i}` })),
+    setVolumeAffine: vi.fn(async (_index: number, _affine: Affine) => {}),
+    resetVolumeAffine: vi.fn(async (_index: number) => {}),
+  }
+}
+
+describe('applySliceSpace', () => {
+  it('moves every volume of a canvas by the background correction', async () => {
+    // An overlay acquired on a different grid: it has to follow the background,
+    // not get its own orthogonalization, or the two drift apart.
+    const overlay: Affine = [
+      [2, 0, 0, -90],
+      [0, 2, 0, -126],
+      [0, 0, 2, -72],
+      [0, 0, 0, 1],
+    ]
+    const nv = makeNv([OBLIQUE, overlay])
+    await applySliceSpace([nv] as any, false)
+
+    const correction = voxelSpaceCorrection({ originalAffine: OBLIQUE } as any)!
+    expect(nv.setVolumeAffine).toHaveBeenCalledTimes(2)
+    expect(nv.setVolumeAffine.mock.calls[0][0]).toBe(0)
+    expectAffineClose(nv.setVolumeAffine.mock.calls[0][1], multiplyAffine(correction, OBLIQUE))
+    expect(nv.setVolumeAffine.mock.calls[1][0]).toBe(1)
+    expectAffineClose(nv.setVolumeAffine.mock.calls[1][1], multiplyAffine(correction, overlay))
+  })
+
+  it('does not touch an already axis-aligned canvas', async () => {
+    const nv = makeNv([AXIAL])
+    await applySliceSpace([nv] as any, false)
+    await applySliceSpace([nv] as any, true)
+    expect(nv.setVolumeAffine).not.toHaveBeenCalled()
+    expect(nv.resetVolumeAffine).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent and restores world space through resetVolumeAffine', async () => {
+    const nv = makeNv([OBLIQUE])
+    await applySliceSpace([nv] as any, false)
+    await applySliceSpace([nv] as any, false)
+    expect(nv.setVolumeAffine).toHaveBeenCalledTimes(1)
+
+    await applySliceSpace([nv] as any, true)
+    await applySliceSpace([nv] as any, true)
+    expect(nv.resetVolumeAffine).toHaveBeenCalledTimes(1)
+    expect(nv.resetVolumeAffine).toHaveBeenCalledWith(0)
+
+    // Back to voxel space: the volume is corrected again, not skipped.
+    await applySliceSpace([nv] as any, false)
+    expect(nv.setVolumeAffine).toHaveBeenCalledTimes(2)
+  })
+
+  it('brings a volume loaded later into the active space', async () => {
+    const nv = makeNv([OBLIQUE])
+    await applySliceSpace([nv] as any, false)
+    nv.volumes.push({ originalAffine: AXIAL, id: 'late' })
+    await applySliceSpace([nv] as any, false)
+    expect(nv.setVolumeAffine).toHaveBeenCalledTimes(2)
+    expect(nv.setVolumeAffine.mock.calls[1][0]).toBe(1)
+  })
+
+  it('skips empty canvases and survives a failing volume', async () => {
+    const empty = makeNv([])
+    const failing = makeNv([OBLIQUE])
+    failing.setVolumeAffine = vi.fn(async (_index: number, _affine: Affine) => {
+      throw new Error('no GL context')
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await applySliceSpace([empty, failing] as any, false)
+    expect(empty.setVolumeAffine).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})
+
+describe('isSameAffine', () => {
+  it('ignores float noise but not a real shear', () => {
+    const noisy = AXIAL.map((row) => [...row])
+    noisy[0][1] = 1e-7
+    expect(isSameAffine(AXIAL, noisy)).toBe(true)
+    noisy[0][1] = 0.05
+    expect(isSameAffine(AXIAL, noisy)).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #266.

## Why

niivue 0.x had `opts.isSliceMM`. Its default (`false`) drew 2D slices on the native voxel grid; `true` drew them in scanner/world mm space, which rotates and resamples an obliquely acquired volume.

**@niivue/niivue 1.0 dropped the option.** I checked rc.9 through rc.11: no `isSliceMM`, no equivalent accessor. `UIConfig.isPositionInMM` exists but the render path never reads it. v1's 2D model-view-projection is built from `volumes[0].obliqueRAS`, so slices are always drawn in world space, and an oblique acquisition came up rotated with no way to see the rectangular grid it was measured on.

## How

`calculateRAS` still derives the axis-aligned matrices 0.x used for voxel space (`frac2mmOrtho`, `extentsMinOrtho`/`extentsMaxOrtho`, `mm2ortho`); nothing in the view consumes them. Rather than reach for those internals, the new `packages/niivue-react/src/sliceSpace.ts` goes through niivue's public affine API:

- Replace a volume's affine with its **nearest axis-aligned equivalent** and the core derives an identity `obliqueRAS` on its own, laying the slices back on the voxel grid.
- Each voxel axis keeps its dominant direction, sign and length, so niivue's `permRAS` (and the texture layout it drives) is unchanged: the voxel data is neither permuted nor mirrored, only the shear is dropped.
- The world origin stays on the same voxel, so the crosshair does not jump when switching.
- Everything is derived from `volume.originalAffine` (stored once at load, never mutated), which makes the switch idempotent, and `resetVolumeAffine` restores world space exactly.
- The correction comes from the **background** volume and is applied to **every** volume on the canvas, so overlays stay registered to the background instead of each drifting onto its own grid. An already axis-aligned volume is left untouched entirely.

## What else changed

- New persisted `worldSpace` setting, default **off**. **View > World Space** toggle, shortcut **`W`** (free in both shortcut registries and in niivue core, which claims V/A/C/H/J/K/L and the arrows).
- `niivue.worldSpace` VS Code setting and a `niivue.toggleWorldSpace` command bound to `W`, so the key stays rebindable in the Keyboard Shortcuts editor.
- The overlay message handler now re-emits `nvArray`. Without it an overlay added while voxel space was active kept its world-space affine and misaligned with the corrected background.
- **`Select` moved into the menu bar** (second half of #266). It was pinned to its own slot at the far right of the top bar, which read as unrelated to the menus it scopes. It is now a normal bar item trailing the others, and it collapses into the overflow ("More") menu like every other item. `BarItem` gained a `select` type for this; behaviour of the control itself is unchanged.

## Verification

`pnpm turbo type-check lint test` is green (355 tests). New: 15 unit tests for the affine math and `applySliceSpace`, a Menu test for the `W` toggle and the `Select` placement, and a registry-wide test that no two shortcuts share a key combination.

Checked in the PWA against the ~19 degree oblique `apps/pwa/public/FLAIR.nii.gz`, reading live render state off the `nv` instance:

| | default (voxel) | after `W` (world) |
|---|---|---|
| live affine row 0 | `[1, 0, 0, -56.16]` | `[0.994, 0.016, 0.112, -64.90]` |
| `obliqueRAS` max off-diagonal | `0` | `0.309` |
| `frac2mm === frac2mmOrtho` | yes | no |

Adding `aal.nii.gz` (a different, axis-aligned grid) as an overlay while voxel space was active: both volumes ended up with the same world-to-display map to within 2e-14, so registration is preserved, and both returned to their exact file affines on toggling back. No console errors.

## Reviewer notes

- **Known limitations, both also present in 0.x's voxel-space mode** and documented in the module header: meshes are not moved onto the voxel grid with the volumes, and the mm readout becomes voxel-grid mm rather than scanner mm.
- Because the workaround rewrites `hdr.affine`, the modified affine is visible in the header dialog and would be persisted in a `.nvd` saved while voxel space is active. The real fix is upstream; I plan to open an issue on the niivue core repo asking for a first-class slice-space option (the ortho matrices are already computed there, so it looks cheap), after which this module can be deleted.
- The top bar's overflow split could not be exercised in the browser preview: `ResizeObserver` never fires there at all. The measurement inputs were verified instead (9 proxies with sane widths, including the new `Select` proxy), and the unit test covers the rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
