### PR TITLE
ci: repin changesets/action to a ref that ships its bundle

### DIFF
--- a/.github/workflows/release-coordinator.yml
+++ b/.github/workflows/release-coordinator.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Create Version PR or Publish
         id: changesets
-        uses: changesets/action@ae5c373a18fe02dac7d40bcbc0184758c90d94d2 # v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm run version
           publish: pnpm run release


### PR DESCRIPTION
Fixes the Release Coordinator, which has failed on every push to `main` since 2026-06-23.

## Problem

```
##[error]File not found: '/home/runner/work/_actions/changesets/action/ae5c373a.../dist/index.js'
```

`changesets/action`'s `action.yml` declares `main: "dist/index.js"`. The pin introduced in #260 points at `ae5c373a`, which is the head of the action's `maintenance/v1` **source** branch, and that branch carries no `dist/` directory (the contents API returns 404 for it). The runner downloads the action, cannot find its entry point, and the step dies before a single line of release logic runs.

That is the whole failure. `Dispatch per-app release workflows` is skipped, no version PR is updated, nothing publishes.

Timeline lines up exactly: last successful coordinator run 2026-06-22T16:24, PR #167 last updated 2026-06-22T16:25, #260 merged 2026-06-23T10:02, first failure 2026-06-23T10:02. Consequence today: 24 changesets queued, and #167 is missing the 6 that merged after the break.

## Fix

Repin to `v1.9.0`, the newest release on the v1 line. Verified against the GitHub API before pinning:

- `dist/index.js` exists at that ref (179428 bytes), and `runs.main` still points at it
- the four inputs this workflow passes are all present: `version`, `publish`, `commit`, `title`
- `hasChangesets` is still an output, which the `Dispatch per-app release workflows` step gates on
- `a45c4d59` is the **commit** the annotated tag `v1.9.0` dereferences to, not the tag object's own SHA, so it matches how `actions/checkout` and the rest are pinned here

## Why not v2

v2 renamed every input: `version-script`, `publish-script`, `commit-message`, `pr-title`. Because unknown `with:` keys are only a warning, a straight bump would leave the action running its default `changeset version` instead of `pnpm run version` — silently skipping the vscode even-minor normalizer and the pyproject version sync. That is a far worse failure than the current loud one, so the v1 line is the right target until the inputs are migrated deliberately.

## After merging

The first push to `main` should refresh PR #167 with all 24 changesets. Review the regenerated changelogs there before merging it.

Note that publishing is still blocked separately: the nightly pre-release on 2026-08-19 built and packaged fine, then failed with `Access Denied: The Personal Access Token used has expired` on `secrets.VSCE_PAT`, which `release_vscode.yml` uses too. That token needs rotating independently of this PR.

Worth deciding separately: dependabot groups action bumps together (#271 bumped 9 at once) and will eventually propose `changesets/action` v2, which would reintroduce the silent-input problem. An ignore rule for the major version, or a review note on this workflow, would prevent that.

## Verification

Cannot be exercised without merging, since the workflow only runs on push to `main`. What was checked: the new ref serves the entry point and a compatible interface (above), and the edited workflow still parses as YAML with the step resolving to `uses: changesets/action@a45c4d59...` and `with:` keys `version, publish, commit, title`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
