### PR TITLE
chore(deps): update NiiVue core to 1.0.0-rc.12

### DIFF
--- a/.changeset/niivue-rc12.md
+++ b/.changeset/niivue-rc12.md
@@ -11,7 +11,3 @@ Update the NiiVue core from `@niivue/niivue@1.0.0-rc.9` to `1.0.0-rc.12`.
 
 Picks up the upstream fix for the WebGPU race condition (niivue/mono#61, closed
 2026-08-03; rc.12 published 2026-08-10). No API changes were required on our side.
-
-Note that rc.12 still rejects numpy's default 64-bit integer dtypes with
-`Unsupported NPY dtype: <i8` / `<u8`, for `.npy` and `.npz` alike, so the
-downcasting loader shim remains necessary.

--- a/.changeset/niivue-rc12.md
+++ b/.changeset/niivue-rc12.md
@@ -10,4 +10,11 @@
 Update the NiiVue core from `@niivue/niivue@1.0.0-rc.9` to `1.0.0-rc.12`.
 
 Picks up the upstream fix for the WebGPU race condition (niivue/mono#61, closed
-2026-08-03; rc.12 published 2026-08-10). No API changes were required on our side.
+2026-08-03; rc.12 published 2026-08-10).
+
+The numpy int64/uint64 support added in #90 is now applied by converting the buffer
+before handing it to NiiVue, rather than by registering a converter through
+`nv.useLoader`. As of rc.12 a registered `.npy` converter is not reached before the
+built-in reader throws `Unsupported NPY dtype: <i8`, so the registration silently
+stopped taking effect. Converting up front is independent of how NiiVue resolves its
+readers, and the output is still a `.npy` that NiiVue's own reader parses.

--- a/.changeset/niivue-rc12.md
+++ b/.changeset/niivue-rc12.md
@@ -1,0 +1,17 @@
+---
+'@niivue/react': patch
+'@niivue/pwa': patch
+'niivue': patch
+'@niivue/streamlit': patch
+'@niivue/jupyter': patch
+'@niivue/tauri': patch
+---
+
+Update the NiiVue core from `@niivue/niivue@1.0.0-rc.9` to `1.0.0-rc.12`.
+
+Picks up the upstream fix for the WebGPU race condition (niivue/mono#61, closed
+2026-08-03; rc.12 published 2026-08-10). No API changes were required on our side.
+
+Note that rc.12 still rejects numpy's default 64-bit integer dtypes with
+`Unsupported NPY dtype: <i8` / `<u8`, for `.npy` and `.npz` alike, so the
+downcasting loader shim remains necessary.

--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@niivue/dicom-loader": "^1.0.0",
-    "@niivue/niivue": "1.0.0-rc.9",
+    "@niivue/niivue": "1.0.0-rc.12",
     "@niivue/react": "workspace:*",
     "@preact/signals": "^2.9.0",
     "@tauri-apps/api": "^2.11.0",

--- a/apps/jupyter/package.json
+++ b/apps/jupyter/package.json
@@ -73,7 +73,7 @@
     "@jupyterlab/services": "^7.5.7",
     "@jupyterlab/translation": "^4.5.7",
     "@lumino/widgets": "^2.7.5",
-    "@niivue/niivue": "1.0.0-rc.9"
+    "@niivue/niivue": "1.0.0-rc.12"
   },
   "devDependencies": {
     "@jupyterlab/builder": "^4.5.7",

--- a/apps/pwa/package.json
+++ b/apps/pwa/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@niivue/dicom-loader": "^1.0.0",
-    "@niivue/niivue": "1.0.0-rc.9",
+    "@niivue/niivue": "1.0.0-rc.12",
     "@niivue/react": "workspace:*",
     "@preact/signals": "^2.9.0",
     "preact": "^10.29.2",

--- a/apps/streamlit/niivue_component/frontend/package.json
+++ b/apps/streamlit/niivue_component/frontend/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@niivue/dicom-loader": "^1.0.0",
-    "@niivue/niivue": "1.0.0-rc.9",
+    "@niivue/niivue": "1.0.0-rc.12",
     "@niivue/react": "workspace:*",
     "@preact/signals": "^2.9.0",
     "preact": "^10.29.2",

--- a/packages/niivue-react/package.json
+++ b/packages/niivue-react/package.json
@@ -94,7 +94,7 @@
   },
   "peerDependencies": {
     "@niivue/dicom-loader": "^1.0.0",
-    "@niivue/niivue": "1.0.0-rc.9",
+    "@niivue/niivue": "1.0.0-rc.12",
     "@preact/signals": "^2.9.0",
     "preact": "^10.29.2"
   }

