### PR TITLE
test: CI control run against current main (do not merge)

### DIFF
--- a/packages/niivue-react/src/utility.ts
+++ b/packages/niivue-react/src/utility.ts
@@ -1,3 +1,4 @@
+// CI control: no-op change to trigger the full pipeline against current main.
 import NiiVue from '@niivue/niivue'
 import type { NVImage } from '@niivue/niivue'
 import { isNiftiName, NIFTI_PEEK_BYTES, niftiTooLargeWarning } from './nifti'


### PR DESCRIPTION
**Draft, do not merge. Delete once the answer is in.**

Control experiment. Two independent PRs based on current main (#272, #273) both fail the same e2e test, `keyboard-shortcuts.spec.ts:42 "clip plane advances exactly once per c press (#224)"`, with `Received: 2`.

Meanwhile:
- CI has not run on a push to `main` since 2026-06-23.
- #259 and #267 were both merged with CI results dated 2026-06-22 and 2026-07-30 respectively, against a different main.

So it is unclear whether these PRs introduce the failure or simply inherit it. This PR changes one comment line and nothing else, so whatever CI reports here is the state of `main` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)