### PR TITLE
refactor(react): drop GL refreshes that niivue v1 already performs

### DIFF
--- a/.changeset/gl-refresh-cleanup.md
+++ b/.changeset/gl-refresh-cleanup.md
@@ -1,0 +1,19 @@
+---
+'@niivue/react': patch
+'@niivue/pwa': patch
+'niivue': patch
+'@niivue/streamlit': patch
+'@niivue/jupyter': patch
+'@niivue/tauri': patch
+---
+
+Drop redundant GL refreshes after overlay and colorbar changes.
+
+niivue v1's `setVolume` and `setMeshLayerProperty` assign the properties and refresh the GL
+volume themselves, so the trailing `updateGLVolume()` calls in ScalingBox were redundant; the
+mesh branch was refreshing twice outright. `addMeshLayer` likewise refreshes internally, so
+setting the colorbar flag before the call removes another refresh. The view-mode toggles in
+the menu now use `drawScene()`, which redraws without a full volume refresh.
+
+Each removed call is one fewer `updateBindGroups` pass, the path implicated in the WebGPU
+resize race (niivue/mono#61).

--- a/packages/niivue-react/src/components/Menu.tsx
+++ b/packages/niivue-react/src/components/Menu.tsx
@@ -209,7 +209,9 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
     nvArraySelected.value.forEach((nv) => {
       // v1: "Multiplanar + Render" shows the planes without the 4D graph.
       nv.isGraphVisible = false
-      nv.updateGLVolume()
+      // Display-only toggle: drawScene() redraws without updateGLVolume's
+      // updateBindGroups pass (the WebGPU resize-race crash path, niivue/mono#61).
+      nv.drawScene()
     })
   }
 
@@ -224,7 +226,9 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
       nv.isGraphVisible = true
       nv.graphNormalizeValues = false
       nv.graphLineAlpha = 1.0
-      nv.updateGLVolume()
+      // Display-only toggle: drawScene() redraws without updateGLVolume's
+      // updateBindGroups pass (the WebGPU resize-race crash path, niivue/mono#61).
+      nv.drawScene()
     })
   }
 

--- a/packages/niivue-react/src/components/Menu.tsx
+++ b/packages/niivue-react/src/components/Menu.tsx
@@ -209,8 +209,6 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
     nvArraySelected.value.forEach((nv) => {
       // v1: "Multiplanar + Render" shows the planes without the 4D graph.
       nv.isGraphVisible = false
-      // Display-only toggle: drawScene() redraws without updateGLVolume's
-      // updateBindGroups pass (the WebGPU resize-race crash path, niivue/mono#61).
       nv.drawScene()
     })
   }
@@ -226,8 +224,6 @@ export const Menu = (props: AppProps & { appInfo?: AppInfo }) => {
       nv.isGraphVisible = true
       nv.graphNormalizeValues = false
       nv.graphLineAlpha = 1.0
-      // Display-only toggle: drawScene() redraws without updateGLVolume's
-      // updateBindGroups pass (the WebGPU resize-race crash path, niivue/mono#61).
       nv.drawScene()
     })
   }

--- a/packages/niivue-react/src/components/ScalingBox.tsx
+++ b/packages/niivue-react/src/components/ScalingBox.tsx
@@ -165,11 +165,9 @@ function isVolumeOverlay(nv: ExtendedNiivue) {
   return nv.volumes.length > 0
 }
 
