### PR TITLE
ci(deps): cut Dependabot PR churn and gate bumps on real tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    rebase-strategy: 'disabled'
     commit-message:
       prefix: 'ci'
       include: 'scope'
@@ -37,6 +40,15 @@ updates:
       day: 'monday'
     open-pull-requests-limit: 3
     versioning-strategy: 'increase-if-necessary'
+    # Quarantine window against poisoned releases: a compromised version is
+    # usually yanked within hours, so waiting lets the registry clean up before
+    # we pull it in. Security updates ignore cooldown and still land at once.
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    # Dependabot otherwise rebases every open PR each time a sibling merges,
+    # and each rebase re-runs the full CI matrix. Stale PRs are cheaper.
+    rebase-strategy: 'disabled'
     commit-message:
       prefix: 'chore'
       prefix-development: 'chore'
@@ -154,6 +166,15 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 3
+    # Quarantine window against poisoned releases: a compromised version is
+    # usually yanked within hours, so waiting lets the registry clean up before
+    # we pull it in. Security updates ignore cooldown and still land at once.
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    # Dependabot otherwise rebases every open PR each time a sibling merges,
+    # and each rebase re-runs the full CI matrix. Stale PRs are cheaper.
+    rebase-strategy: 'disabled'
     commit-message:
       prefix: 'chore'
       include: 'scope'
@@ -172,6 +193,15 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 3
+    # Quarantine window against poisoned releases: a compromised version is
+    # usually yanked within hours, so waiting lets the registry clean up before
+    # we pull it in. Security updates ignore cooldown and still land at once.
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    # Dependabot otherwise rebases every open PR each time a sibling merges,
+    # and each rebase re-runs the full CI matrix. Stale PRs are cheaper.
+    rebase-strategy: 'disabled'
     commit-message:
       prefix: 'chore'
       include: 'scope'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,6 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
-    rebase-strategy: 'disabled'
     commit-message:
       prefix: 'ci'
       include: 'scope'
@@ -46,9 +45,6 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 30
-    # Dependabot otherwise rebases every open PR each time a sibling merges,
-    # and each rebase re-runs the full CI matrix. Stale PRs are cheaper.
-    rebase-strategy: 'disabled'
     commit-message:
       prefix: 'chore'
       prefix-development: 'chore'
@@ -172,9 +168,6 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 30
-    # Dependabot otherwise rebases every open PR each time a sibling merges,
-    # and each rebase re-runs the full CI matrix. Stale PRs are cheaper.
-    rebase-strategy: 'disabled'
     commit-message:
       prefix: 'chore'
       include: 'scope'
@@ -199,9 +192,6 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 30
-    # Dependabot otherwise rebases every open PR each time a sibling merges,
-    # and each rebase re-runs the full CI matrix. Stale PRs are cheaper.
-    rebase-strategy: 'disabled'
     commit-message:
       prefix: 'chore'
       include: 'scope'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 5
+    # Same quarantine rationale as npm below. Action tags are not SemVer, so
+    # only the flat window applies here.
     cooldown:
       default-days: 7
     commit-message:

--- a/.github/workflows/build_pwa_preview.yml
+++ b/.github/workflows/build_pwa_preview.yml
@@ -38,6 +38,10 @@ concurrency:
 
 jobs:
   build:
+    # Distinct check name: CI has a 'build' job too, and a required status
+    # check is matched by name alone. This workflow is path-filtered, so a
+    # shared name lets a run that never starts satisfy CI's required check.
+    name: preview-build
     # Fork PRs do NOT auto-build. The maintainer triggers the build manually
     # via workflow_dispatch after reviewing the diff. This saves CI minutes on
     # drive-by fork PRs and gives the maintainer an explicit consent point

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,24 +32,32 @@ jobs:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         id: filter
         with:
+          # pnpm-lock.yaml gates every app: a dependency bump touches only the
+          # lockfile, and without it here the whole test matrix is skipped.
           filters: |
             packages:
               - 'packages/**'