--- a/packages/niivue-react/src/components/NiiVueCanvas.tsx
+++ b/packages/niivue-react/src/components/NiiVueCanvas.tsx
@@ -351,15 +351,23 @@ async function loadVolume(nv: ExtendedNiivue, item: any, settings: NiiVueSetting
       }
     }
   }
-  // NumPy .npy/.npz: register converters that down-cast element types NiiVue's
-  // reader cannot handle (notably int64/uint64, numpy's default integer types)
-  // so the volume displays instead of erroring or rendering black. See #90.
-  // Registered once per instance: the npy converter shares its from/to extension,
-  // so re-registering would nest it around the previous reader on every load.
-  if (isNpyName(item.uri) && !nv.npyLoadersRegistered) {
-    nv.useLoader(convertNpy, 'npy', 'npy')
-    nv.useLoader(convertNpz, 'npz', 'npy')
-    nv.npyLoadersRegistered = true
+  // NumPy .npy/.npz: down-cast element types NiiVue's reader cannot handle
+  // (notably int64/uint64, numpy's default integer types) so the volume displays
+  // instead of erroring. See #90.
+  //
+  // Converted here rather than through nv.useLoader: as of 1.0.0-rc.12 a
+  // registered npy converter is not reached before the built-in reader throws
+  // "Unsupported NPY dtype: <i8". Converting the bytes up front keeps this
+  // working whichever way niivue resolves its readers. The output is still a
+  // .npy, so niivue's own reader parses it.
+  if (isNpyName(item.uri)) {
+    if (!item.data) {
+      item.data = await (await fetch(item.uri)).arrayBuffer()
+    }
+    const bytes = ensureArrayBuffer(item.data)
+    item.data = item.uri.toLowerCase().endsWith('.npz')
+      ? await convertNpz(bytes)
+      : convertNpy(bytes)
   }
   const isMincFile = (uri: string) => {
     const lowerUri = uri.toLowerCase()

--- a/packages/niivue-react/src/events.ts
+++ b/packages/niivue-react/src/events.ts
@@ -462,7 +462,6 @@ export class ExtendedNiivue extends NiiVue {
   key = NaN
   body = null
   documentData: File | null = null // pending .nvd import (CBOR bytes wrapped in a File), consumed by NiiVueCanvas
-  npyLoadersRegistered = false // guards one-time nv.useLoader registration for .npy/.npz (see NiiVueCanvas)
   onVolumeUpdated = () => { }
   onFrameUpdate = (frame: number) => { }
   // v1: cross-canvas pan/3D sync is handled natively by `nv.broadcastTo(targets)`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       '@niivue/niivue':
-        specifier: 1.0.0-rc.9
-        version: 1.0.0-rc.9
+        specifier: 1.0.0-rc.12
+        version: 1.0.0-rc.12
       '@niivue/react':
         specifier: workspace:*
         version: link:../../packages/niivue-react
@@ -195,8 +195,8 @@ importers:
         specifier: ^2.7.5
         version: 2.7.5
       '@niivue/niivue':
-        specifier: 1.0.0-rc.9
-        version: 1.0.0-rc.9
+        specifier: 1.0.0-rc.12
+        version: 1.0.0-rc.12
     devDependencies:
       '@jupyterlab/builder':
         specifier: ^4.5.7
@@ -274,8 +274,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       '@niivue/niivue':
-        specifier: 1.0.0-rc.9
-        version: 1.0.0-rc.9
+        specifier: 1.0.0-rc.12
+        version: 1.0.0-rc.12
       '@niivue/react':
         specifier: workspace:*
         version: link:../../packages/niivue-react
@@ -391,8 +391,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       '@niivue/niivue':
-        specifier: 1.0.0-rc.9
-        version: 1.0.0-rc.9
+        specifier: 1.0.0-rc.12
+        version: 1.0.0-rc.12
       '@niivue/react':
         specifier: workspace:*
         version: link:../../../../packages/niivue-react
@@ -521,8 +521,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       '@niivue/niivue':
-        specifier: 1.0.0-rc.9
-        version: 1.0.0-rc.9
+        specifier: 1.0.0-rc.12
+        version: 1.0.0-rc.12
       '@niivue/viewer-protocol':
         specifier: workspace:*
         version: link:../viewer-protocol
@@ -2696,8 +2696,8 @@ packages:
   '@niivue/minc-loader@1.0.0':
     resolution: {integrity: sha512-wcrFHr+7F5aGg7cdxFoOYolJH6EHlW5xZNkh0+lAkDPnOneLAWlS8+RzPw383jcqIx5+xf+dgK4TVgU/OZ8KUQ==}
 
-  '@niivue/niivue@1.0.0-rc.9':
-    resolution: {integrity: sha512-CPu6+KTONESagpbYn+BF/TWy27twmPgqpLNam9x24tl9XDWKfJTLhkjqBZSCVOyWqu1eYMdJFt/nQeDbTGdWvA==}
+  '@niivue/niivue@1.0.0-rc.12':
+    resolution: {integrity: sha512-jLjepjnPPGRWdiZiQtYOZE0saLARRfPqfEQtbInYX7LGrQGcCpljtcetIIEi6oAT0Cv22upo7JTOlkNJyuOBow==}
 
   '@node-rs/crc32-android-arm-eabi@1.10.6':
     resolution: {integrity: sha512-vZAMuJXm3TpWPOkkhxdrofWDv+Q+I2oO7ucLRbXyAPmXFNDhHtBxbO1rk9Qzz+M3eep8ieS4/+jCL1Q0zacNMQ==}
@@ -11512,7 +11512,7 @@ snapshots:
     dependencies:
       nifti-reader-js: 0.7.1
 
-  '@niivue/niivue@1.0.0-rc.9':
+  '@niivue/niivue@1.0.0-rc.12':
     dependencies:
       cbor-x: 1.6.4
       clipper2-ts: 2.0.1-17
@@ -17390,7 +17390,7 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.22.0
+      enhanced-resolve: 5.18.3
       es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -17401,7 +17401,7 @@ snapshots:
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.3
+      tapable: 2.3.0
       terser-webpack-plugin: 5.3.14(esbuild@0.28.0)(webpack@5.102.1(esbuild@0.28.0))
       watchpack: 2.4.4
       webpack-sources: 3.3.3


### PR DESCRIPTION
Bumps `@niivue/niivue` from `1.0.0-rc.9` to `1.0.0-rc.12` across niivue-react, pwa, jupyter, streamlit and tauri.

rc.12 was published 2026-08-10, after the upstream WebGPU race condition (niivue/mono#61) was closed on 2026-08-03, so it carries that fix.

## The one thing that needed changing: numpy int64

The `useLoader` shim added in #259 stops working on rc.12. It is **not** a missing API (`useLoader` is still exported with an identical signature) and the registration does run. Verified in the browser: `npyLoadersRegistered` was `true`, yet the registered converter was never invoked and niivue's built-in reader still threw `Unsupported NPY dtype: <i8`. As of rc.12 the load path does not reach a registered `.npy` converter before the built-in reader runs.

Rather than fight the reader-resolution order, this converts the buffer **before** handing it to NiiVue. `convertNpy` / `convertNpz` from #259 are unchanged; only the call site moves. The output is still a valid `.npy`, so niivue's own reader parses it, and the behaviour is identical on rc.9 and rc.12.

Where a host supplies a URL rather than a buffer (the vscode webview does this for known extensions, see `editorProvider.ts:345`), the bytes are fetched first. That matches what the DICOM extensionless sniff a few lines below already does.

`ExtendedNiivue.npyLoadersRegistered` is dropped; it only existed to make the one-time `useLoader` registration idempotent.

## Verification

In the PWA on rc.12, all fixtures generated with numpy's default integer dtype:

| Fixture | Before | After |
| --- | --- | --- |
| `int64 .npy` | `Unsupported NPY dtype: <i8` | Loads, `matrix size: 16 x 32 x 32` |
| `uint64 .npy` | `Unsupported NPY dtype: <u8` | Loads |
| `int64 .npz` | `Unsupported NPY dtype: <i8` | Loads |
| `int32 .npy` (control) | Loads | Loads |

Three-canvas run: `loadedCount: 3`, every instance `isLoaded: true` with 1 volume and no `loadError`.

Also on rc.12: all 31 unit test files across 6 packages pass, 16/16 type-check and lint tasks, and volume / 4D / mesh render correctly on real WebGPU.

## Worth doing upstream too

niivue's NPY reader declares its supported dtypes as a fixed table (`b1, i1, u1, i2, u2, i4, u4, f4, f8`) and throws on anything else. numpy's **default** integer dtype on Linux and macOS is `int64`, so `np.save(x)` without an explicit dtype produces a file niivue cannot open. Teaching the core reader to down-cast `i8`/`u8` the way this shim does would fix it for every niivue consumer and let this workaround be deleted. Happy to open that upstream if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