-// v1: setVolume / setMeshLayerProperty refresh the GL volume themselves, so the
-// trailing updateGLVolume() is gone (one fewer updateBindGroups pass, niivue/mono#61).
-// isColormapInverted is not a VolumeUpdate field, so that branch still mutates directly.
 function handleOverlayInvert(nv: ExtendedNiivue, layerNumber: number, invert: boolean) {
   if (isVolumeOverlay(nv)) {
+    // isColormapInverted is not a VolumeUpdate field, so it needs a manual refresh.
     const overlay = nv.volumes[layerNumber]
     if (overlay) {
       overlay.isColormapInverted = invert

--- a/packages/niivue-react/src/components/ScalingBox.tsx
+++ b/packages/niivue-react/src/components/ScalingBox.tsx
@@ -165,30 +165,27 @@ function isVolumeOverlay(nv: ExtendedNiivue) {
   return nv.volumes.length > 0
 }
 
+// v1: setVolume / setMeshLayerProperty refresh the GL volume themselves, so the
+// trailing updateGLVolume() is gone (one fewer updateBindGroups pass, niivue/mono#61).
+// isColormapInverted is not a VolumeUpdate field, so that branch still mutates directly.
 function handleOverlayInvert(nv: ExtendedNiivue, layerNumber: number, invert: boolean) {
   if (isVolumeOverlay(nv)) {
     const overlay = nv.volumes[layerNumber]
     if (overlay) {
       overlay.isColormapInverted = invert
     }
+    nv.updateGLVolume()
   } else {
-    // v1: setMeshLayerProperty(meshIndex, layerIndex, { camelCaseKey }); meshIndex 0.
     nv.setMeshLayerProperty(0, layerNumber, { isColormapInverted: invert })
   }
-  nv.updateGLVolume()
 }
 
 function handleOverlayScaling(nv: ExtendedNiivue, layerNumber: number, scaling: ScalingOpts) {
   if (isVolumeOverlay(nv)) {
-    const overlay = nv.volumes[layerNumber]
-    if (overlay) {
-      overlay.calMin = scaling.min
-      overlay.calMax = scaling.max
-    }
+    nv.setVolume(layerNumber, { calMin: scaling.min, calMax: scaling.max })
   } else {
     nv.setMeshLayerProperty(0, layerNumber, { calMin: scaling.min, calMax: scaling.max })
   }
-  nv.updateGLVolume()
 }
 
 function handleOpacity(nv: ExtendedNiivue, layerNumber: number, opacity: number) {
@@ -199,7 +196,6 @@ function handleOpacity(nv: ExtendedNiivue, layerNumber: number, opacity: number)
   } else {
     nv.setMeshLayerProperty(0, layerNumber, { opacity })
   }
-  nv.updateGLVolume()
 }
 
 function handleOverlayColormap(nv: ExtendedNiivue, layerNumber: number, colormap: string) {
@@ -208,21 +204,17 @@ function handleOverlayColormap(nv: ExtendedNiivue, layerNumber: number, colormap
   } else {
     setMeshColormap(nv, layerNumber, colormap)
   }
-  nv.updateGLVolume()
 }
 
 function setVolumeColormap(nv: ExtendedNiivue, layerNumber: number, colormap: string) {
-  const overlay = nv.volumes?.[layerNumber]
-  if (!overlay) {
+  if (!nv.volumes?.[layerNumber]) {
     return
   }
-  if (colormap === 'symmetric') {
-    overlay.colormap = 'warm'
-    overlay.colormapNegative = 'winter'
-  } else {
-    overlay.colormap = colormap
-    overlay.colormapNegative = ''
-  }
+  const props =
+    colormap === 'symmetric'
+      ? { colormap: 'warm', colormapNegative: 'winter' }
+      : { colormap, colormapNegative: '' }
+  nv.setVolume(layerNumber, props)
 }
 
 function setMeshColormap(nv: ExtendedNiivue, layerNumber: number, colormap: string) {

--- a/packages/niivue-react/src/events.ts
+++ b/packages/niivue-react/src/events.ts
@@ -224,9 +224,7 @@ async function addMeshOverlay(nv: NiiVue, item: any, type: string, settings: Nii
   // addMeshLayer parses the buffer, appends the layer, and updates the mesh
   // internally, so the manual readLayer/push/updateMesh dance is gone. The old
   // `useNegativeCmap` flag is expressed by a non-empty `colormapNegative`.
-  // Set the colorbar flag before addMeshLayer so its own GL refresh already
-  // reflects it, dropping a second updateGLVolume() (one fewer updateBindGroups
-  // pass, the WebGPU resize-race path, niivue/mono#61).
+  // Set before addMeshLayer so its internal refresh picks up the flag.
   nv.isColorbarVisible = true
   await nv.addMeshLayer(0, {
     url: new File([item.data], item.uri),

--- a/packages/niivue-react/src/events.ts
+++ b/packages/niivue-react/src/events.ts
@@ -224,6 +224,10 @@ async function addMeshOverlay(nv: NiiVue, item: any, type: string, settings: Nii
   // addMeshLayer parses the buffer, appends the layer, and updates the mesh
   // internally, so the manual readLayer/push/updateMesh dance is gone. The old
   // `useNegativeCmap` flag is expressed by a non-empty `colormapNegative`.
+  // Set the colorbar flag before addMeshLayer so its own GL refresh already
+  // reflects it, dropping a second updateGLVolume() (one fewer updateBindGroups
+  // pass, the WebGPU resize-race path, niivue/mono#61).
+  nv.isColorbarVisible = true
   await nv.addMeshLayer(0, {
     url: new File([item.data], item.uri),
     name: item.uri,
@@ -234,8 +238,6 @@ async function addMeshOverlay(nv: NiiVue, item: any, type: string, settings: Nii
     calMax: a.calMax,
   })
 
-  nv.isColorbarVisible = true
-  await nv.updateGLVolume()
   const layerNumber = nv.meshes[0].layers.length - 1
   if (type === 'addMeshCurvature') {
     await nv.setMeshLayerProperty(0, layerNumber, { isColorbarVisible: false })


### PR DESCRIPTION
Split out of #272, which had bundled it with the WebGPU backend probe. Unrelated change, so it gets its own PR.

## What

niivue v1's `setVolume` and `setMeshLayerProperty` assign the properties **and** refresh the GL volume themselves, so the trailing `updateGLVolume()` calls were redundant:

- `ScalingBox`: the mesh branch was refreshing twice outright (`setMeshLayerProperty` had already refreshed). The volume branch now goes through `setVolume` instead of mutating fields and refreshing by hand.
- `events.ts`: `addMeshLayer` refreshes internally, so the colorbar flag is set before the call rather than followed by another refresh.
- `Menu`: the two view-mode toggles are display-only, so they use `drawScene()`, which redraws without a full volume refresh.

Each removed call is one fewer `updateBindGroups` pass, the path implicated in the WebGPU resize race (niivue/mono#61).

`isColormapInverted` is not a `VolumeUpdate` field, so that one branch still mutates directly and refreshes itself.

## Verification

`@niivue/react` green on current main: 18 test files, build + type-check + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)