### PR TITLE
fix(keyboard): remove niivue's built-in window hotkeys after attach (#224)

### DIFF
--- a/.changeset/fix-builtin-hotkey-double-apply.md
+++ b/.changeset/fix-builtin-hotkey-double-apply.md
@@ -1,0 +1,20 @@
+---
+'@niivue/react': patch
+'@niivue/pwa': patch
+'niivue': patch
+'@niivue/streamlit': patch
+'@niivue/jupyter': patch
+'@niivue/tauri': patch
+---
+
+Stop keyboard shortcuts being applied twice (#224).
+
+niivue v1 still ships built-in hotkeys and binds them to `window` during
+`attachToCanvas`, so `c` advanced the clip plane once via niivue and once more via
+the app's own shortcut hook. The app broadcasts to every selected canvas and is the
+intended single source of truth, so niivue's listener is now removed once attach has
+installed it.
+
+This affects anyone with a working GPU. It was not caught earlier because the e2e
+suite runs on headless CI where `attachToCanvas` always rejects, so niivue's listener
+was never registered there.

--- a/packages/niivue-react/src/components/NiiVueCanvas.tsx
+++ b/packages/niivue-react/src/components/NiiVueCanvas.tsx
@@ -27,7 +27,7 @@ import { dicomLoader } from '@niivue/dicom-loader'
 import { mnc2nii } from '@niivue/minc-loader'
 import { Signal } from '@preact/signals'
 import { useEffect, useRef } from 'preact/hooks'
-import { ExtendedNiivue, notifyImageLoaded } from '../events'
+import { ExtendedNiivue, notifyImageLoaded, removeBuiltinKeyHandler } from '../events'
 import { isNiftiName, NIFTI_PEEK_BYTES, niftiTooLargeWarning } from '../nifti'
 import { convertNpy, convertNpz, isNpyName } from '../npy'
 import { NiiVueSettings } from '../settings'
@@ -65,6 +65,7 @@ export const NiiVueCanvas = ({
     nv.attached = nv
       .attachToCanvas(canvasRef.current)
       .then(() => {
+        removeBuiltinKeyHandler(nv)
         nv.addEventListener('frameChange', (e) => nv.onFrameUpdate(e.detail.frame))
       })
       .catch((error) => {

--- a/packages/niivue-react/src/events.ts
+++ b/packages/niivue-react/src/events.ts
@@ -12,6 +12,24 @@ import { buildImageMessageBodies, isImageType } from './utility'
  * overlay message handlers (overlay / addMeshOverlay paths) call this so that
  * `waitForImageLoad` in tests works for all load types.
  */
+/**
+ * Detach niivue's own window keydown listener.
+ *
+ * v1 still ships built-in hotkeys (`NVControlBase`'s handler binds to *window*,
+ * not the canvas) and 'c' there advances `currentClipPlaneIndex` on the focused
+ * instance. The app's useKeyboardShortcuts hook already advances it for every
+ * selected canvas, so leaving both bound makes one press count twice - the
+ * regression in niivue/niivue-vscode#224. The app is the single source of truth
+ * for shortcuts, so niivue's listener comes off once attach has installed it.
+ */
+export function removeBuiltinKeyHandler(nv: NiiVue): void {
+  const handler = (nv as unknown as { _eventListeners?: { keydown?: EventListener } })
+    ._eventListeners?.keydown
+  if (handler) {
+    window.removeEventListener('keydown', handler)
+  }
+}
+
 export function notifyImageLoaded() {
   const w = window as any
   w.__niivue = w.__niivue || {}
@@ -466,10 +484,9 @@ function growNvArrayBy(nvArray: Signal<NiiVue[]>, n: number) {
       isDragDropEnabled: false, // handled by app (Volume component)
       // 'c' (cycle clip plane) and 'v' (cycle view mode) are handled by the
       // app's useKeyboardShortcuts hook, which broadcasts to every selected
-      // canvas. v1.0 removed the built-in clip-plane / view-mode hotkey options
-      // (no built-in hotkeys remain), so niivue no longer double-acts on the
-      // focused canvas - the app is the single source of truth. See
-      // niivue/niivue-vscode#224.
+      // canvas. v1.0 still binds its own hotkeys to window during attach, so
+      // removeBuiltinKeyHandler takes that listener off once attached, leaving
+      // the app as the single source of truth. See niivue/niivue-vscode#224.
     })
     nv.key = Math.random()
     nvArray.value = [...nvArray.value, nv]


### PR DESCRIPTION
Fixes #224 properly, and unblocks #272.

## The bug

niivue v1 **still ships built-in hotkeys**. `NVControlBase` binds a keydown handler to `window` (not the canvas) during `attachToCanvas`, and its `C` branch does:

```js
t.currentClipPlaneIndex++, t.currentClipPlaneIndex > 6 && (t.currentClipPlaneIndex = 0)
```

The app's `useKeyboardShortcuts` hook advances the same value for every selected canvas. Both are bound to `window`, so one `c` press counts twice.

The comment in `events.ts` asserting that "v1.0 removed the built-in clip-plane / view-mode hotkey options (no built-in hotkeys remain)" is incorrect. The handler is present in both `1.0.0-rc.9` and `1.0.0-rc.12`. That comment is corrected here.

## Why CI never caught it

`keyboard-shortcuts.spec.ts:42` exists precisely to assert one press equals one step. It passes on CI for the wrong reason: headless CI has no GPU adapter, so `attachToCanvas` always rejects there (see the comment in `NiiVueCanvasAttachGate.test.tsx`, added by #267), niivue's listener is never registered, and only the app's handler runs.

On any machine with a working GPU, attach succeeds, both handlers register, and the shortcut double-applies. **This is live on main for real users.**

## Verification

Ran `keyboard-shortcuts.spec.ts` locally on a machine with working WebGPU:

- on `main`: **fails**, `Expected: 1, Received: 2`
- on this branch: **passes**

`@niivue/react` unit suite green: 18 files, build + type-check + lint pass.

## Relationship to #272

#272 (WebGL2 fallback) makes `attachToCanvas` succeed on CI where it previously always failed, which unmasks this bug and turns its e2e red. That PR is blocked on this one; it is not the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)