### PR TITLE
fix(build): give app-target bundles their own output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ build_log.json
 # Generated directories
 lib/
 dist/
+dist-vscode/
+dist-jupyter/
 static/
 build/
 apps/vscode/niivue/

--- a/apps/jupyter/build-assets.mjs
+++ b/apps/jupyter/build-assets.mjs
@@ -6,11 +6,11 @@ const rootDir = path.resolve(process.cwd(), '..', '..')
 const reactPkgDir = path.resolve(rootDir, 'packages', 'niivue-react')
 const jupyterStaticDir = path.resolve(process.cwd(), 'static', 'niivue')
 
-// 1. Build niivue-react with BUILD_TARGET=vscode
-console.log('Building @niivue/react with BUILD_TARGET=vscode...')
+// 1. Build niivue-react with BUILD_TARGET=jupyter
+console.log('Building @niivue/react with BUILD_TARGET=jupyter...')
 execSync('pnpm build', {
   cwd: reactPkgDir,
-  env: { ...process.env, BUILD_TARGET: 'vscode' },
+  env: { ...process.env, BUILD_TARGET: 'jupyter' },
   stdio: 'inherit',
 })
 
@@ -20,7 +20,7 @@ fs.rmSync(jupyterStaticDir, { recursive: true, force: true })
 fs.mkdirSync(jupyterStaticDir, { recursive: true })
 
 // 3. Copy files from dist excluding PWA artifacts (build/, *.html, manifest.webmanifest, registerSW.js, sw.js, workbox-*.js)