+              - 'pnpm-lock.yaml'
             pwa:
               - 'apps/pwa/**'
               - 'packages/**'
+              - 'pnpm-lock.yaml'
             jupyter:
               - 'apps/jupyter/**'
               - 'packages/**'
+              - 'pnpm-lock.yaml'
             vscode:
               - 'apps/vscode/**'
               - 'packages/**'
+              - 'pnpm-lock.yaml'
             streamlit:
               - 'apps/streamlit/**'
               - 'packages/**'
+              - 'pnpm-lock.yaml'
             desktop:
               - 'apps/desktop-tauri/**'
               - 'packages/**'
+              - 'pnpm-lock.yaml'
 
   lint-and-typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -1,0 +1,50 @@
+# Queues Dependabot PRs for auto-merge so routine bumps stop needing a click.
+#
+# Trust posture: TRUSTED.
+#   - Never checks out or runs PR code. Reads Dependabot's own metadata and
+#     calls the merge API, nothing else.
+#
+# Gated on the DEPENDABOT_AUTOMERGE repository variable. Auto-merge only waits
+# for checks that main actually requires, so with no ruleset in place it would
+# merge on the spot. Set the variable to 'true' once main requires the CI
+# check; until then this workflow deliberately does nothing.
+
+name: Dependabot Auto-merge
+
+on: pull_request
+
+# Dependabot-triggered runs get a read-only token unless the workflow asks for
+# more. Both scopes are needed to queue a merge.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      vars.DEPENDABOT_AUTOMERGE == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Dev dependencies and workflow actions cannot reach users: a bad bump
+      # breaks CI, not a release. Runtime deps and every major stay manual.
+      # A changed maintainer set is the usual tell for a hijacked package, so
+      # those go to review no matter how harmless the version jump looks.
+      - name: Queue auto-merge
+        if: >-
+          steps.meta.outputs.update-type != 'version-update:semver-major' &&
+          steps.meta.outputs.maintainer-changes == 'false' &&
+          (
+            steps.meta.outputs.dependency-type == 'direct:development' ||
+            steps.meta.outputs.dependency-group == 'actions'
+          )
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Cuts the manual work Dependabot creates, and closes a gap where dependency
bumps were never actually tested.

## Dependency PRs were untested

`pnpm-lock.yaml` was in no `dorny/paths-filter` entry, so a lockfile-only
change matched no app filter and skipped `test-pwa`, `test-jupyter`,
`test-vscode`, `test-streamlit`, `test-desktop` and `e2e-tests`. PR #279 shows
seven SKIPPED jobs. Every Dependabot PR merged since the config landed in May
was gated on lint and build alone.

## Cooldown

7 days, 30 for majors. A compromised release is usually yanked within hours,
so waiting lets the registry clean up before we pull it in. It also collapses
intermediate versions into one PR instead of a bump arriving every week.
Cooldown covers version updates only, so security updates still land at once.

## Opt-in auto-merge

Non-major dev-dependency and github-actions bumps merge themselves. Those
cannot reach users: a bad bump breaks CI, not a release. Runtime dependencies,
every major, and anything whose maintainer set changed still go to review,
since a changed maintainer set is the usual tell for a hijacked package.

Inert until the `DEPENDABOT_AUTOMERGE` repository variable is set to `true`.
Auto-merge only waits for checks a branch actually requires, and `main` has no
ruleset yet, so enabling it before one exists would merge without CI gating.

## Check name collision

CI and Build PWA Preview both had a job called `build`, and required status
checks are matched by name alone. Build PWA Preview is path-filtered at the
workflow level, so on a PR that misses those paths it never starts and its
check never appears. A required check that never appears blocks the merge
permanently. The preview job is now `preview-build`.

## Follow-up

Add a ruleset on `main` requiring the CI checks, then set
`DEPENDABOT_AUTOMERGE=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)