-const srcDistDir = path.resolve(reactPkgDir, 'dist')
+const srcDistDir = path.resolve(reactPkgDir, 'dist-jupyter')
 console.log(`Copying built files from ${srcDistDir} to ${jupyterStaticDir}...`)
 
 const excludePatterns = [

--- a/apps/vscode/DEVELOPMENT.md
+++ b/apps/vscode/DEVELOPMENT.md
@@ -98,7 +98,9 @@ The React package is built specifically for VS Code:
 BUILD_TARGET=vscode pnpm --filter @niivue/react build
 ```
 
-This configures the React app for WebView embedding without PWA features.
+This configures the React app for WebView embedding without PWA features. It writes
+a standalone bundle to `packages/niivue-react/dist-vscode/`, leaving the library
+build in `dist/` untouched.
 
 ## Testing
 

--- a/apps/vscode/build-webview.mjs
+++ b/apps/vscode/build-webview.mjs
@@ -19,7 +19,7 @@ execSync('pnpm build', {
 })
 
 // 3. Copy dist files into the (re-created) niivue dir
-const srcDistDir = path.resolve(reactPkgDir, 'dist')
+const srcDistDir = path.resolve(reactPkgDir, 'dist-vscode')
 console.log(`Copying built files from ${srcDistDir} to ${vscodeNiivueDir}...`)
 fs.mkdirSync(vscodeNiivueDir, { recursive: true })
 fs.cpSync(srcDistDir, vscodeNiivueDir, { recursive: true })

--- a/packages/niivue-react/package.json
+++ b/packages/niivue-react/package.json
@@ -55,7 +55,7 @@
     "dev:types-only": "tsc --emitDeclarationOnly --declaration --outDir dist --watch",
     "build": "vite build && tsc --emitDeclarationOnly --declaration --outDir dist",
     "preview": "vite",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist dist-vscode dist-jupyter",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "type-check": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/niivue-react/scripts/watch-and-sync.mjs
+++ b/packages/niivue-react/scripts/watch-and-sync.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const sourceDir = join(__dirname, '../dist');
+const sourceDir = join(__dirname, '../dist-vscode');
 const targetDir = join(__dirname, '../../../apps/vscode/niivue');
 
 let lastModTime = 0;

--- a/packages/niivue-react/vite.config.ts
+++ b/packages/niivue-react/vite.config.ts
@@ -6,6 +6,13 @@ import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
 import virtual from 'vite-plugin-virtual'
 
+// Standalone app bundles for embedding hosts (VS Code webview, Jupyter widget).
+// Each gets its own outDir so it never overwrites the library build in dist/.
+const APP_TARGETS = ['vscode', 'jupyter']
+const appTarget = APP_TARGETS.includes(process.env.BUILD_TARGET ?? '')
+  ? process.env.BUILD_TARGET
+  : null
+
 export default defineConfig(({ mode }) => ({
   server: {
     host: '0.0.0.0', // Allow connections from any host
@@ -24,8 +31,8 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     preact(),
-    // Only generate .d.ts files in production builds (skip in development mode for speed)
-    ...(mode === 'development'
+    // Only generate .d.ts files for the library build (skip in development mode for speed)
+    ...(mode === 'development' || appTarget
       ? []
       : [
         dts({
@@ -76,6 +83,7 @@ export default defineConfig(({ mode }) => ({
     }),
   ],
   build: {
+    outDir: appTarget ? `dist-${appTarget}` : 'dist',
     // Only enable watch mode in development
     watch: mode === 'development' ? {
       // Rollup watch options with polling for dev containers
@@ -85,19 +93,17 @@ export default defineConfig(({ mode }) => ({
       },
     } : null,
     lib: {
-      entry:
-        process.env.BUILD_TARGET === 'vscode'
-          ? resolve(__dirname, 'src/main.tsx')
-          : resolve(__dirname, 'src/index.ts'),
+      entry: appTarget
+        ? resolve(__dirname, 'src/main.tsx')
+        : resolve(__dirname, 'src/index.ts'),
       name: 'NiivueReact',
       formats: ['es'],
       fileName: 'index',
     },
     rollupOptions: {
-      external:
-        process.env.BUILD_TARGET === 'vscode'
-          ? [] // Bundle all dependencies for VS Code
-          : ['preact', 'preact/hooks', '@niivue/niivue', '@niivue/dicom-loader', '@preact/signals'],
+      external: appTarget
+        ? [] // Bundle all dependencies into the standalone app
+        : ['preact', 'preact/hooks', '@niivue/niivue', '@niivue/dicom-loader', '@preact/signals'],
       output: {
         globals: {
           preact: 'preact',


### PR DESCRIPTION
## Problem

`pnpm build` deterministically corrupted `packages/niivue-react/dist`.

`apps/vscode/build-webview.mjs` and `apps/jupyter/build-assets.mjs` both rebuild `@niivue/react` with `BUILD_TARGET=vscode`, which swaps the lib entry from `src/index.ts` to `src/main.tsx`. Both wrote into the same `dist/` with `fileName: 'index'`, and they run after the library build in the turbo graph, so the app bundle always won:

| `packages/niivue-react/dist` | after `pnpm --filter @niivue/react build` | after a full `pnpm build` |
| --- | --- | --- |
| `index.d.ts` | 1115 B, 21 exports | 10 B (`export {}`) |
| `index.js` | 957874 B (library, externals kept) | 2244211 B (app bundle, all deps inlined) |

Consumers that resolve types through the package's `types` field then failed `pnpm type-check` with `Module '"@niivue/react"' has no exported member 'Container'` or `Cannot find module '@niivue/react'`. Which app failed varied by run: `@niivue/pwa`, `@niivue/tauri` and `@niivue/streamlit` all lack a `paths` mapping, so `tsc --noEmit` follows the workspace symlink to the stub. `apps/streamlit/niivue_component/frontend/vitest.config.ts` aliases `@niivue/react` straight at `dist/index.js`, so those tests ran against whichever bundle won the race.

Severity was limited: `@niivue/react` is `"private": true` and never published, so no external consumer was affected. It was a local-dev and type-check hazard.

## Why nothing repaired it

The package's build script is `vite build && tsc --emitDeclarationOnly --declaration --outDir dist`, but the tsc half emits nothing at all. `tsconfig.base.json` sets `"noEmit": true`, which silently suppresses the emit: exit 0, and `--listEmittedFiles` prints zero files. Every `.d.ts` under `dist/` comes from the vite `dts` plugin's `insertTypesEntry`, so when the entry became `src/main.tsx` the stub was final.

## Change

Each build target now writes its own output directory:

| `BUILD_TARGET` | entry | outDir |
| --- | --- | --- |
| unset (library) | `src/index.ts` | `dist` |
| `vscode` | `src/main.tsx` | `dist-vscode` |
| `jupyter` | `src/main.tsx` | `dist-jupyter` |

`apps/jupyter` now passes `BUILD_TARGET=jupyter` instead of reusing `vscode`. Previously both callers shared one directory, so under turbo's parallel app builds they could also clobber each other mid-copy; separate directories close that too. Declaration emit is skipped for app targets, since an app entry has no library types to emit.

The build callers, the `dev:vscode-sync` watcher, the package `clean` script, `.gitignore` and the `BUILD_TARGET` section of `apps/vscode/DEVELOPMENT.md` follow the new layout.

## Verification

From a deleted `dist`, `turbo run build --force` (8/8 tasks, 0 cached, so both app-target builds genuinely ran) leaves `dist/index.d.ts` at 1115 B with all 21 export lines and `dist/index.js` at 957874 B.

- `turbo run type-check --force`: 8/8, 0 cached
- `pnpm test`: 15/15
- `turbo run lint --force`: 10/10

Forcing matters here. A cached `type-check` reports success without re-running, which masks the failure.

## Notes for the reviewer

- `apps/vscode/niivue/` still contains the `index.js` and `index.css` that `src/html.ts` loads. It no longer carries 55 stray `.d.ts` files, which `.vscodeignore` already excluded, so vsix contents are unchanged.
- Two adjacent issues found but deliberately left alone, both pre-existing:
  - `pnpm dev:types-only` and the tsc half of `pnpm build` are dead code for the same `noEmit` reason, so `pnpm dev:source` never refreshes declarations. Fixing it means deciding which tool owns declaration emit.
  - `apps/vscode/niivue/**` is not in turbo's `build` outputs, so a cache hit on the vscode build will not restore the webview assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
